### PR TITLE
Issue #8: Support capturing output artifacts from dynamic fixtures

### DIFF
--- a/.argo/test-yamls/fixtures-dynamic.yaml
+++ b/.argo/test-yamls/fixtures-dynamic.yaml
@@ -65,3 +65,45 @@ args: ["
 resources:
   cpu_cores: 0.05
   mem_mib: 64
+
+---
+type: workflow
+version: 1
+name: test-fixtures-dynamic-outputs
+description: Workflow which exports artifacts produced by dynamic fixtures
+inputs:
+  parameters:
+    COMMIT:
+      default: "%%session.commit%%"
+    REPO:
+      default: "%%session.repo%%"
+fixtures:
+- DYN_FIX_WITH_OUTPUTS:
+    template: test-dynamic-fixture-container-with-outputs
+steps:
+- WEB-CLIENT-INLINED:
+   image: alpine:latest
+   command: [sh, -c]
+   args: ["sleep 60"]
+   resources:
+     cpu_cores: 0.05
+     mem_mib: 64
+outputs:
+  artifacts:
+    WF_OUTPUTS:
+      from: "%%fixtures.DYN_FIX_WITH_OUTPUTS.outputs.artifacts.BIN-DIR%%"
+
+---
+type: container
+version: 1
+name: test-dynamic-fixture-container-with-outputs
+image: alpine:latest
+command: [sh, -c]
+args: ["sleep 999999"]
+resources:
+  cpu_cores: 0.05
+  mem_mib: 64
+outputs:
+  artifacts:
+    BIN-DIR:
+      path: /bin

--- a/saas/common/src/applatix.io/template/param.go
+++ b/saas/common/src/applatix.io/template/param.go
@@ -20,7 +20,7 @@ const (
 var (
 	paramNameRegexStr       = "[-0-9A-Za-z_]+"
 	paramNameRegex          = regexp.MustCompile("^[-0-9A-Za-z_]+$")
-	ouputArtifactRegexp     = regexp.MustCompile(`^%%steps\.` + paramNameRegexStr + `\.outputs\.artifacts\.` + paramNameRegexStr + `%%$`)
+	ouputArtifactRegexp     = regexp.MustCompile(`^%%(steps|fixtures)\.` + paramNameRegexStr + `\.outputs\.artifacts\.` + paramNameRegexStr + `%%$`)
 	VarRegex                = regexp.MustCompile("%%[-0-9A-Za-z_]+(\\.[-0-9A-Za-z_]+)*%%")
 	varRegexExact           = regexp.MustCompile("^%%[-0-9A-Za-z_]+(\\.[-0-9A-Za-z_]+)*%%$")
 	listExpansionParamRegex = regexp.MustCompile("\\$\\$\\[(.*)\\]\\$\\$")


### PR DESCRIPTION
This change restores support for capturing output artifacts from dynamic fixtures, which was broken during the YAML redesign.