### PR TITLE
Do not acquire lock in get_spot_instance_price().

### DIFF
--- a/platform/source/lib/ax/platform/minion_manager/cloud_provider/aws/aws_bid_advisor.py
+++ b/platform/source/lib/ax/platform/minion_manager/cloud_provider/aws/aws_bid_advisor.py
@@ -277,14 +277,16 @@ class AWSBidAdvisor(object):
     def get_spot_instance_price(self, instance_type, zone):
         """
         Returns the spot-instance price for the given instance_type and zone.
+        Caller is *required* to acquire the lock.
         """
+        assert self.lock.locked(), "BidAdvisor lock not acquired"
+
         # The spot price list is sorted by time. Find the latest instance
         # for the zone and instance_type and use that as the spot price.
-        with self.lock:
-            for price_info in self.spot_price_list:
-                if price_info["InstanceType"] == instance_type and \
-                        price_info["AvailabilityZone"] == zone:
-                    return float(price_info["SpotPrice"])
+        for price_info in self.spot_price_list:
+            if price_info["InstanceType"] == instance_type and \
+                    price_info["AvailabilityZone"] == zone:
+                return float(price_info["SpotPrice"])
         return None
 
     def get_new_bid(self, zone, instance_type):


### PR DESCRIPTION
The lock is already acquired.

Testing Done:

1. Without this change, the minion-manager hangs while switching from
on-demand to spot instances.
2. With this change, the switch happened successfully.

Closes #10 