### PR TITLE
Issue #33: fix force-upgrade semantics

### DIFF
--- a/common/python/ax/cluster_management/app/cluster_upgrader.py
+++ b/common/python/ax/cluster_management/app/cluster_upgrader.py
@@ -71,20 +71,21 @@ class ClusterUpgrader(ClusterOperationBase):
         upgrade_service = True
 
         if self._cfg.target_software_info.kube_installer_version == self._current_software_info.kube_installer_version \
-            and self._cfg.target_software_info.kube_version == self._current_software_info.kube_version:
+            and self._cfg.target_software_info.kube_version == self._current_software_info.kube_version \
+                and not self._cfg.force_upgrade:
             upgrade_kube = False
 
         if self._cfg.target_software_info.image_namespace == self._current_software_info.image_namespace \
             and self._cfg.target_software_info.image_version == self._current_software_info.image_version \
             and self._cfg.target_software_info.image_version != "latest" \
-            and not upgrade_kube:
+            and not upgrade_kube \
+                and not self._cfg.force_upgrade:
             upgrade_service = False
 
-        if not upgrade_service and not upgrade_kube and not self._cfg.force_upgrade:
+        if not upgrade_service and not upgrade_kube:
             logger.info("%sCluster's software versions is not changed, not performing upgrade.%s", COLOR_GREEN, COLOR_NORM)
             logger.info("%sIf you want to force upgrade cluster, please specify --force-upgrade flag.%s", COLOR_YELLOW, COLOR_NORM)
             return
-
 
         if self._cfg.dry_run:
             logger.info("DRY RUN: upgrading cluster %s", self._name_id)


### PR DESCRIPTION
we should not set upgrade_kube and upgrad_service to False if user specifies `--force-upgrade`
Tested upgrading cluster to same version with --force-upgrade, it worked

Fixes #33 