### PR TITLE
Change Tasks to use Kubernetes Pods instead of Jobs (#41)

### DIFF
--- a/.argo/test-yamls/pod-throughput-test.yaml
+++ b/.argo/test-yamls/pod-throughput-test.yaml
@@ -4,7 +4,7 @@ name: quick-exit
 description: does nothing and exits quickly
 resources:
   mem_mib: 32
-  cpu_cores: 0.1
+  cpu_cores: 0.01
 image: alpine:latest
 command: ["sh",  "-c", "exit 0"]
 

--- a/platform/source/lib/ax/platform/axmon_main.py
+++ b/platform/source/lib/ax/platform/axmon_main.py
@@ -68,42 +68,43 @@ class AXMon(with_metaclass(Singleton, object)):
         conf = Task.insert_defaults(data)
         dry_run = data.get("dry_run", False)
         if dry_run:
-            name = Task.generate_job_name(conf)
+            name = Task.generate_name(conf)
             logger.debug("task_create: dry_run name is {}".format(name))
             return {"{}".format(name): KubeObjStatusCode.OK}
 
         # create the workflow
-        task = Task()
+        task_id = Task.generate_name(conf)
+        task = Task(task_id)
         job_obj = task.create(conf)
         task.start(job_obj)
-        return {"{}".format(task.jobname): KubeObjStatusCode.OK}
+        return {"{}".format(task.name): KubeObjStatusCode.OK}
 
     def task_show(self, task_id):
         if task_id is None:
             raise ValueError("task id must be specified")
-        task = Task()
-        return task.status(task_id)
+        task = Task(task_id)
+        return task.status()
 
-    def task_delete(self, task_id, delete_pod, force):
-        logger.debug("Deleting task %s delete_pod=%s force=%s", task_id, delete_pod, force)
+    def task_delete(self, task_id, force):
+        logger.debug("Deleting task %s force=%s", task_id, force)
         if task_id is None:
             raise ValueError("task id must be specified")
-        task = Task()
-        return task.delete(task_id, delete_pod=delete_pod, force=force)
+        task = Task(task_id)
+        return task.delete(force=force)
 
     def task_stop_running_pod(self, task_id):
         logger.debug("Stopping task %s", task_id)
         if task_id is None:
             raise ValueError("task id must be specified")
-        task = Task()
-        return task.stop_running_pod(task_id)
+        task = Task(task_id)
+        return task.stop()
 
     def task_log(self, task_id):
         logger.debug("Getting log endpoint for %s", task_id)
         if task_id is None:
             raise ValueError("task id must be specified")
-        task = Task()
-        return task.get_log_endpoint(task_id)
+        task = Task(task_id)
+        return task.get_log_endpoint()
 
     def add_registry(self, server, username, password, save=True):
         client = AXDockerClient()

--- a/platform/source/lib/ax/platform/pod.py
+++ b/platform/source/lib/ax/platform/pod.py
@@ -285,17 +285,6 @@ class Pod(KubeObject):
 
         raise AXPlatformException("Pod for a task needs to have a non-wait container")
 
-    def _delete_volumes_for_pod(self, status):
-        # TODO: Disable this for now. We need a better solution than a hard delete of volumes
-        # This delete is right now commented out as it is deleting all volumes including volumes
-        # attached via volume pool
-        # for volume in status.spec.volumes:
-        #    assert isinstance(volume, swagger_client.V1Volume), "Expect an object of type V1Volume"
-        #    pvc = volume.persistent_volume_claim
-        #    if pvc is not None and not pvc.read_only:
-        #        VolumeManager().delete(pvc.claim_name)
-        pass
-
     def _get_status_obj(self):
         status = self.client.api.read_namespaced_pod_status(self.namespace, self.name)
         assert isinstance(status, swagger_client.V1Pod), "Status object should be of type V1Pod"

--- a/platform/source/lib/ax/platform/rest.py
+++ b/platform/source/lib/ax/platform/rest.py
@@ -513,7 +513,7 @@ def task_delete(task_id):
     if stop_running_pod_only == "True":
         result = axmon.task_stop_running_pod(task_id)
     else:
-        result = axmon.task_delete(task_id, delete_pod=delete_pod == "True", force=force == "True")
+        result = axmon.task_delete(task_id, force=force == "True")
     return jsonify(result=result)
 
 @_app.route("/v1/axmon/task/<task_id>/logs", methods=['GET'])

--- a/platform/source/lib/ax/platform/task.py
+++ b/platform/source/lib/ax/platform/task.py
@@ -180,7 +180,7 @@ class Task(object):
         }
 
         if pending:
-            # If the pod is pending it is likely stuck on container image pull failure which
+            # If the pod is pending it is likely stuck on container image pull failure
             try:
                 for init_status in status.status.init_container_statuses or []:
                     if init_status.state.waiting is not None:

--- a/platform/source/lib/ax/platform/task.py
+++ b/platform/source/lib/ax/platform/task.py
@@ -31,7 +31,6 @@ from ax.util.converter import string_to_dns_label, string_to_k8s_label
 from .pod import Pod, PodSpec
 from .container_specs import SidecarTask
 from .container import Container
-from ax.platform.routes import ServiceEndpoint, NginxIngressController, IngressRules
 
 from argo.services.service import Service
 
@@ -56,7 +55,7 @@ CLUSTER_META_URL_V1 = os.getenv("AX_CLUSTER_META_URL_V1")
 class TaskOperation(Operation):
 
     def __init__(self, task_obj):
-        token = task_obj.jobname
+        token = task_obj.name
         super(TaskOperation, self).__init__(token)
 
     @staticmethod
@@ -64,17 +63,16 @@ class TaskOperation(Operation):
         return "TaskOperation"
 
 
-class Task(KubeObject):
+class Task(object):
     """
     The job of this object is to track the creation and deletion of a step in a workflow.
     Callers can create this object with the specification from service template, followed
     by call to create, wait_for_start etc
     """
-    def __init__(self):
+    def __init__(self, name, namespace="axuser"):
+        self.name = name
+        self.namespace = namespace
         self.client = KubernetesApiClient(use_proxy=True)
-        self.batchapi = self.client.batchv
-        self.kube_namespace = "axuser"
-        self.jobname = None
 
         self.service = None     # this is the argo.services.service.Service object
         self._host_vols = []
@@ -85,9 +83,6 @@ class Task(KubeObject):
         self._s3_bucket = AXClusterDataPath(self._name_id).bucket()
         self._s3_key_prefix = AXClusterDataPath(self._name_id).artifact()
 
-        self._attribute_map = {
-            "uuid": "metadata.uid"
-        }
         self.software_info = SoftwareInfo()
         self._ax_resources = {}
 
@@ -101,10 +96,8 @@ class Task(KubeObject):
         self.service = Service()
         self.service.parse(conf)
 
-        self.jobname = Task.generate_job_name(conf)
-        job = swagger_client.V1Job()
         labels = {
-            "app": self.jobname,
+            "app": self.name,
             "service_instance_id": self.service.service_context.service_instance_id,
             "root_workflow_id": self.service.service_context.root_workflow_id,
             "leaf_full_path": string_to_k8s_label(self.service.service_context.leaf_full_path or "no_path"),
@@ -112,264 +105,125 @@ class Task(KubeObject):
             "role": "user",
         }
 
-        job_meta = swagger_client.V1ObjectMeta()
-        job_meta.name = self.jobname
-        job_meta.labels = labels
-        job.metadata = job_meta
+        template_spec = self._container_to_pod(labels)
 
-        job_spec = swagger_client.V1JobSpec()
+        # convert V1PodTemplateSpec to V1Pod
+        pod_spec = swagger_client.V1Pod()
+        pod_spec.metadata = template_spec.metadata
+        pod_spec.spec = template_spec.spec
+        return pod_spec
 
-        job_spec.template = self._container_to_pod(labels)
-        job.spec = job_spec
-        return job
-
-    def start(self, job):
+    def start(self, spec):
         """
-        Start a Job object
-        :param job:
+        Start a task
+        :param spec: The swagger specification for Pod
+        :type spec: swagger_client.V1Pod
         :return:
         """
-        assert isinstance(job, swagger_client.V1Job), "Expect to have a swagger_client.V1Job to create"
+        assert isinstance(spec, swagger_client.V1Pod), "Unexpected object {} in Task.start".format(type(spec))
 
         @retry_unless(status_code=[409, 422])
         def create_in_provider():
-            return self.batchapi.create_namespaced_job(job, self.kube_namespace)
+            return self.client.api.create_namespaced_pod(spec, self.namespace)
 
         with TaskOperation(self):
             return create_in_provider()
 
-    def status(self, name, status_obj=None):
+    def status(self, status_obj=None):
         """
         Return the status of the job with the pass name
         Args:
-            name: string that is the unique job name
             status_obj: if passed the job status will be used instead of queried from provider
 
         Returns: a json dict with task status
         """
-        self.jobname = name
-        job = None
         if status_obj:
-            job = status_obj
+            assert isinstance(status_obj, swagger_client.V1Pod), "Unexpected status object {} in Task.status".format(type(status_obj))
+            status = status_obj
         else:
-            job = self._get_job(name)
+            status = Pod(self.name, self.namespace)._get_status_obj()
 
-        logger.debug("Task status {} is {}".format(name, json.dumps(job.status.to_dict())))
-        active = job.status.active == 1
-        completed = job.status.succeeded == 1
-        if hasattr(job.status, "failed"):
-            failed = job.status.failed
-        else:
-            failed = 0
+        # pkg/api/v1/types.go in kubernetes source code describes the following PodPhase
+        # const (
+        #     // PodPending means the pod has been accepted by the system, but one or more of the containers
+        #     // has not been started. This includes time before being bound to a node, as well as time spent
+        #     // pulling images onto the host.
+        #     PodPending PodPhase = "Pending"
+        #     // PodRunning means the pod has been bound to a node and all of the containers have been started.
+        #     // At least one container is still running or is in the process of being restarted.
+        #     PodRunning PodPhase = "Running"
+        #     // PodSucceeded means that all containers in the pod have voluntarily terminated
+        #     // with a container exit code of 0, and the system is not going to restart any of these containers.
+        #     PodSucceeded PodPhase = "Succeeded"
+        #     // PodFailed means that all containers in the pod have terminated, and at least one container has
+        #     // terminated in a failure (exited with a non-zero exit code or was stopped by the system).
+        #     PodFailed PodPhase = "Failed"
+        #     // PodUnknown means that for some reason the state of the pod could not be obtained, typically due
+        #     // to an error in communicating with the host of the pod.
+        #     PodUnknown PodPhase = "Unknown"
+        # )
+        pending = True if status.status.phase == "Pending" else False
+        active = True if status.status.phase == "Running" or pending else False
+        failed = True if status.status.phase == "Failed" else False
+        completed = True if status.status.phase == "Succeeded" or failed else False
 
-        status = {
+        if status.status.phase == "Unknown":
+            raise AXPlatformException("Status of task {} could not be found due to some temporary problem. Please retry".format(self.name))
+
+        ret_status = {
             "active": active,
             "succeeded": completed,
+            # TODO: Should this be removed
             "message": "",
+            "reason": "",
             "failed": failed
         }
-        if active:
-            reason = self.get_last_pod_waiting_reason()
-            if reason:
-                status['reason'] = reason
 
-            # do some cleanup for pods that have failed due to system errors such as mismatch
-            # betweeen kubernetes scheduler and kubelet resources
+        if pending:
+            # If the pod is pending it is likely stuck on container image pull failure which
             try:
-                self.delete_pods_with_condition(lambda pod: pod.status.phase == "Failed")
-            except Exception as e:
-                logger.debug("Exception {} in trying to delete pods with condition for job {}".format(e, name))
-        try:
-            status["message"] = job.status.conditions[0].message if not active and not completed else ""
-        except Exception:
-            logger.error("job %s. status is %s", job.status, status)
-            pass
-        return status
+                for init_status in status.status.init_container_statuses or []:
+                    if init_status.state.waiting is not None:
+                        # find the first init container that is stuck on waiting and stuff the reason and message
+                        ret_status["reason"] = init_status.state.waiting.reason or ""
+                        ret_status["message"] = init_status.state.waiting.message or ""
+                        break
+            except Exception:
+                pass
 
-    def delete(self, name, delete_pod=True, force=False):
+        return ret_status
+
+    def delete(self, force=False):
         """
         Delete the task from kubernetes and returns the final status
-        Args:
-            name: string that is the unique job name
-
         Returns: Last status of the job
-
         """
-        logger.debug("Task delete for {}".format(name))
-        self.jobname = name
-
+        logger.debug("Task delete for {}".format(self.name))
         with TaskOperation(self):
-            job_status = self._get_job(name)
-            status = self.status(name, status_obj=job_status)
+            status = self.status()
+            p = Pod(self.name, self.namespace)
+            if not force:
+                p.stop()
+            p.delete()
+            return status
 
-            ax_resources = self._get_ax_resources(job_status)
-            self.service_instance_id = job_status.metadata.labels.get("service_instance_id", None)
-            self._delete_job(name, delete_pod, force)
-
-        # cleanup other ax_resources
-        volumepools = ax_resources.get("volumepools", [])
-        for poolname, volname in volumepools:
-            vmanager = VolumeManager()
-            logger.debug("Return volume {} to volume pool {}".format(volname, poolname))
-            try:
-                vmanager.put_in_pool(poolname, volname, current_ref=self.service_instance_id)
-            except AXVolumeOwnershipException as e:
-                logger.debug("Volume {} has already been returned for job {}. This is normal".format(volname, name))
-
-        service_endpoint = ax_resources.get("service_endpoint", None)
-        if service_endpoint:
-            endpoint_name = service_endpoint["name"]
-            nginx_controller = service_endpoint.get("use-nginx", None)
-            if nginx_controller is None and "persist" in service_endpoint and service_endpoint["persist"]:
-                logger.debug("Do not delete service endpoint {} as persist is set to true".format(endpoint_name))
-            else:
-                s = ServiceEndpoint(endpoint_name)
-                s.delete()
-
-                if nginx_controller:
-                    r = IngressRules(endpoint_name, nginx_controller)
-                    r.delete()
-
-        return status
-
-    def get_status(self):
-        status = self._get_job(self.jobname)
-        return status.to_dict()
-
-    def get_pod_list(self):
-        result = self.client.api.list_namespaced_pod(self.kube_namespace, label_selector="job-name={}".format(self.jobname))
-        assert isinstance(result, swagger_client.V1PodList), "Expect object of type V1PodList"
-        return result
-
-    def delete_pods_with_condition(self, func):
-        """
-        Deletes pod for which the passed function returns true
-        Args:
-            func: The function should have the following prototype boolean Function(V1Pod)
-        """
-        def sortfunc(item):
-            try:
-                return parser.parse(item.status.start_time)
-            except Exception as e:
-                logger.debug("Could not parse start time for pod {} due to exception {}".format(item.metadata.name, e))
-                return parser.parse("9999-12-31T23:59:59Z")
-
-        l = self.get_pod_list()
-        sorted_list = sorted(l.items, key=sortfunc)
-        for pod in sorted_list:
-            if func(pod):
-                logger.debug("Pod {} matches condition for deletion".format(pod.metadata.name))
-                p = Pod(pod.metadata.name, namespace="axuser")
-                p.delete()
-
-    def get_last_pod(self):
-        try:
-            l = self.get_pod_list()
-            if len(l.items) == 0:
-                raise ValueError("No Pod found for job {}".format(self.jobname))
-            p = None
-            for i in l.items:
-                if p is None or i.status.startTime > p.status.startTime:
-                    p = i
-            pod = Pod(p.metadata.name)
-            pod.build_attributes()
-            return pod
-
-        except swagger_client.rest.ApiException as e:
-            details = json.loads(e.body)
-            raise AXPlatformException(message=details["message"])
-
-    def get_last_pod_waiting_reason(self):
-        try:
-            l = self.get_pod_list()
-            p = None
-            for i in l.items:
-                if p is None or i.status.startTime > p.status.startTime:
-                    p = i
-            if p is not None:
-                statuses = json.loads(p.metadata.annotations['pod.alpha.kubernetes.io/init-container-statuses'])
-                reason = statuses[0]['state']['waiting']['reason']
-                logger.debug("got reason %s", reason)
-                return reason
-        except Exception:
-            pass
-
-        return None
-
-    def get_log_endpoint(self, name):
-        self.jobname = name
-        url_run, _ = self.get_last_pod().get_log_urls()
+    def get_log_endpoint(self):
+        url_run, _ =  Pod(self.name, self.namespace).get_log_urls()
         return url_run
-
-    @retry_unless(status_code=[404, 409, 422])
-    def _get_job(self, name):
-        return self.batchapi.read_namespaced_job_status(self.kube_namespace, name)
 
     def _get_ax_resources(self, status):
         ax_str = status.spec.template.metadata.annotations.get("ax_resources", "{}")
         return json.loads(ax_str)
 
-    def stop_running_pod(self, name):
-        self.jobname = name
-        self.stop_all_pods(delete_pod=False, force=False)
-
-    def stop_all_pods(self, delete_pod, force):
-        if (not delete_pod) and force:
-            logger.warning("stop_running_pod(%s, delete_pod=%s, force=%s) has no effect.",
-                           self.jobname, delete_pod, force)
-            return
-
-        try:
-            pods = self.get_pod_list()
-            if not force:
-                for p in pods.items:
-                    if p.status.phase in ["Pending", "Running"]:
-                        pod = Pod(p.metadata.name)
-                        pod.stop(self.jobname)
-                        continue
-                    else:
-                        logger.debug("Don't need to stop [%s][%s], status=%s", self.jobname, p.metadata.name, p.status.phase)
-            else:
-                logger.debug("Force delete pods for [%s]", self.jobname)
-
-            if delete_pod:
-                logger.debug("Deleting all pods for [%s]", self.jobname)
-                self.client.api.deletecollection_namespaced_pod(namespace=self.kube_namespace,
-                                                                label_selector="job-name={}".format(self.jobname))
-                logger.debug("Deleted all pods for [%s]", self.jobname)
-            else:
-                logger.debug("Don't delete pods for [%s]", self.jobname)
-
-            for p in pods.items:
-                pod = Pod(p.metadata.name)
-                logger.debug("Delete volumes for [%s][%s]", self.jobname, p.metadata.name)
-                pod._delete_volumes_for_pod(p)
-
-            time.sleep(DELETE_TASK_GRACE_PERIOD)
-
-        except swagger_client.rest.ApiException as e:
-            logger.exception("delete_all_pods")
-            details = json.loads(e.body)
-            raise AXPlatformException(message=details["message"])
-
-    def _delete_job(self, name, delete_pod, force):
-        logger.debug("Deleting job for [%s]", self.jobname)
-        options = swagger_client.V1DeleteOptions()
-        options.grace_period_seconds = 0
-
-        @retry_unless(swallow_code=[404], status_code=[409, 422])
-        def delete_in_provider():
-            self.batchapi.delete_namespaced_job(options, self.kube_namespace, name)
-
-        delete_in_provider()
-        self.stop_all_pods(delete_pod=delete_pod, force=force)
+    def stop(self):
+        Pod(self.name, self.namespace).stop()
 
     def _container_to_pod(self, labels):
 
         # generate the service environment
         self._gen_service_env()
 
-        pod_spec = PodSpec(self.jobname)
+        pod_spec = PodSpec(self.name)
         pod_spec.restart_policy = "Never"
 
         main_container = self._container_spec()
@@ -398,7 +252,7 @@ class Task(KubeObject):
 
         # TODO: This function calls ax_artifact and needs to be rewritten. Ugly code.
         artifacts_container = pod_spec.enable_artifacts(self.software_info.image_namespace, self.software_info.image_version, self_sid, self.service.template.to_dict())
-        artifacts_container.add_env("AX_JOB_NAME", value=self.jobname)
+        artifacts_container.add_env("AX_JOB_NAME", value=self.name)
 
         if self.service.template.docker_spec:
             dind_c = pod_spec.enable_docker(self.service.template.docker_spec.graph_storage_size_mib)
@@ -426,7 +280,7 @@ class Task(KubeObject):
         container = self.service.template
         c = Container(container.name, container.image, pull_policy=container.image_pull_policy)
 
-        c.add_env("AX_CONTAINER_NAME", value=self.jobname)
+        c.add_env("AX_CONTAINER_NAME", value=self.name)
         c.add_env("AX_ROOT_SERVICE_INSTANCE_ID", value=self.service.service_context.root_workflow_id)
         c.add_env("AX_SERVICE_INSTANCE_ID", value=self.service.service_context.service_instance_id)
 
@@ -473,7 +327,7 @@ class Task(KubeObject):
 
         c = SidecarTask(main_container_name, self.software_info.image_namespace, self.software_info.image_version)
         c.add_env("AX_MAIN_CONTAINER_NAME", value=main_container_name)
-        c.add_env("AX_JOB_NAME", value=self.jobname)
+        c.add_env("AX_JOB_NAME", value=self.name)
         c.add_env("AX_CUSTOMER_ID", AXCustomerId().get_customer_id())
         c.add_env("AX_REGION", AXClusterConfig().get_region())
         c.add_env("AX_CLUSTER_NAME_ID", self._name_id)
@@ -511,7 +365,7 @@ class Task(KubeObject):
         return base64.b64encode(json.dumps(service_env))
 
     @staticmethod
-    def generate_job_name(conf):
+    def generate_name(conf):
         """
         This function generates a kubernetes job name from a service template and also
         ensures that the generated name has some relationship to human readable job names 


### PR DESCRIPTION
This change is to axmon to generate a Pod spec for Tasks instead of
generating a Job spec. It will now be up to workflow executor and
workflow ADC to ensure that tasks that did not complete due to node
failure or other conditions are restarted.