### PR TITLE
Issue #45: get aws partition based on region

### DIFF
--- a/common/python/ax/cloud/aws/__init__.py
+++ b/common/python/ax/cloud/aws/__init__.py
@@ -8,9 +8,9 @@ from .ami import AMI
 from .instance_profile import InstanceProfile
 from .aws_s3 import AXS3Bucket, BUCKET_CLEAN_KEYWORD
 from .security import SecurityToken
-from .util import default_aws_retry
+from .util import default_aws_retry, get_aws_partition_from_region
 from .ec2 import EC2InstanceState, EC2, EC2IPPermission
 from .autoscaling import ASGInstanceLifeCycle, ASG
 from .launch_config import LaunchConfig
 from .ebs import RawEBSVolume
-from .consts import AWS_DEFAULT_PROFILE
+from .consts import AWS_DEFAULT_PROFILE, AWS_ALL_RESOURCES

--- a/common/python/ax/cloud/aws/consts.py
+++ b/common/python/ax/cloud/aws/consts.py
@@ -6,3 +6,12 @@
 
 
 AWS_DEFAULT_PROFILE = "default"
+
+
+AWS_ALL_RESOURCES = "*"
+
+
+class AWSPartitions:
+    PARTITION_AWS = "aws"
+    PARTITION_US_GOV = "aws-us-gov"
+    PARTITION_CHINA = "aws-cn"

--- a/common/python/ax/cloud/aws/util.py
+++ b/common/python/ax/cloud/aws/util.py
@@ -8,6 +8,7 @@
 import boto3
 from botocore.exceptions import ClientError, EndpointConnectionError, ConnectionClosedError, BotoCoreError
 
+from .consts import AWSPartitions
 
 def default_aws_retry(exception):
     # Boto has 3 types of errors (see botocore/exceptions.py)
@@ -69,3 +70,18 @@ def tag_dict_to_aws_filter(tags):
         )
     return filters
 
+
+def get_aws_partition_from_region(region_name):
+    """
+    Given region, return the partition name. Partition is used to form Amazon Resource Number (ARNs)
+    See http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
+    :param region_name:
+    :return:
+    """
+    region_string = region_name.lower()
+    if region_string.startswith("cn-"):
+        return AWSPartitions.PARTITION_CHINA
+    elif region_string.startswith("us-gov"):
+        return AWSPartitions.PARTITION_US_GOV
+    else:
+        return AWSPartitions.PARTITION_AWS

--- a/platform/cluster/aws/util.sh
+++ b/platform/cluster/aws/util.sh
@@ -757,11 +757,11 @@ function delete-tag {
 
 # Creates the IAM roles (if they do not already exist)
 function create-iam-profiles {
-    /ax/bin/ax-upgrade-misc --ensure-aws-iam --cluster-name-id $CLUSTER_ID --aws-profile $AWS_DEFAULT_PROFILE
+    /ax/bin/ax-upgrade-misc --ensure-aws-iam --cluster-name-id $CLUSTER_ID --aws-profile $AWS_DEFAULT_PROFILE --aws-region ${AWS_REGION}
 }
 
 function delete-iam-profiles {
-    /ax/bin/ax-upgrade-misc --delete-aws-iam --cluster-name-id $CLUSTER_ID --aws-profile $AWS_DEFAULT_PROFILE
+    /ax/bin/ax-upgrade-misc --delete-aws-iam --cluster-name-id $CLUSTER_ID --aws-profile $AWS_DEFAULT_PROFILE --aws-region ${AWS_REGION}
 }
 
 # Wait for instance to be in specified state

--- a/platform/source/lib/ax/platform/ax_master_manager.py
+++ b/platform/source/lib/ax/platform/ax_master_manager.py
@@ -626,7 +626,8 @@ class AXMasterManager:
             self.master_instance = self.ec2.Instance(instance_id)
             logger.info("Running master %s.", instance_id)
             self.aws_image = ami_id
-            self.instance_profile = AXClusterInstanceProfile(self.cluster_name_id, aws_profile=self.profile).get_master_arn()
+            self.instance_profile = AXClusterInstanceProfile(self.cluster_name_id, region_name=self.region,
+                                                             aws_profile=self.profile).get_master_arn()
             self.populate_attributes()
             master_tag_updated = self.ensure_master_tags()
             # TODO: Possible race here.

--- a/platform/source/lib/ax/platform/ax_minion_upgrade.py
+++ b/platform/source/lib/ax/platform/ax_minion_upgrade.py
@@ -94,8 +94,9 @@ class MinionUpgrade(object):
 
         # Replace ImageId and everything listed in default_kube_up_env.
         config["ImageId"] = ami_id
-        config["IamInstanceProfile"] = AXClusterInstanceProfile(self._cluster_name_id,
-                                                                aws_profile=self._profile).get_minion_instance_profile_name()
+        config["IamInstanceProfile"] = AXClusterInstanceProfile(
+            self._cluster_name_id, region_name=self._region, aws_profile=self._profile
+        ).get_minion_instance_profile_name()
         user_data = zlib.decompressobj(32 + zlib.MAX_WBITS).decompress(user_data)
         user_data = kube_env_update(user_data, updates)
         comp = zlib.compressobj(9, zlib.DEFLATED, zlib.MAX_WBITS | 16)

--- a/platform/source/tools/ax-upgrade-misc.py
+++ b/platform/source/tools/ax-upgrade-misc.py
@@ -46,13 +46,12 @@ if __name__ == "__main__":
     args = ax_parser.parse_args()
     if args.ensure_aws_iam or args.delete_aws_iam:
         from ax.platform.cluster_instance_profile import AXClusterInstanceProfile
-        aws_profile = args.aws_profile
-        assert aws_profile, "Missing AWS profile to ensure aws iam"
         assert args.cluster_name_id, "Missing cluster name id to ensure aws iam"
+        assert args.aws_region, "Missing AWS region to ensure aws iam"
         if args.ensure_aws_iam:
-            AXClusterInstanceProfile(args.cluster_name_id, aws_profile=aws_profile).update()
+            AXClusterInstanceProfile(args.cluster_name_id, args.aws_region, aws_profile=args.aws_profile).update()
         elif args.delete_aws_iam:
-            AXClusterInstanceProfile(args.cluster_name_id, aws_profile=aws_profile).delete()
+            AXClusterInstanceProfile(args.cluster_name_id, args.aws_region, aws_profile=args.aws_profile).delete()
 
     if args.ensure_aws_s3:
         from ax.platform.cluster_buckets import AXClusterBuckets


### PR DESCRIPTION
Fixes #45 

When creating IAM role / bucket policy, we need to dynamically generate policy string based on aws partition.

Tested install and upgrade and they worked