### PR TITLE
Issue #28: Reduce axdb, zookeeper and kafka container sizes.

### DIFF
--- a/saas/axdb/BaseDockerfile
+++ b/saas/axdb/BaseDockerfile
@@ -1,47 +1,5 @@
-From %%ARGO_BASE_REGISTRY%%/argobase/debian:8.5
+From %%ARGO_BASE_REGISTRY%%/argobase/mini-debian:9.1
 
-# Basic utilities.
-RUN apt-get update && apt-get install -y \
-		apt-utils \
-		curl \
-		git \
-		maven \
-		sudo \
-		wget \
-        vim \
-        bc
+ADD base-install.sh /tmp/base-install.sh
+RUN /tmp/base-install.sh
 
-# oracle jdk
-RUN mkdir /opt/jdk
-RUN cd /opt
-RUN wget --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u71-b13/jdk-8u71-linux-x64.tar.gz
-RUN tar -zxf jdk-8u71-linux-x64.tar.gz -C /opt/jdk
-RUN update-alternatives --install /usr/bin/java java /opt/jdk/jdk1.8.0_71/bin/java 10000
-RUN update-alternatives --install /usr/bin/javac javac /opt/jdk/jdk1.8.0_71/bin/javac 10000
-RUN rm jdk-8u71-linux-x64.tar.gz
-
-# install Cassandra
-RUN echo "deb http://debian.datastax.com/datastax-ddc 3.7 main" | tee -a /etc/apt/sources.list.d/cassandra.sources.list
-RUN curl -L https://debian.datastax.com/debian/repo_key | apt-key add -
-
-RUN apt-get update -y && apt-get install -y \
-        datastax-ddc
-
-RUN service cassandra stop
-RUN rm -rf /var/lib/cassandra/data/system/*
-
-# 7000: intra-node communication
-# 7001: TLS intra-node communication
-# 7199: JMX
-# 9042: CQL
-# 9160: thrift service
-EXPOSE 7000 7001 7199 9042 9160
-
-# install cassandra-lucene-index
-RUN cd /root && \
-    git clone http://github.com/Stratio/cassandra-lucene-index && \
-    cd cassandra-lucene-index && \
-    git checkout 3.7.1 && \
-    mvn clean package
-RUN cp /root/cassandra-lucene-index/plugin/target/cassandra-lucene-index-plugin-*.jar /usr/share/cassandra/lib
-RUN rm -rf /root/cassandra-lucene-index

--- a/saas/axdb/Dockerfile
+++ b/saas/axdb/Dockerfile
@@ -1,4 +1,4 @@
-From %%ARGO_BASE_REGISTRY%%/argobase/axdb-base:v1.2
+From %%ARGO_BASE_REGISTRY%%/argobase/axdb-base:v1.3
 
 WORKDIR /
 

--- a/saas/axdb/base-install.sh
+++ b/saas/axdb/base-install.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -e
+apt-get update
+apt-get install -y \
+        curl \
+        git \
+        maven \
+        wget \
+        vim \
+        bc \
+        procps \
+        gnupg2
+
+# oracle jdk
+mkdir -p /opt/jdk
+cd /opt
+wget --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-linux-x64.tar.gz
+tar -zxf jdk-8u144-linux-x64.tar.gz -C /opt/jdk
+update-alternatives --install /usr/bin/java java /opt/jdk/jdk1.8.0_144/bin/java 10000
+rm jdk-8u144-linux-x64.tar.gz
+
+# install Cassandra
+echo "deb http://debian.datastax.com/datastax-ddc 3.7 main" | tee -a /etc/apt/sources.list.d/cassandra.sources.list
+curl -L https://debian.datastax.com/debian/repo_key | apt-key add -
+apt-get update -y && apt-get install -y \
+        datastax-ddc
+service cassandra stop
+rm -rf /var/lib/cassandra/data/system/*
+
+# install cassandra-lucene-index
+cd /root && \
+    git clone http://github.com/Stratio/cassandra-lucene-index && \
+    cd cassandra-lucene-index && \
+    git checkout 3.7.1 && \
+    mvn clean package
+cp /root/cassandra-lucene-index/plugin/target/cassandra-lucene-index-plugin-*.jar /usr/share/cassandra/lib
+rm -rf /root/cassandra-lucene-index
+
+# Clean up unnecessary files.
+rm -f /opt/jdk/jdk1.8.0_144/src.zip /opt/jdk/jdk1.8.0_144/javafx-src.zip
+find /usr/lib/python2.7 -name "*.pyc" | xargs rm
+rm -rf /root/.m2
+apt-get purge -y maven git gnupg2
+apt-get autoremove -y
+apt-get clean -y
+rm -rf /var/lib/apt/lists
+rm -rf /usr/share/locale /usr/share/doc /usr/share/man

--- a/saas/axdb/preDockerBuild.sh
+++ b/saas/axdb/preDockerBuild.sh
@@ -3,5 +3,5 @@
 base_registry=${ARGO_BASE_REGISTRY:-docker.io}
 dev_registry=${ARGO_DEV_REGISTRY}
 
-cat BaseDockerfile | sed "s#%%ARGO_BASE_REGISTRY%%#${base_registry}#g" | docker build -t ${dev_registry}/axdb-base:v1.2 -
-docker push ${dev_registry}/axdb-base:v1.2
+cat BaseDockerfile | sed "s#%%ARGO_BASE_REGISTRY%%#${base_registry}#g" | docker build -t ${dev_registry}/axdb-base:v1.3 -f - .
+docker push ${dev_registry}/axdb-base:v1.3

--- a/saas/tests/luceneindex/Dockerfile
+++ b/saas/tests/luceneindex/Dockerfile
@@ -1,4 +1,4 @@
-From %%ARGO_BASE_REGISTRY%%/argobase/axdb-base:v1.1
+From %%ARGO_BASE_REGISTRY%%/argobase/axdb-base:v1.3
 
 WORKDIR /
 

--- a/saas/tools/BaseDockerfile
+++ b/saas/tools/BaseDockerfile
@@ -1,33 +1,4 @@
-From %%ARGO_BASE_REGISTRY%%/argobase/debian:8.5
+From argobase/mini-debian:9.1
 
-# Basic utilities.
-RUN apt-get update && apt-get install -y \
-		apt-utils \
-		curl \
-		sudo \
-		wget \
-		vim  \
-		bc
-
-# oracle jdk
-RUN mkdir /opt/jdk
-RUN cd /opt
-RUN wget --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u71-b13/jdk-8u71-linux-x64.tar.gz
-RUN tar -zxf jdk-8u71-linux-x64.tar.gz -C /opt/jdk
-RUN update-alternatives --install /usr/bin/java java /opt/jdk/jdk1.8.0_71/bin/java 10000
-RUN update-alternatives --install /usr/bin/javac javac /opt/jdk/jdk1.8.0_71/bin/javac 10000
-RUN rm jdk-8u71-linux-x64.tar.gz
-
-# install netcat for health check
-RUN apt-get update && apt-get install -y netcat
-
-# install confluent pacakge
-# First install Confluent’s public key, which is used to sign the packages in the apt repository.
-RUN wget -qO - http://packages.confluent.io/deb/3.1/archive.key | sudo apt-key add -
-
-#Add the repository
-#sudo add-apt-repository "deb http://packages.confluent.io/deb/3.0 stable main"
-RUN echo "deb http://packages.confluent.io/deb/3.1 stable main" >> /etc/apt/sources.list
-
-# install confluent platform
-RUN sudo apt-get update && sudo apt-get install -y confluent-platform-2.11
+ADD base-install.sh /tmp/base-install.sh
+RUN /tmp/base-install.sh && rm /tmp/base-install.sh

--- a/saas/tools/KafkaTestDockerfile
+++ b/saas/tools/KafkaTestDockerfile
@@ -1,4 +1,4 @@
-From %%ARGO_BASE_REGISTRY%%/argobase/axdb-dev:v2.0.3
+From %%ARGO_BASE_REGISTRY%%/argobase/axdb-dev:v2.5.1
 
 # Basic utilities.
 RUN apt-get update && apt-get install -y \

--- a/saas/tools/base-install.sh
+++ b/saas/tools/base-install.sh
@@ -1,0 +1,30 @@
+#!bin/bash
+
+apt-get update
+apt-get install -y \
+        curl \
+        wget \
+        vim  \
+        bc \
+        netcat \
+        gnupg2
+
+# oracle jdk
+mkdir -p /opt/jre
+cd /opt
+wget --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jre-8u144-linux-x64.tar.gz
+tar -zxf jre-8u144-linux-x64.tar.gz -C /opt/jre
+update-alternatives --install /usr/bin/java java /opt/jre/jre1.8.0_144/bin/java 10000
+rm jre-8u144-linux-x64.tar.gz
+
+# install confluent pacakge
+wget -qO - http://packages.confluent.io/deb/3.1/archive.key | apt-key add -
+echo "deb http://packages.confluent.io/deb/3.1 stable main" >> /etc/apt/sources.list
+apt-get update && apt-get install -y confluent-platform-2.11
+
+# Clean up unnecessary files.
+apt-get purge -y gnupg2
+apt-get autoremove -y
+apt-get clean -y
+rm -rf /var/lib/apt/lists
+rm -rf /usr/share/locale /usr/share/doc /usr/share/man

--- a/saas/tools/kafka/Dockerfile
+++ b/saas/tools/kafka/Dockerfile
@@ -5,7 +5,7 @@
 #   docker build -t confluent/kafka kafka
 #   docker run -d --name kafka --link zookeeper:zookeeper confluent/kafka
 
-FROM %%ARGO_BASE_REGISTRY%%/argobase/kafka-base:v1.4
+FROM %%ARGO_BASE_REGISTRY%%/argobase/kafka-base:v1.5
 
 
 ENV LOG_DIR "/ax/kafka/log"

--- a/saas/tools/preDockerBuild.sh
+++ b/saas/tools/preDockerBuild.sh
@@ -3,8 +3,8 @@
 base_registry=${ARGO_BASE_REGISTRY:-docker.io}
 dev_registry=${ARGO_DEV_REGISTRY}
 
-cat BaseDockerfile | sed "s#%%ARGO_BASE_REGISTRY%%#${base_registry}#g" | docker build -t ${dev_registry}/kafka-base:v1.4 -
-docker push ${dev_registry}/kafka-base:v1.4
+cat BaseDockerfile | sed "s#%%ARGO_BASE_REGISTRY%%#${base_registry}#g" | docker build -t ${dev_registry}/kafka-base:v1.5 -f - .
+docker push ${dev_registry}/kafka-base:v1.5
 
-cat KafkaTestDockerfile | sed "s#%%ARGO_BASE_REGISTRY%%#${base_registry}#g" | docker build -t ${dev_registry}/kafka-dev:v1.4 -
-docker push ${dev_registry}/kafka-dev:v1.4
+cat KafkaTestDockerfile | sed "s#%%ARGO_BASE_REGISTRY%%#${base_registry}#g" | docker build -t ${dev_registry}/kafka-dev:v1.5 -f - .
+docker push ${dev_registry}/kafka-dev:v1.5

--- a/saas/tools/rest-proxy/Dockerfile
+++ b/saas/tools/rest-proxy/Dockerfile
@@ -6,7 +6,7 @@
 #   docker run -d --name rest-proxy --link zookeeper:zookeeper --link schema-registry:schema-registry \
 #       confluent/rest-proxy
 
-FROM %%ARGO_BASE_REGISTRY%%/argobase/kafka-base:v1.1
+FROM %%ARGO_BASE_REGISTRY%%/argobase/kafka-base:v1.5
 
 RUN ["mkdir", "-p", "/ax/rest-proxy/bin"]
 COPY rest-proxy-run.sh /ax/rest-proxy/bin/rest-proxy-run.sh

--- a/saas/tools/schema-registry/Dockerfile
+++ b/saas/tools/schema-registry/Dockerfile
@@ -6,7 +6,7 @@
 #   docker run -d --name schema-registry --link zookeeper:zookeeper --link kafka:kafka \
 #       --env SCHEMA_REGISTRY_AVRO_COMPATIBILITY_LEVEL=none confluent/schema-registry
 
-FROM %%ARGO_BASE_REGISTRY%%/argobase/kafka-base:v1.1
+FROM %%ARGO_BASE_REGISTRY%%/argobase/kafka-base:v1.5
 
 RUN mkdir -p /ax/schema-registry/bin
 COPY schema-registry-run.sh /ax/schema-registry/bin/schema-registry-run.sh

--- a/saas/tools/zookeeper/Dockerfile
+++ b/saas/tools/zookeeper/Dockerfile
@@ -4,7 +4,7 @@
 #   docker build -t %%ARGO_BASE_REGISTRY%%/argobase/min/zookeeper:latest .
 #   docker run -d --name zookeeper %%ARGO_BASE_REGISTRY%%/argobase/min/zookeeper:latest
 
-FROM %%ARGO_BASE_REGISTRY%%/argobase/kafka-base:v1.4
+FROM %%ARGO_BASE_REGISTRY%%/argobase/kafka-base:v1.5
 
 ENV LOG_DIR "/ax/zookeeper/log"
 ENV ZK_DATA_DIR "/ax/zookeeper/data"


### PR DESCRIPTION
This commit reduces container sizes. Two major side effects.
- Base linux container is upgraded from 8.5 to 9.1. Upstream 9.1 is smaller than 8.5.
- Old JDK/JRE 8u71 is not available from Oracle any more. Upgrade to 8u144.

Other changes include:
- Move install code to separate script. This creates single layer so that cleanup is easier.
- Add extra cleanup to remove unnecessary deb packages, maven build cache (100MB), all documentations, jdk source code, pyc files, all of which take anywhere from 10MB+ to 100MB+.

End result:
axdb: 1.4GB -> 583MB
kafka: 1.09GB -> 639MB
zookeeper: 1.09GB -> 639MB