### PR TITLE
Issue #90: Hack to force restart docker after salt call.

### DIFF
--- a/platform/cluster/saltbase/salt/docker/init.sls
+++ b/platform/cluster/saltbase/salt/docker/init.sls
@@ -416,7 +416,7 @@ docker-upgrade:
 # TODO: Fix this
 fix-service-docker:
   cmd.wait:
-    - name: /opt/kubernetes/helpers/services enable docker
+    - name: /opt/kubernetes/helpers/services bounce docker
     - watch:
       - file: {{ pillar.get('systemd_system_path') }}/docker.service
       - file: {{ environment_file }}


### PR DESCRIPTION
This is fundaentally bad bootstrap script from kube-up. It starts docker/kubelet in the same time when docker graph storage is configured and all salt configurations are updated. There is always
race among these initialization steps.

Kube-up calls salt and doesn't restart docker afterwards on AWS and instead let docker health checker to detect and restart. Because of race, docker health checker sometimes misses this too. Docker daemon ended up with old generic options rather than ones provided by salt. Docker daemon responded to `docker info` and `docker ps` call but wouldn't start any containers as it's told to use device mapper as graph storage but underlying storage is overlay2.

The correct fix would be using systemd in right way to define dependencies among OS booting, network config, device mounting, graph storage, all salt configurations, and finally docker and kubelet startup.

In the mean time, this seems to be a simple hack to guarantee docker options specified in salt does take effect.