### PR TITLE
Issue #125: AWSMetaData class should not assert on_kube_host or in_pod

### DIFF
--- a/common/python/ax/aws/meta_data.py
+++ b/common/python/ax/aws/meta_data.py
@@ -20,7 +20,6 @@ class AWSMetaData(object):
     There are usually higher level interfaces to use in other places.
     """
     def __init__(self):
-        assert AXEnv().is_in_pod() or AXEnv().on_kube_host()
         self._meta_url = "http://169.254.169.254/latest/meta-data/"
         self._user_url = "http://169.254.169.254/latest/user-data/"
 


### PR DESCRIPTION
The class is a generic client to get AWS metadata, so it should not assert pod/kube host.