### PR TITLE
Issue #95: ADC takes a long time to revive WFE

### DIFF
--- a/devops/src/ax/devops/workflow/adc_main.py
+++ b/devops/src/ax/devops/workflow/adc_main.py
@@ -505,8 +505,8 @@ class ADC(with_metaclass(Singleton, object)):
         return result
 
     def _heartbeat_with_wfe_thread(self):
-        idle_ms_threshold = 10 * 60 * 1000
-        poll_interval_second = 60 * 1
+        idle_ms_threshold = 1 * 60 * 1000  # If no heartbeat for 1 minute, process overdue WFEs
+        poll_interval_second = 15  # Check overdue WFEs every 15 seconds
         try:
             while True:
                 time.sleep(poll_interval_second)

--- a/devops/src/ax/devops/workflow/ax_workflow_executor.py
+++ b/devops/src/ax/devops/workflow/ax_workflow_executor.py
@@ -3180,15 +3180,15 @@ class AXWorkflowExecutor(object):
         t.start()
 
     def _heartbeat_with_adc_thread(self, workflow_id):
-        sleep_ms_at_least = 2 * 60 * 1000  # every 2 minutes
+        sleep_ms_at_least = 20 * 1000  # every 20 seconds
         sleep_ms_at_most = sleep_ms_at_least + 10 * 1000  # plus 10 seconds
 
         count = 0
         while True:
             sleep_second = int(random.randint(sleep_ms_at_least, sleep_ms_at_most) / 1000)
             while sleep_second > 0:
+                time_start = time.time()
                 try:
-                    time_start = time.time()
                     workflow_query_key = AXWorkflow.REDIS_QUERY_LIST_KEY.format(workflow_id)
                     tuple_val = redis_client.brpop([workflow_query_key], timeout=sleep_second)
                     if tuple_val is not None:


### PR DESCRIPTION
- As containers are running as pod instead of job (#41), ADC becomes the only entity that can restart a failed workflow executor (WFE). Currently the revival thredhold is set as 10 min which is too high. The change is changing the threhold to 1 min and sending heartbeat every 30 seconds from WFE to ADC.