### PR TITLE
Issue #125: Need to fix get_public_ip to raise exception.

### DIFF
--- a/common/python/ax/aws/meta_data.py
+++ b/common/python/ax/aws/meta_data.py
@@ -39,7 +39,9 @@ class AWSMetaData(object):
         return r.text
 
     def get_public_ip(self):
-        return requests.get(self._meta_url + "public-ipv4", timeout=3).text.strip()
+        r = requests.get(self._meta_url + "public-ipv4", timeout=3)
+        r.raise_for_status()
+        return r.text.strip()
 
     def get_instance_id(self):
         url = self._meta_url + "instance-id"

--- a/common/python/ax/util/network.py
+++ b/common/python/ax/util/network.py
@@ -80,6 +80,7 @@ def get_public_ip_through_external_server():
         try:
             server_url = server[0]
             resp = requests.get(url=server_url, timeout=15)
+            resp.raise_for_status()
             conf = json.loads(resp.text)
             ip = conf[server[1]]
             if ip is not None:


### PR DESCRIPTION
Once assertion at AWS meta is removed, get_public_ip would return invalid IP if it runs on EC2 instance without external IP. Raise exception if that is case. Also make sure same thing is doen for external servers.