### PR TITLE
Use pod short-names for kdesc.

### DIFF
--- a/bash-helpers.sh
+++ b/bash-helpers.sh
@@ -104,7 +104,15 @@ kp()
 
 kdesc()
 {
-    k "describe" "pods" $@
+    if [ -z "$1" ]
+    then
+        echo "Usage: kdesc pod-name-prefix"
+        return 1
+    fi
+    pod=`kp | grep $1 | cut -d " " -f 1`
+    shift
+    echo "Using pod: " $pod
+    k "describe" "pods" $pod $@
 }
 
 kdp()


### PR DESCRIPTION
Makes it easier to describe pods.