### PR TITLE
Issue 140: Missing action options

### DIFF
--- a/saas/axops/src/ui/src/app/common/volumes-list/volumes-list.component.ts
+++ b/saas/axops/src/ui/src/app/common/volumes-list/volumes-list.component.ts
@@ -18,6 +18,9 @@ export class VolumesListComponent {
     @Output()
     public onDeletedVolume: EventEmitter<string> = new EventEmitter<string>();
 
+    @Output()
+    public onEditVolume: EventEmitter<Volume> = new EventEmitter<Volume>();
+
     constructor(
         private volumesService: VolumesService,
         private notificationsService: NotificationsService,
@@ -26,6 +29,12 @@ export class VolumesListComponent {
 
     public getDropdownMenu(volume: Volume) {
         return new DropdownMenuSettings([{
+            title: 'Edit',
+            iconName: 'fa-pencil-square-o',
+            action: async () => {
+                this.onEditVolume.emit(volume);
+            }
+        }, {
             title: 'Delete',
             iconName: 'fa-times-circle-o',
             action: () => {

--- a/saas/axops/src/ui/src/app/views/+fixtures/fixture-classes/fixture-classes.component.ts
+++ b/saas/axops/src/ui/src/app/views/+fixtures/fixture-classes/fixture-classes.component.ts
@@ -58,15 +58,17 @@ export class FixtureClassesComponent implements HasLayoutSettings, OnInit {
     }
 
     public getGroupMenu(templateGroup: TemplateGroup) {
+        let dropdownMenuList = [{
+            title: 'Reassign Template',
+            action: () => {
+                this.classIdToReassing = templateGroup.enabledClass.id;
+                this.selectTemplateGroup(templateGroup);
+            },
+            iconName: 'ax-icon-connect'
+        }];
+
         if (templateGroup.enabledClass) {
-            return new DropdownMenuSettings([{
-                title: 'Reassign Template',
-                action: () => {
-                    this.classIdToReassing = templateGroup.enabledClass.id;
-                    this.selectTemplateGroup(templateGroup);
-                },
-                iconName: 'ax-icon-connect'
-            }, {
+            dropdownMenuList.push({
                 title: 'Delete Class',
                 action: () => {
                     this.modalService.showModal(
@@ -78,14 +80,16 @@ export class FixtureClassesComponent implements HasLayoutSettings, OnInit {
                         });
                 },
                 iconName: 'ax-icon-stop'
-            }]);
+            });
         } else {
-            return new DropdownMenuSettings([{
+            dropdownMenuList.push({
                 title: 'Enable',
                 action: () => this.selectTemplateGroup(templateGroup),
                 iconName: 'ax-icon-play-2'
-            }]);
+            });
         }
+
+        return new DropdownMenuSettings(dropdownMenuList);
     }
 
     private async loadFixtures() {

--- a/saas/axops/src/ui/src/app/views/+fixtures/fixture-classes/fixture-classes.component.ts
+++ b/saas/axops/src/ui/src/app/views/+fixtures/fixture-classes/fixture-classes.component.ts
@@ -60,14 +60,14 @@ export class FixtureClassesComponent implements HasLayoutSettings, OnInit {
     public getGroupMenu(templateGroup: TemplateGroup) {
         if (templateGroup.enabledClass) {
             return new DropdownMenuSettings([{
-                title: 'Reassign',
+                title: 'Reassign Template',
                 action: () => {
                     this.classIdToReassing = templateGroup.enabledClass.id;
                     this.selectTemplateGroup(templateGroup);
                 },
                 iconName: 'ax-icon-connect'
             }, {
-                title: 'Delete',
+                title: 'Delete Class',
                 action: () => {
                     this.modalService.showModal(
                         'Delete fixture class?', `Are you sure you want to delete fixture class '${templateGroup.enabledClass.name}'?`).subscribe(async confirmed => {

--- a/saas/axops/src/ui/src/app/views/+fixtures/fixture-instances/fixture-instances.component.ts
+++ b/saas/axops/src/ui/src/app/views/+fixtures/fixture-instances/fixture-instances.component.ts
@@ -144,11 +144,11 @@ export class FixtureInstancesComponent implements HasLayoutSettings, LayoutSetti
         return new DropdownMenuSettings([{
             title: 'Create Instance',
             action: () => this.router.navigate([{ create: 'true' }], { relativeTo: this.route }),
-            iconName: ''
+            iconName: 'ax-icon-fixturenew'
         }, {
             title: 'Reassign Template',
             action: () => this.router.navigate([{ reassign: 'true' }], { relativeTo: this.route }),
-            iconName: ''
+            iconName: 'ax-icon-connect'
         }, {
             title: 'Delete Class',
             action: () => {
@@ -159,7 +159,7 @@ export class FixtureInstancesComponent implements HasLayoutSettings, LayoutSetti
                     }
                 });
             },
-            iconName: ''
+            iconName: 'ax-icon-stop'
         }], 'fa-ellipsis-v');
     }
 

--- a/saas/axops/src/ui/src/app/views/+volumes/volume-edit-panel/volume-edit-panel.component.ts
+++ b/saas/axops/src/ui/src/app/views/+volumes/volume-edit-panel/volume-edit-panel.component.ts
@@ -1,13 +1,16 @@
-import { Component, Input, Output, EventEmitter, ViewChild } from '@angular/core';
+import { Component, Input, Output, EventEmitter, ViewChild, OnInit } from '@angular/core';
 
 import { Volume } from '../../../model';
 import { VolumeFormWidgetComponent } from '../volume-form-widget/volume-form-widget.component';
+import { VolumesService } from '../../../services/volumes.service';
 
 @Component({
     selector: 'ax-volume-edit-panel',
     templateUrl: './volume-edit-panel.html',
 })
-export class VolumeEditPanelComponent {
+export class VolumeEditPanelComponent implements OnInit {
+    public loaderEditVolume: boolean = false;
+
     @Output()
     public closePanel = new EventEmitter<any>();
     @Output()
@@ -17,9 +20,20 @@ export class VolumeEditPanelComponent {
     public show: boolean;
     @Input()
     public volume: Volume;
+    @Input()
+    public editVolumeId: string;
 
     @ViewChild(VolumeFormWidgetComponent)
     public volumeFormWidget: VolumeFormWidgetComponent;
+
+    constructor(private volumesService: VolumesService) {
+    }
+
+    ngOnInit() {
+        if (!this.volume && !!this.editVolumeId) {
+            this.getVolumeById(this.editVolumeId);
+        }
+    }
 
     public close() {
         this.closePanel.emit({});
@@ -31,5 +45,11 @@ export class VolumeEditPanelComponent {
 
     public get formInvalid(): boolean {
         return this.volumeFormWidget && this.volumeFormWidget.volumeForm ? this.volumeFormWidget.volumeForm.invalid : false;
+    }
+
+    private async getVolumeById(volumeId) {
+        this.loaderEditVolume = true;
+        this.volume = await this.volumesService.getVolumeById(volumeId);
+        this.loaderEditVolume = false;
     }
 }

--- a/saas/axops/src/ui/src/app/views/+volumes/volume-edit-panel/volume-edit-panel.html
+++ b/saas/axops/src/ui/src/app/views/+volumes/volume-edit-panel/volume-edit-panel.html
@@ -7,7 +7,8 @@
         <h2>Edit Volume Properties</h2>
         <p>Argo provides predefined configurations, which differ in performance characteristics, so that you can
             tailor your storage performance to the needs of your applications.</p>
-        <ax-volume-form-widget [storageClass]="volume.storageClass" [volume]="volume">
+        <ax-volume-form-widget [storageClass]="volume.storageClass" [volume]="volume" *ngIf="volume">
         </ax-volume-form-widget>
+        <ax-loader-list-mockup [itemHeight]="324" [itemsLength]="1" *ngIf="loaderEditVolume"></ax-loader-list-mockup>
     </sliding-panel-body>
 </ax-sliding-panel>

--- a/saas/axops/src/ui/src/app/views/+volumes/volumes-overview/volumes-overview.component.html
+++ b/saas/axops/src/ui/src/app/views/+volumes/volumes-overview/volumes-overview.component.html
@@ -10,7 +10,7 @@
                 <i class="fa ax-icon-stop-property"></i>
                 Storage Class: <span>{{provider.type}}</span>
             </div>
-            <ax-volumes-list [volumes]="provider.volumes" (onDeletedVolume)="onDeletedVolume()"></ax-volumes-list>
+            <ax-volumes-list [volumes]="provider.volumes" (onDeletedVolume)="onDeletedVolume()" (onEditVolume)="onEditVolume($event)"></ax-volumes-list>
         </div>
         <div *ngIf="!providers?.length" class="no-data-panel">
             <strong><i class="fa fa-info-circle"></i>{{ 'No data to display' | translate }}</strong>
@@ -18,3 +18,4 @@
     </div>
 </div>
 <ax-volume-add-panel [show]="showAddPanel" (onClosePanel)="closeAddPanel($event)"></ax-volume-add-panel>
+<ax-volume-edit-panel [show]="showEditPanel" [volume]="editedVolume" [editVolumeId]="editVolumeId" (closePanel)="cancelEdit()" (saveVolume)="editVolume($event)"></ax-volume-edit-panel>

--- a/saas/axops/src/ui/src/app/views/+volumes/volumes-overview/volumes-overview.component.ts
+++ b/saas/axops/src/ui/src/app/views/+volumes/volumes-overview/volumes-overview.component.ts
@@ -4,6 +4,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { HasLayoutSettings, LayoutSettings } from '../../layout';
 import { VolumesService } from '../../../services';
 import { Volume } from '../../../model';
+import { NotificationsService } from 'argo-ui-lib/src/components';
 
 @Component({
     selector: 'ax-volumes-overview',
@@ -15,11 +16,15 @@ export class VolumesOverviewComponent implements HasLayoutSettings, LayoutSettin
     public providers: { type: string, volumes: Volume[] }[] = [];
     public showAddPanel: boolean = false;
     public volumesType: 'named' | 'anonymous';
+    public editedVolume: Volume;
+    public showEditPanel = false;
+    public editVolumeId: string;
 
     constructor(
         private volumesService: VolumesService,
         private router: Router,
-        private route: ActivatedRoute) {
+        private route: ActivatedRoute,
+        private notificationsService: NotificationsService) {
     }
 
     public get layoutSettings(): LayoutSettings {
@@ -39,6 +44,8 @@ export class VolumesOverviewComponent implements HasLayoutSettings, LayoutSettin
     public ngOnInit() {
         this.route.params.subscribe(async params => {
             this.showAddPanel = params['add'] === 'true';
+            this.showEditPanel = params['edit'] === 'true';
+            this.editVolumeId = params['volumeId'];
             let volumesType = params['type'] || 'named';
             if (this.volumesType !== volumesType) {
                 this.volumesType = volumesType;
@@ -59,6 +66,23 @@ export class VolumesOverviewComponent implements HasLayoutSettings, LayoutSettin
     }
 
     public onDeletedVolume() {
+        this.loadVolumes();
+    }
+
+    public onEditVolume(volume: Volume) {
+        this.editedVolume = volume;
+        this.router.navigate(['/app/volumes', { edit: 'true', volumeId: volume.id }], { relativeTo: this.route });
+    }
+
+    public cancelEdit() {
+        this.router.navigate(['/app/volumes', { edit: 'false' }], { relativeTo: this.route } );
+    }
+
+    public async editVolume(volume: Volume) {
+        await this.volumesService.updateVolume(volume);
+        this.notificationsService.success('Volume has been successfully updated.');
+        this.router.navigate(['/app/volumes', { edit: 'false' }], { relativeTo: this.route } );
+
         this.loadVolumes();
     }
 


### PR DESCRIPTION
Added edit option to Volumes main page. Adjusted dropdown actions for Volumes and Fixtures screens.
Fixes #140 

@alex please take a look at the Rahuls comment in issue. If you can describe me when reassign should be visible. I'll update this PR accordingly:
> - Display reassign only when it's applicable. @alexmt we have discussed those usecases in the past.
