### PR TITLE
Return correct spot-instance option from axmon REST API.

### DIFF
--- a/.argo/argo-platform-unit-tests.yaml
+++ b/.argo/argo-platform-unit-tests.yaml
@@ -20,7 +20,8 @@ steps:
         pytest -vv /src/platform/tests/cluster_state_machine/ &&
         python2 -m pytest -s -vv /src/platform/tests/minion_manager/aws/aws_minion_manager_test.py &&
         python2 -m pytest -s -vv /src/platform/tests/minion_manager/aws/aws_bid_advisor_test.py &&
-        python2 -m pytest -s -vv /src/platform/tests/minion_manager/broker_test.py
+        python2 -m pytest -s -vv /src/platform/tests/minion_manager/broker_test.py &&
+        python2 -m pytest -s -vv /src/platform/tests/spot_instance_option_manager_test.py
   KUBE-MONITOR-TESTS:
     template: argo-platform-unit-test-base
     arguments:

--- a/platform/source/lib/ax/platform/ax_asg.py
+++ b/platform/source/lib/ax/platform/ax_asg.py
@@ -85,6 +85,12 @@ class AXUserASGManager(with_metaclass(Singleton, object)):
     def get_all_asgs(self):
         return self.asgs.values()
 
+    def get_all_asg_names(self):
+        asg_names = []
+        for asg in self.asgs.values():
+            asg_names.append(asg["AutoScalingGroupName"])
+        return asg_names
+
     @retry(retry_on_exception=default_aws_retry, wait_exponential_multiplier=1000, stop_max_attempt_number=3)
     def set_asg_spec(self, name, minsize, maxsize, desired=-1):
         if desired < 0:

--- a/platform/source/lib/ax/platform/minion_management/spot_instance_option_manager.py
+++ b/platform/source/lib/ax/platform/minion_management/spot_instance_option_manager.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2015-2017 Applatix, Inc. All rights reserved.
+#
+
+import logging
+
+from ax.platform.ax_asg import AXUserASGManager
+from ax.platform.cluster_config import SpotInstanceOption
+from ax.util.singleton import Singleton
+from future.utils import with_metaclass
+
+
+logger = logging.getLogger(__name__)
+
+
+class SpotInstanceOptionManager(with_metaclass(Singleton, object)):
+    def __init__(self, cluster_name_id, region):
+        self._cluster_name_id = cluster_name_id
+        self._region = region
+
+    def option_to_asgs(self, option):
+        """
+        Returns the names of the ASGs based on the provided config option.
+        """
+        assert option in SpotInstanceOption.VALID_SPOT_INSTANCE_OPTIONS, \
+            "{} is not a valid spot instance option".format(option)
+        asg_manager = AXUserASGManager(self._cluster_name_id, self._region)
+        if option == SpotInstanceOption.ALL_SPOT:
+            asg_names = asg_manager.get_all_asg_names()
+            return asg_names
+        elif option == SpotInstanceOption.NO_SPOT:
+            return []
+        else:
+            return [asg_manager.get_variable_asg()["AutoScalingGroupName"]]
+        return
+
+    def asgs_to_option(self, asgs):
+        """
+        Returns the config option based on the names of the ASGs.
+        """
+        asg_manager = AXUserASGManager(self._cluster_name_id, self._region)
+        all_asg_names = asg_manager.get_all_asg_names()
+        if asgs is None or len(asgs) == 0:
+            return SpotInstanceOption.NO_SPOT
+        elif set(asgs) == set(all_asg_names):
+            return SpotInstanceOption.ALL_SPOT
+        else:
+            return SpotInstanceOption.PARTIAL_SPOT
+        return

--- a/platform/source/lib/ax/platform/minion_manager/README.md
+++ b/platform/source/lib/ax/platform/minion_manager/README.md
@@ -1,0 +1,32 @@
+## Synopsis
+
+The minion-manager component in Argo does the following:
+
+1. Allows usage of AWS spot-instances in the Kubernetes cluster.
+2. Monitors the health of minions in the Kubernetes cluster and terminates unhealthy ones.
+
+## API Reference
+
+The minion-manager configuration can be modified from AXMON. The minion-manager config currently includes two fields:
+
+1. enabled: True/False :: Indicates whether the minion-manager is enabled on not.
+2. spot_instances_option: "all"/"partial"/"none". The autoscaling groups to use for spot-instances.
+
+Endpoint: http://axmon.axsys/v1/axmon/cluster/spot_instance_config
+
+Method: GET
+
+Output:
+{
+  "spot_instances_option": "all",
+  "enabled": "True"
+}
+
+Method: PUT
+
+Example: curl -H "Content-Type: application/json" -X PUT -d '{"enabled":"True","spot_instances_option":"partial"}' http://axmon.axsys:8901/v1/axmon/cluster/spot_instance_config
+
+## Tests
+
+Minion-manager tests run as part of argo-ci.
+

--- a/platform/source/lib/ax/platform/minion_manager/cloud_provider/aws/aws_minion_manager.py
+++ b/platform/source/lib/ax/platform/minion_manager/cloud_provider/aws/aws_minion_manager.py
@@ -503,7 +503,7 @@ class AWSMinionManager(MinionManagerBase):
         app = Flask("MinionManagerRestAPI")
 
         def _update_config_map(enabled_str, asgs):
-            cmap = self.k8s_client.api.read_namespaced_config_map(
+            cmap = k8s_client.api.read_namespaced_config_map(
                 namespace=MM_CONFIG_MAP_NAMESPACE, name=MM_CONFIG_MAP_NAME)
             cmap.data["MM_SPOT_INSTANCE_ENABLED"] = enabled_str
             if asgs:

--- a/platform/source/lib/ax/platform/rest.py
+++ b/platform/source/lib/ax/platform/rest.py
@@ -37,6 +37,7 @@ from ax.platform.bootstrap import AXBootstrap
 from ax.platform.deployments import Deployment
 from ax.platform.axmon_main import AXMon
 from ax.platform.cluster_config import AXClusterConfig, SpotInstanceOption
+from ax.platform.minion_management.spot_instance_option_manager import SpotInstanceOptionManager
 from ax.platform.volumes import VolumeManager
 from ax.platform.exceptions import AXPlatformException
 from ax.platform.cloudprovider.aws import Route53, Route53HostedZone
@@ -201,22 +202,19 @@ def put_spot_instance_config():
         raise ValueError("enabled must be string or boolean")
     payload = {'enabled': enabled_str}
 
-    # Get "asgs" option
-    (asgs,) = _get_optional_arguments('asgs')
-    if asgs is not None:
-        assert asgs in SpotInstanceOption.VALID_SPOT_INSTANCE_OPTIONS, "Unknown spot-instance-option " + asgs
-        asg_option = ""
-        if asgs == SpotInstanceOption.PARTIAL_SPOT:
-            asg_option = asg_manager.get_variable_asg()["AutoScalingGroupName"]
-        elif asgs == SpotInstanceOption.ALL_SPOT:
-            for asg in asg_manager.get_all_asgs():
-                asg_option = asg_option + asg["AutoScalingGroupName"] + " "
-            # Remove the last <space>
-            asg_option = asg_option[:-1]
-        elif asgs == SpotInstanceOption.NO_SPOT:
+    # Get "spot_instances_option" option
+    (option,) = _get_optional_arguments('spot_instances_option')
+    if option is not None:
+        spotOptionMgr = SpotInstanceOptionManager(
+            cluster_name_id, AXClusterConfig().get_region())
+        asg_names = spotOptionMgr.option_to_asgs(option)
+        asg_option = " ".join(asg_names)
+
+        if option == SpotInstanceOption.NO_SPOT:
             _app.logger.info("ASGS passed in a \"none\". Disabling minion-manager.")
             enabled_str = "False"
             payload['enabled'] = enabled_str
+
         payload['asgs'] = asg_option
 
     requests.put(MINION_MANAGER_HOSTNAME + ":" + MINION_MANAGER_PORT + "/spot_instance_config", params=payload)
@@ -228,7 +226,15 @@ def put_spot_instance_config():
 @_app.route("/v1/axmon/cluster/spot_instance_config", methods=['GET'])
 def get_spot_instance_config():
     response = requests.get(MINION_MANAGER_HOSTNAME + ":" + MINION_MANAGER_PORT + "/spot_instance_config")
-    return response.text
+    response.raise_for_status()
+    details = response.json()
+    assert "asgs" in details, "No asgs returned by minion-manager"
+
+    spotOptionMgr = SpotInstanceOptionManager(
+        cluster_name_id, AXClusterConfig().get_region())
+    spot_option = spotOptionMgr.asgs_to_option(details["asgs"].split(" "))
+
+    return jsonify({"status": "ok", "enabled": details["status"], "spot_instances_option": spot_option})
 
 @_app.route("/v1/axmon/portal", methods=['GET'])
 def axmon_api_get_portal():

--- a/platform/source/lib/ax/platform/rest.py
+++ b/platform/source/lib/ax/platform/rest.py
@@ -217,7 +217,8 @@ def put_spot_instance_config():
 
         payload['asgs'] = asg_option
 
-    requests.put(MINION_MANAGER_HOSTNAME + ":" + MINION_MANAGER_PORT + "/spot_instance_config", params=payload)
+    response = requests.put(MINION_MANAGER_HOSTNAME + ":" + MINION_MANAGER_PORT + "/spot_instance_config", params=payload)
+    response.raise_for_status()
 
     _app.logger.info("Change in Spot instance config: {}".format(enabled_str))
     return jsonify({"status": "ok"})

--- a/platform/tests/spot_instance_option_manager_test.py
+++ b/platform/tests/spot_instance_option_manager_test.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2015-2017 Applatix, Inc. All rights reserved.
+#
+
+"""The file has unit tests for the SpotInstanceOptionManager."""
+
+import mock
+import pytest
+import unittest
+
+from ax.platform.cluster_config import SpotInstanceOption
+from ax.platform.minion_management.spot_instance_option_manager import SpotInstanceOptionManager
+import boto3
+from bunch import bunchify
+from moto import mock_autoscaling, mock_sts
+
+
+class SpotInstanceOptionManagerTest(unittest.TestCase):
+    """
+    Tests for the SpotInstanceOptionManager.
+    """
+    cluster_name = "cluster"
+    cluster_id = "6883161e-d211-11e6-bc1d-c0ffeec0ffee"
+    cluster_name_id = cluster_name + "-" + cluster_id
+    asg_names = []
+    for asg in [cluster_name + "-user-on-demand", cluster_name + "-user-spot", cluster_name + "-user-variable"]:
+        asg_names.append(asg)
+
+    session = boto3.Session(region_name="us-west-2")
+    autoscaling = session.client("autoscaling")
+
+    def create_mock_asg(self, asg_name):
+        lc_name = asg_name + "-lc"
+        response = self.autoscaling.create_launch_configuration(
+            LaunchConfigurationName=lc_name, ImageId='ami-f00bad',
+            KeyName='kubernetes-some-key')
+        r = bunchify(response)
+        assert r.ResponseMetadata.HTTPStatusCode == 200
+
+        response = self.autoscaling.create_auto_scaling_group(
+            AutoScalingGroupName=asg_name, LaunchConfigurationName=lc_name,
+            MinSize=3, MaxSize=3, DesiredCapacity=3,
+            Tags=[{'ResourceId': self.cluster_name_id, 'Key': 'KubernetesCluster', 'Value': self.cluster_name_id},
+                  {'ResourceId': self.cluster_name_id, 'Key': 'AXTier', 'Value': 'user'}]
+        )
+        r = bunchify(response)
+        assert r.ResponseMetadata.HTTPStatusCode == 200
+
+    def setup_test(self):
+        for asg in self.asg_names:
+            self.create_mock_asg(asg)
+
+        return SpotInstanceOptionManager(self.cluster_name_id, "us-west-2")
+
+    @mock_autoscaling
+    @mock_sts
+    def test_option_to_asgs(self):
+        spot_option_mgr = self.setup_test()
+        assert set(spot_option_mgr.option_to_asgs(SpotInstanceOption.ALL_SPOT)) == set(self.asg_names)
+
+        partial_asg = spot_option_mgr.option_to_asgs(SpotInstanceOption.PARTIAL_SPOT)
+        assert len(partial_asg) == 1, "Too many ASGs returned for PARTIAL_SPOT"
+        assert partial_asg[0] == self.cluster_name + "-user-variable"
+
+        no_spot = spot_option_mgr.option_to_asgs(SpotInstanceOption.NO_SPOT)
+        assert len(no_spot) == 0
+
+    @mock_autoscaling
+    @mock_sts
+    def test_asgs_to_option(self):
+        spot_option_mgr = self.setup_test()
+        assert spot_option_mgr.asgs_to_option(self.asg_names) == SpotInstanceOption.ALL_SPOT
+        assert spot_option_mgr.asgs_to_option([self.cluster_name + "-user-variable"]) == SpotInstanceOption.PARTIAL_SPOT
+        assert spot_option_mgr.asgs_to_option([]) == SpotInstanceOption.NO_SPOT


### PR DESCRIPTION
Testing Done:

1. Added unit tests for spot-instance-option-manager
2. Also verified that the AXMON APIs for get/put of the spot-instance config options work as expected.

Closes #176.