### PR TITLE
Issue #146: add cluster state machine to ensure cluster management operations can be triggered properly

### DIFF
--- a/.argo/argo-platform-unit-tests.yaml
+++ b/.argo/argo-platform-unit-tests.yaml
@@ -17,6 +17,7 @@ steps:
         pytest -vv /src/platform/tests/util/ &&
         pytest -vv /src/platform/tests/lib/ax/platform/ax_asg_test.py &&
         pytest -vv /src/platform/tests/axmon/operations_test.py &&
+        pytest -vv /src/platform/tests/cluster_state_machine/ &&
         python2 -m pytest -s -vv /src/platform/tests/minion_manager/aws/aws_minion_manager_test.py &&
         python2 -m pytest -s -vv /src/platform/tests/minion_manager/aws/aws_bid_advisor_test.py &&
         python2 -m pytest -s -vv /src/platform/tests/minion_manager/broker_test.py

--- a/common/python/ax/cloud/aws/aws_s3.py
+++ b/common/python/ax/cloud/aws/aws_s3.py
@@ -342,6 +342,7 @@ class AXS3Bucket(object):
         except Exception as e:
             if "NoSuchKey" not in str(e):
                 raise
+        return None
 
     def get_object_url_from_key(self, key):
         if self._region == "us-east-1":

--- a/common/python/ax/cloud/gke/gcs.py
+++ b/common/python/ax/cloud/gke/gcs.py
@@ -168,6 +168,7 @@ class AXGCSBucket(object):
         except Exception as e:
             if "NoSuchKey" not in str(e):
                 raise
+        return None
 
     def get_object_url_from_key(self, key):
         return ""

--- a/common/python/ax/cluster_management/app/cluster_pauser.py
+++ b/common/python/ax/cluster_management/app/cluster_pauser.py
@@ -11,6 +11,7 @@ Module for pausing an Argo cluster
 
 import logging
 import yaml
+import sys
 import time
 
 from ax.cloud.aws import EC2InstanceState
@@ -38,7 +39,8 @@ class ClusterPauser(ClusterOperationBase):
         super(ClusterPauser, self).__init__(
             cluster_name=self._cfg.cluster_name,
             cluster_id=self._cfg.cluster_id,
-            cloud_profile=self._cfg.cloud_profile
+            cloud_profile=self._cfg.cloud_profile,
+            dry_run=self._cfg.dry_run
         )
 
         # This will raise exception if name/id mapping cannot be found
@@ -63,11 +65,18 @@ class ClusterPauser(ClusterOperationBase):
         )
         self._cidr = str(get_public_ip()) + "/32"
 
-    def run(self):
-        # Abort operation if cluster is not successfully installed
+    def pre_run(self):
+        if self._csm.is_paused():
+            logger.info("Cluster is already paused.")
+            sys.exit(0)
+
+        # This is for backward compatibility
         if not check_cluster_staging(cluster_info_obj=self._cluster_info, stage="stage2"):
             raise RuntimeError("Cluster is not successfully installed: Stage2 information missing! Operation aborted.")
+        self._csm.do_pause()
+        self._persist_cluster_state_if_needed()
 
+    def run(self):
         if self._cfg.dry_run:
             logger.info("DRY RUN: pausing cluster %s", self._name_id)
             return
@@ -97,6 +106,10 @@ class ClusterPauser(ClusterOperationBase):
             raise RuntimeError(e)
         finally:
             self._disallow_pauser_access_if_needed()
+
+    def post_run(self):
+        self._csm.done_pause()
+        self._persist_cluster_state_if_needed()
 
     def _wait_for_deregistering_minions(self):
         """

--- a/common/python/ax/cluster_management/app/cluster_uninstaller.py
+++ b/common/python/ax/cluster_management/app/cluster_uninstaller.py
@@ -41,7 +41,8 @@ class ClusterUninstaller(ClusterOperationBase):
         super(ClusterUninstaller, self).__init__(
             cluster_name=self._cfg.cluster_name,
             cluster_id=self._cfg.cluster_id,
-            cloud_profile=self._cfg.cloud_profile
+            cloud_profile=self._cfg.cloud_profile,
+            dry_run=self._cfg.dry_run
         )
 
         # This will raise exception if name/id mapping cannot be found
@@ -59,13 +60,20 @@ class ClusterUninstaller(ClusterOperationBase):
         self._total_nodes = 1
         self._cidr = str(get_public_ip()) + "/32"
 
-    def run(self):
+    def pre_run(self):
         # Abort operation if cluster is not successfully installed
         if not check_cluster_staging(cluster_info_obj=self._cluster_info, stage="stage2") and not self._cfg.force_uninstall:
             raise RuntimeError("Cluster is not successfully installed or has already been half deleted. If you really want to uninstall the cluster, please add '--force-uninstall' flag to finish uninstalling cluster. e.g. 'argocluster uninstall --force-uninstall --cluster-name xxx'")
-
+        if not self._csm.is_running() and not self._cfg.force_uninstall:
+            raise RuntimeError("Cluster is not in Running state. If you really want to uninstall the cluster, please add '--force-uninstall' flag to finish uninstalling cluster. e.g. 'argocluster uninstall --force-uninstall --cluster-name xxx'")
+        self._csm.do_uninstall()
         self._ensure_critical_information()
+        self._persist_cluster_state_if_needed()
 
+    def post_run(self):
+        return
+
+    def run(self):
         if self._cfg.dry_run:
             logger.info("DRY RUN: Uninstalling cluster %s", self._name_id)
             return

--- a/common/python/ax/cluster_management/app/cluster_upgrader.py
+++ b/common/python/ax/cluster_management/app/cluster_upgrader.py
@@ -12,6 +12,7 @@ Module for pausing an Argo cluster
 import logging
 import os
 import subprocess
+import sys
 import yaml
 from pprint import pformat
 
@@ -40,7 +41,8 @@ class ClusterUpgrader(ClusterOperationBase):
         super(ClusterUpgrader, self).__init__(
             cluster_name=self._cfg.cluster_name,
             cluster_id=self._cfg.cluster_id,
-            cloud_profile=self._cfg.cloud_profile
+            cloud_profile=self._cfg.cloud_profile,
+            dry_run=self._cfg.dry_run
         )
 
         # This will raise exception if name/id mapping cannot be found
@@ -64,34 +66,36 @@ class ClusterUpgrader(ClusterOperationBase):
             )
         )
         self._cidr = str(get_public_ip()) + "/32"
+        self._upgrade_kube_needed = True
+        self._upgrade_service_needed = True
 
-    def run(self):
+    def pre_run(self):
+        if not check_cluster_staging(cluster_info_obj=self._cluster_info, stage="stage2"):
+            raise RuntimeError("Cluster is not successfully installed: Stage2 information missing! Operation aborted.")
+
         self._runtime_validation()
 
-        upgrade_kube = True
-        upgrade_service = True
+        self._csm.do_upgrade()
+        self._persist_cluster_state_if_needed()
 
         if self._cfg.target_software_info.kube_installer_version == self._current_software_info.kube_installer_version \
             and self._cfg.target_software_info.kube_version == self._current_software_info.kube_version \
                 and not self._cfg.force_upgrade:
-            upgrade_kube = False
+            self._upgrade_kube_needed = False
 
         if self._cfg.target_software_info.image_namespace == self._current_software_info.image_namespace \
             and self._cfg.target_software_info.image_version == self._current_software_info.image_version \
             and self._cfg.target_software_info.image_version != "latest" \
-            and not upgrade_kube \
+            and not self._upgrade_kube_needed \
                 and not self._cfg.force_upgrade:
-            upgrade_service = False
+            self._upgrade_service_needed = False
 
-        if not upgrade_service and not upgrade_kube:
+        if not self._upgrade_kube_needed and not self._upgrade_service_needed:
             logger.info("%sCluster's software versions is not changed, not performing upgrade.%s", COLOR_GREEN, COLOR_NORM)
             logger.info("%sIf you want to force upgrade cluster, please specify --force-upgrade flag.%s", COLOR_YELLOW, COLOR_NORM)
-            return
+            sys.exit(0)
 
-        if self._cfg.dry_run:
-            logger.info("DRY RUN: upgrading cluster %s", self._name_id)
-            return
-
+    def run(self):
         upgrade_info = "    Software Image: {}:{}  ->  {}:{}\n".format(
             self._current_software_info.image_namespace, self._current_software_info.image_version,
             self._cfg.target_software_info.image_namespace, self._cfg.target_software_info.image_version
@@ -104,7 +108,11 @@ class ClusterUpgrader(ClusterOperationBase):
         )
         logger.info("\n\n%sUpgrading cluster %s:\n\n%s%s\n", COLOR_GREEN, self._name_id, upgrade_info, COLOR_NORM)
 
-        # Main pause cluster routine
+        if self._cfg.dry_run:
+            logger.info("DRY RUN: upgrading cluster %s", self._name_id)
+            return
+
+        # Main upgrade cluster routine
         try:
             self._ensure_credentials()
 
@@ -112,13 +120,13 @@ class ClusterUpgrader(ClusterOperationBase):
 
             ensure_manifest_temp_dir()
 
-            if upgrade_service:
+            if self._upgrade_service_needed:
                 self._shutdown_platform()
 
-            if upgrade_kube:
+            if self._upgrade_kube_needed:
                 self._upgrade_kube()
 
-            if upgrade_service:
+            if self._upgrade_service_needed:
                 self._start_platform()
                 self._cluster_info.upload_platform_manifests_and_config(
                     platform_manifest_root=self._cfg.manifest_root,
@@ -130,6 +138,10 @@ class ClusterUpgrader(ClusterOperationBase):
             raise RuntimeError(e)
         finally:
             self._disallow_upgrader_access_if_needed()
+
+    def post_run(self):
+        self._csm.done_upgrade()
+        self._persist_cluster_state_if_needed()
 
     def _runtime_validation(self):
         all_errs = []

--- a/common/python/ax/cluster_management/app/state/__init__.py
+++ b/common/python/ax/cluster_management/app/state/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2015-2017 Applatix, Inc. All rights reserved.
+#
+
+from .state import ClusterStateMachine
+from .consts import ClusterState

--- a/common/python/ax/cluster_management/app/state/consts.py
+++ b/common/python/ax/cluster_management/app/state/consts.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2015-2017 Applatix, Inc. All rights reserved.
+#
+
+
+class ClusterState:
+    INSTALLING = "Installing"
+    RUNNING = "Running"
+    PAUSING = "Pausing"
+    PAUSED = "Paused"
+    RESUMING = "Resuming"
+    UPGRADING = "Upgrading"
+    UNINSTALLING = "Uninstalling"
+
+    # Used before cluster state is firstly set. i.e. an stale cluster that does not have
+    # state information, or a cluster before installation. Cluster can transit from
+    # this state to any other state
+    UNKNOWN = "Unknown"
+
+    VALID_CLUSTER_STATES = [INSTALLING, RUNNING, PAUSING, PAUSED, RESUMING, UPGRADING, UNINSTALLING, UNKNOWN]
+

--- a/common/python/ax/cluster_management/app/state/state.py
+++ b/common/python/ax/cluster_management/app/state/state.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2015-2017 Applatix, Inc. All rights reserved.
+#
+
+
+"""
+The cluster state machine provides a mechanism to avoid cluster administrator initiate
+an inappropriate cluster management operation when cluster is not ready for that. For
+example, cluster upgrader would assume cluster is in running state as it needs to talk
+with cluster master for upgrade. If the cluster is paused, or the cluster is even in
+its install phase, we need to abort upgrade.
+
+Implementation of cluster state transitions. Note that is not a constantly running
+state machine, and needs an external blob store, such as S3 to check/persist cluster
+state. This class is used by cluster management apps such as cluster pauser, upgrader,
+etc.
+
+This implementation assumes there is only 1 instance of the state machine manipulating
+cluster state, as there is no proper locking mechanism in normal blob stores such as S3,
+nor is such locking mechanism needed in use cases (e.g. there is only one person upgrading
+cluster at one time)
+
+Cluster has 2 types of states:
+    - Mutating state (Installing, Pausing, Upgrading, Resuming, Uninstalling)
+    - Stable state (Running, Paused, Unknown)
+
+Mutating state can be triggered from stable state, in addition, for backward compatibility,
+if a cluster is currently having no state record (Unknown), we can transit to a mutating
+state as well. One exception is that cluster can enter uninstalling from any state, as
+we support force uninstall.
+
+Stable state can be triggered from mutating state ONLY
+"""
+
+from transitions import Machine
+
+from ax.platform.ax_cluster_info import AXClusterInfo
+from .consts import ClusterState
+
+
+class ClusterStateMachine(object):
+    def __init__(self, cluster_name_id, cloud_profile):
+        self._cluster_info = AXClusterInfo(cluster_name_id=cluster_name_id, aws_profile=cloud_profile)
+        current_state = self._cluster_info.download_cluster_current_state() or ClusterState.UNKNOWN
+
+        self.machine = Machine(model=self, states=ClusterState.VALID_CLUSTER_STATES, initial=current_state)
+        self._add_transitions()
+
+    def _add_transitions(self):
+        self.machine.add_transition(
+            trigger="do_install",
+            source=[ClusterState.UNKNOWN, ClusterState.INSTALLING],
+            dest=ClusterState.INSTALLING
+        )
+
+        self.machine.add_transition(
+            trigger="done_install",
+            source=ClusterState.INSTALLING,
+            dest=ClusterState.RUNNING
+        )
+
+        self.machine.add_transition(
+            trigger="do_pause",
+            source=[ClusterState.UNKNOWN, ClusterState.RUNNING, ClusterState.PAUSING],
+            dest=ClusterState.PAUSING
+        )
+
+        self.machine.add_transition(
+            trigger="done_pause",
+            source=ClusterState.PAUSING,
+            dest=ClusterState.PAUSED
+        )
+
+        self.machine.add_transition(
+            trigger="do_resume",
+            source=[ClusterState.UNKNOWN, ClusterState.PAUSED, ClusterState.RESUMING],
+            dest=ClusterState.RESUMING
+        )
+
+        self.machine.add_transition(
+            trigger="done_resume",
+            source=ClusterState.RESUMING,
+            dest=ClusterState.RUNNING
+        )
+
+        self.machine.add_transition(
+            trigger="do_upgrade",
+            source=[ClusterState.UNKNOWN, ClusterState.RUNNING, ClusterState.UPGRADING],
+            dest=ClusterState.UPGRADING
+        )
+
+        self.machine.add_transition(
+            trigger="done_upgrade",
+            source=ClusterState.UPGRADING,
+            dest=ClusterState.RUNNING
+        )
+
+        self.machine.add_transition(
+            trigger="do_uninstall",
+            source=[
+                ClusterState.RUNNING, ClusterState.UNKNOWN, ClusterState.UPGRADING,
+                ClusterState.PAUSING, ClusterState.PAUSED, ClusterState.RESUMING,
+                ClusterState.UNINSTALLING, ClusterState.INSTALLING
+            ],
+            dest=ClusterState.UNINSTALLING
+        )
+
+    @property
+    def current_state(self):
+        return self.state
+
+    def is_installing(self):
+        return self.current_state == ClusterState.INSTALLING
+
+    def is_running(self):
+        return self.current_state == ClusterState.RUNNING
+
+    def is_pausing(self):
+        return self.current_state == ClusterState.PAUSING
+
+    def is_paused(self):
+        return self.current_state == ClusterState.PAUSED
+
+    def is_upgrading(self):
+        return self.current_state == ClusterState.UPGRADING
+
+    def is_resuming(self):
+        return self.current_state == ClusterState.RESUMING
+
+    def is_uninstalling(self):
+        return self.current_state == ClusterState.UNINSTALLING
+
+    def is_unknown(self):
+        return self.current_state == ClusterState.UNKNOWN
+
+    def persist_state(self):
+        self._cluster_info.upload_cluster_current_state(self.current_state)

--- a/common/python/ax/cluster_management/argo_cluster_manager.py
+++ b/common/python/ax/cluster_management/argo_cluster_manager.py
@@ -76,7 +76,7 @@ class ArgoClusterManager(object):
         err = install_config.validate()
         self._continue_or_die(err)
         self._ensure_customer_id(install_config.cloud_profile)
-        ClusterInstaller(install_config).run()
+        ClusterInstaller(install_config).start()
 
     def pause(self, args):
         pause_config = ClusterPauseConfig(cfg=args)
@@ -84,7 +84,7 @@ class ArgoClusterManager(object):
         err = pause_config.validate()
         self._continue_or_die(err)
         self._ensure_customer_id(pause_config.cloud_profile)
-        ClusterPauser(pause_config).run()
+        ClusterPauser(pause_config).start()
 
     def resume(self, args):
         resume_config = ClusterRestartConfig(cfg=args)
@@ -92,7 +92,7 @@ class ArgoClusterManager(object):
         err = resume_config.validate()
         self._continue_or_die(err)
         self._ensure_customer_id(resume_config.cloud_profile)
-        ClusterResumer(resume_config).run()
+        ClusterResumer(resume_config).start()
 
     def uninstall(self, args):
         uninstall_config = ClusterUninstallConfig(cfg=args)
@@ -100,7 +100,7 @@ class ArgoClusterManager(object):
         err = uninstall_config.validate()
         self._continue_or_die(err)
         self._ensure_customer_id(uninstall_config.cloud_profile)
-        ClusterUninstaller(uninstall_config).run()
+        ClusterUninstaller(uninstall_config).start()
 
     def download_cluster_credentials(self, args):
         config = ClusterMiscOperationConfig(cfg=args)
@@ -124,7 +124,7 @@ class ArgoClusterManager(object):
         err = upgrade_config.validate()
         self._continue_or_die(err)
         self._ensure_customer_id(upgrade_config.cloud_profile)
-        ClusterUpgrader(upgrade_config).run()
+        ClusterUpgrader(upgrade_config).start()
 
     @staticmethod
     def _ensure_customer_id(cloud_profile):

--- a/common/python/ax/meta/config_s3_path.py
+++ b/common/python/ax/meta/config_s3_path.py
@@ -121,6 +121,7 @@ class AXClusterConfigPath(with_metaclass(Singleton, AXConfigBase)):
     CLUSTER_TERRAFORM_DIR = "{name}/{id}/terraform/"
     CLUSTER_S3_PLATFORM_MANIFEST_DIR = "{name}/{id}/platform/manifests/"
     CLUSTER_S3_PLATFORM_CONFIG = "{name}/{id}/platform/config"
+    CLUSTER_S3_CURRENT_STATE = "{name}/{id}/current_state"
 
     def __init__(self, name_id):
         super(AXClusterConfigPath, self).__init__(name_id)
@@ -173,6 +174,9 @@ class AXClusterConfigPath(with_metaclass(Singleton, AXConfigBase)):
 
     def platform_config(self):
         return self.CLUSTER_S3_PLATFORM_CONFIG.format(name=self._cluster_name, id=self._cluster_id)
+
+    def current_state(self):
+        return self.CLUSTER_S3_CURRENT_STATE.format(name=self._cluster_name, id=self._cluster_id)
 
 
 class AXClusterDataPath(with_metaclass(Singleton, AXConfigBase)):

--- a/platform/source/lib/ax/platform/ax_cluster_info.py
+++ b/platform/source/lib/ax/platform/ax_cluster_info.py
@@ -62,6 +62,7 @@ class AXClusterInfo(with_metaclass(Singleton, object)):
         self._s3_cluster_software_info = config_path.versions()
         self._s3_platform_manifest_dir = config_path.platform_manifest_dir()
         self._s3_platform_config = config_path.platform_config()
+        self._s3_cluster_current_state = config_path.current_state()
 
         self._s3_master_config_prefix = config_path.master_config_dir()
         self._s3_master_attributes_path = config_path.master_attributes_path()
@@ -250,6 +251,16 @@ class AXClusterInfo(with_metaclass(Singleton, object)):
         if not self._bucket.delete_object(key=self._staging_info[stage]):
             raise AXPlatformException("Failed to delete {} information".format(stage))
         logger.info("Deleted Argo install %s info from s3 ...", stage)
+
+    def download_cluster_current_state(self):
+        logger.info("Downloading cluster current state ...")
+        return self._bucket.get_object(key=self._s3_cluster_current_state)
+
+    def upload_cluster_current_state(self, state):
+        logger.info("Uploading cluster current state ...")
+        if not self._bucket.put_object(key=self._s3_cluster_current_state, data=state):
+            raise AXPlatformException("Failed to upload cluster current state info for {}".format(self._cluster_name_id))
+        logger.info("Uploading cluster current state ... DONE")
 
     def get_kube_config_file_path(self):
         """

--- a/platform/tests/cluster_state_machine/mock.py
+++ b/platform/tests/cluster_state_machine/mock.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2015-2017 Applatix, Inc. All rights reserved.
+#
+
+from transitions import Machine
+from ax.cluster_management.app.state import ClusterStateMachine, ClusterState
+
+
+class ClusterStateMachineMock(ClusterStateMachine):
+    def __init__(self, current_state):
+        self.machine = Machine(model=self, states=ClusterState.VALID_CLUSTER_STATES, initial=current_state)
+        self._add_transitions()
+
+    def persist_state(self):
+        pass

--- a/platform/tests/cluster_state_machine/test_cluster_state_transition.py
+++ b/platform/tests/cluster_state_machine/test_cluster_state_transition.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2015-2017 Applatix, Inc. All rights reserved.
+#
+
+import pytest
+from transitions import MachineError
+
+from ax.cluster_management.app.state import ClusterState
+from .mock import ClusterStateMachineMock
+
+
+def test_cluster_state_normal_transition():
+    csm = ClusterStateMachineMock(current_state=ClusterState.UNKNOWN)
+
+    # Install
+    csm.do_install()
+    assert csm.is_installing()
+    csm.done_install()
+    assert csm.is_running()
+
+    # Pause
+    csm.do_pause()
+    assert csm.is_pausing()
+    csm.done_pause()
+    assert csm.is_paused()
+
+    # Resume
+    csm.do_resume()
+    assert csm.is_resuming()
+    csm.done_resume()
+    assert csm.is_running()
+
+    # Upgrade
+    csm.do_upgrade()
+    assert csm.is_upgrading()
+    csm.done_upgrade()
+    assert csm.is_running()
+
+    # Uninstall
+    csm.do_uninstall()
+    assert csm.is_uninstalling()
+
+
+def test_valid_cluster_state_transition_from_unknown():
+    # We can transit from Unknown to Installing, Pausing, Upgrading, Resuming, Uninstalling
+    csm = ClusterStateMachineMock(current_state=ClusterState.UNKNOWN)
+    csm.do_install()
+    assert csm.is_installing()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.UNKNOWN)
+    csm.do_pause()
+    assert csm.is_pausing()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.UNKNOWN)
+    csm.do_resume()
+    assert csm.is_resuming()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.UNKNOWN)
+    csm.do_upgrade()
+    assert csm.is_upgrading()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.UNKNOWN)
+    csm.do_uninstall()
+    assert csm.is_uninstalling()
+
+
+def test_invalid_cluster_state_transition_from_unknown():
+    # With Unknown state, we cannot transit it to RUNNING / PAUSED
+    csm = ClusterStateMachineMock(current_state=ClusterState.UNKNOWN)
+    with pytest.raises(MachineError):
+        csm.done_install()
+    assert csm.is_unknown()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.UNKNOWN)
+    with pytest.raises(MachineError):
+        csm.done_pause()
+    assert csm.is_unknown()
+
+
+def test_uninstall_from_any_state():
+    csm = ClusterStateMachineMock(current_state=ClusterState.INSTALLING)
+    csm.do_uninstall()
+    assert csm.is_uninstalling()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.PAUSING)
+    csm.do_uninstall()
+    assert csm.is_uninstalling()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.PAUSED)
+    csm.do_uninstall()
+    assert csm.is_uninstalling()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.RESUMING)
+    csm.do_uninstall()
+    assert csm.is_uninstalling()
+
+
+def test_transit_to_same_state():
+    # This is to make sure we can retry operations
+    csm = ClusterStateMachineMock(current_state=ClusterState.INSTALLING)
+    csm.do_install()
+    assert csm.is_installing()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.PAUSING)
+    csm.do_pause()
+    assert csm.is_pausing()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.RESUMING)
+    csm.do_resume()
+    assert csm.is_resuming()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.UPGRADING)
+    csm.do_upgrade()
+    assert csm.is_upgrading()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.UNINSTALLING)
+    csm.do_uninstall()
+    assert csm.is_uninstalling()
+
+
+def test_other_common_invalid_state_transitions():
+    # Invalid transitions from Installing
+    csm = ClusterStateMachineMock(current_state=ClusterState.INSTALLING)
+    with pytest.raises(MachineError):
+        csm.do_pause()
+    assert csm.is_installing()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.INSTALLING)
+    with pytest.raises(MachineError):
+        csm.do_upgrade()
+    assert csm.is_installing()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.INSTALLING)
+    with pytest.raises(MachineError):
+        csm.do_resume()
+    assert csm.is_installing()
+
+    # Invalid transitions from Pausing
+    csm = ClusterStateMachineMock(current_state=ClusterState.PAUSING)
+    with pytest.raises(MachineError):
+        csm.do_install()
+    assert csm.is_pausing()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.PAUSING)
+    with pytest.raises(MachineError):
+        csm.do_resume()
+    assert csm.is_pausing()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.PAUSING)
+    with pytest.raises(MachineError):
+        csm.do_upgrade()
+    assert csm.is_pausing()
+
+    # Invalid transitions from Resuming
+    csm = ClusterStateMachineMock(current_state=ClusterState.RESUMING)
+    with pytest.raises(MachineError):
+        csm.do_install()
+    assert csm.is_resuming()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.RESUMING)
+    with pytest.raises(MachineError):
+        csm.do_upgrade()
+    assert csm.is_resuming()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.RESUMING)
+    with pytest.raises(MachineError):
+        csm.do_pause()
+    assert csm.is_resuming()
+
+    # Invalid transitions from Upgrading
+    csm = ClusterStateMachineMock(current_state=ClusterState.UPGRADING)
+    with pytest.raises(MachineError):
+        csm.do_install()
+    assert csm.is_upgrading()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.UPGRADING)
+    with pytest.raises(MachineError):
+        csm.do_pause()
+    assert csm.is_upgrading()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.UPGRADING)
+    with pytest.raises(MachineError):
+        csm.do_resume()
+    assert csm.is_upgrading()
+
+    # Invalid transitions from Paused
+    csm = ClusterStateMachineMock(current_state=ClusterState.PAUSED)
+    with pytest.raises(MachineError):
+        csm.do_install()
+    assert csm.is_paused()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.PAUSED)
+    with pytest.raises(MachineError):
+        csm.do_pause()
+    assert csm.is_paused()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.PAUSED)
+    with pytest.raises(MachineError):
+        csm.do_upgrade()
+    assert csm.is_paused()
+
+    # Invalid transitions from Uninstalling
+    csm = ClusterStateMachineMock(current_state=ClusterState.UNINSTALLING)
+    with pytest.raises(MachineError):
+        csm.do_install()
+    assert csm.is_uninstalling()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.UNINSTALLING)
+    with pytest.raises(MachineError):
+        csm.do_pause()
+    assert csm.is_uninstalling()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.UNINSTALLING)
+    with pytest.raises(MachineError):
+        csm.do_upgrade()
+    assert csm.is_uninstalling()
+
+    csm = ClusterStateMachineMock(current_state=ClusterState.UNINSTALLING)
+    with pytest.raises(MachineError):
+        csm.do_resume()
+    assert csm.is_uninstalling()


### PR DESCRIPTION
Resolves #146 

Implemented a state machine mechanism to ensure cluster management operations to be triggered correctly. Added unit tests for state machine, also separated cluster management operations into pre_run, run, and post_run stages.