### PR TITLE
Issue #191: prometheus-deployment crash in stress testing

### DIFF
--- a/platform/containers/prometheus/run.sh
+++ b/platform/containers/prometheus/run.sh
@@ -13,6 +13,22 @@ set -ex
     exit 1
 fi
 
+if [ -e /prometheus/crash_flag ]
+then
+    value=`cat /prometheus/crash_flag`
+    cur=$(date +%s)
+    difference=$(($cur-$value))
+    threshold=300  # threshold is set to 5 min
+    if [ $difference -le $threshold ]
+    then
+        # Clear previous data in the directory
+        rm -rf /prometheus/data
+    fi
+fi
+
+# Reset the time flag
+echo $(date +%s) > /prometheus/crash_flag
+
 # memory_persist is memory and should be small. Use 1/3 of memory_chunks.
 #memory_chunks=`awk 'BEGIN{print int(60000*'$MEM_MULT');}'`
 #memory_persist=`awk 'BEGIN{print int(20000*'$MEM_MULT');}'`


### PR DESCRIPTION
The idea is to clear the data folder when there is a crash happens.