### PR TITLE
Issue #145: argocluster CLI should abort operation if the cluster is supported by portal

### DIFF
--- a/common/python/ax/cluster_management/app/cluster_pauser.py
+++ b/common/python/ax/cluster_management/app/cluster_pauser.py
@@ -66,6 +66,8 @@ class ClusterPauser(ClusterOperationBase):
         self._cidr = str(get_public_ip()) + "/32"
 
     def pre_run(self):
+        if self._cluster_info.is_cluster_supported_by_portal():
+            raise RuntimeError("Cluster is currently supported by portal. Please login to portal to perform cluster management operations.")
         if self._csm.is_paused():
             logger.info("Cluster is already paused.")
             sys.exit(0)

--- a/common/python/ax/cluster_management/app/cluster_restarter.py
+++ b/common/python/ax/cluster_management/app/cluster_restarter.py
@@ -79,6 +79,9 @@ class ClusterResumer(ClusterOperationBase):
         )
 
     def pre_run(self):
+        if self._cluster_info.is_cluster_supported_by_portal():
+            raise RuntimeError("Cluster is currently supported by portal. Please login to portal to perform cluster management operations.")
+
         if self._csm.is_running():
             logger.info("Cluster is already running.")
             sys.exit(0)

--- a/common/python/ax/cluster_management/app/cluster_uninstaller.py
+++ b/common/python/ax/cluster_management/app/cluster_uninstaller.py
@@ -61,6 +61,8 @@ class ClusterUninstaller(ClusterOperationBase):
         self._cidr = str(get_public_ip()) + "/32"
 
     def pre_run(self):
+        if self._cluster_info.is_cluster_supported_by_portal():
+            raise RuntimeError("Cluster is currently supported by portal. Please login to portal to perform cluster management operations.")
         # Abort operation if cluster is not successfully installed
         if not check_cluster_staging(cluster_info_obj=self._cluster_info, stage="stage2") and not self._cfg.force_uninstall:
             raise RuntimeError("Cluster is not successfully installed or has already been half deleted. If you really want to uninstall the cluster, please add '--force-uninstall' flag to finish uninstalling cluster. e.g. 'argocluster uninstall --force-uninstall --cluster-name xxx'")

--- a/common/python/ax/cluster_management/app/cluster_upgrader.py
+++ b/common/python/ax/cluster_management/app/cluster_upgrader.py
@@ -70,6 +70,9 @@ class ClusterUpgrader(ClusterOperationBase):
         self._upgrade_service_needed = True
 
     def pre_run(self):
+        if self._cluster_info.is_cluster_supported_by_portal():
+            raise RuntimeError("Cluster is currently supported by portal. Please login to portal to perform cluster management operations.")
+
         if not check_cluster_staging(cluster_info_obj=self._cluster_info, stage="stage2"):
             raise RuntimeError("Cluster is not successfully installed: Stage2 information missing! Operation aborted.")
 

--- a/common/python/ax/meta/config_s3_path.py
+++ b/common/python/ax/meta/config_s3_path.py
@@ -106,22 +106,24 @@ class AXUpgradeConfigPath(with_metaclass(Singleton, AXConfigBase)):
 
 class AXClusterConfigPath(with_metaclass(Singleton, AXConfigBase)):
 
-    CLUSTER_S3_KUBE_CONFIG_KEY = "{name}/{id}/kube_config"
-    CLUSTER_S3_KUBE_SSH_KEY = "{name}/{id}/kube_ssh"
-    CLUSTER_S3_CLUSTER_CONFIG_KEY = "{name}/{id}/cluster_config"
+    CLUSTER_S3_OBJECT_COMMON_PREFIX = "{name}/{id}"
+    CLUSTER_S3_KUBE_CONFIG_KEY = "{}/kube_config".format(CLUSTER_S3_OBJECT_COMMON_PREFIX)
+    CLUSTER_S3_KUBE_SSH_KEY = "{}/kube_ssh".format(CLUSTER_S3_OBJECT_COMMON_PREFIX)
+    CLUSTER_S3_CLUSTER_CONFIG_KEY = "{}/cluster_config".format(CLUSTER_S3_OBJECT_COMMON_PREFIX)
     CLUSTER_S3_INSTALL_STAGE_0_KEY = CLUSTER_S3_CLUSTER_CONFIG_KEY
-    CLUSTER_S3_INSTALL_STAGE_1_KEY = "{name}/{id}/stage1"
-    CLUSTER_S3_INSTALL_STAGE_2_KEY = "{name}/{id}/stage2"
-    CLUSTER_S3_VERSIONS_KEY = "{name}/{id}/current_versions"
-    CLUSTER_S3_MASTER_CONFIG_DIR = "{name}/{id}/master_config/"     # The trailing / is required.
+    CLUSTER_S3_INSTALL_STAGE_1_KEY = "{}/stage1".format(CLUSTER_S3_OBJECT_COMMON_PREFIX)
+    CLUSTER_S3_INSTALL_STAGE_2_KEY = "{}/stage2".format(CLUSTER_S3_OBJECT_COMMON_PREFIX)
+    CLUSTER_S3_VERSIONS_KEY = "{}/current_versions".format(CLUSTER_S3_OBJECT_COMMON_PREFIX)
+    CLUSTER_S3_MASTER_CONFIG_DIR = "{}/master_config/".format(CLUSTER_S3_OBJECT_COMMON_PREFIX)     # The trailing / is required.
     CLUSTER_S3_MASTER_ATTRIBUTES = CLUSTER_S3_MASTER_CONFIG_DIR + "attributes"
     CLUSTER_S3_MASTER_USER_DATA = CLUSTER_S3_MASTER_CONFIG_DIR + "user-data"
-    CLUSTER_S3_STATE_BEFORE_PAUSE = "{name}/{id}/state_before_pause"
-    CLUSTER_S3_METADATA = "{name}/{id}/metadata/v1/metadata.yaml"
-    CLUSTER_TERRAFORM_DIR = "{name}/{id}/terraform/"
-    CLUSTER_S3_PLATFORM_MANIFEST_DIR = "{name}/{id}/platform/manifests/"
-    CLUSTER_S3_PLATFORM_CONFIG = "{name}/{id}/platform/config"
-    CLUSTER_S3_CURRENT_STATE = "{name}/{id}/current_state"
+    CLUSTER_S3_STATE_BEFORE_PAUSE = "{}/state_before_pause".format(CLUSTER_S3_OBJECT_COMMON_PREFIX)
+    CLUSTER_S3_METADATA = "{}/metadata/v1/metadata.yaml".format(CLUSTER_S3_OBJECT_COMMON_PREFIX)
+    CLUSTER_TERRAFORM_DIR = "{}/terraform/".format(CLUSTER_S3_OBJECT_COMMON_PREFIX)
+    CLUSTER_S3_PLATFORM_MANIFEST_DIR = "{}/platform/manifests/".format(CLUSTER_S3_OBJECT_COMMON_PREFIX)
+    CLUSTER_S3_PLATFORM_CONFIG = "{}/platform/config".format(CLUSTER_S3_OBJECT_COMMON_PREFIX)
+    CLUSTER_S3_CURRENT_STATE = "{}/current_state".format(CLUSTER_S3_OBJECT_COMMON_PREFIX)
+    CLUSTER_S3_PORTAL_SUPPORT = "{}/portal_support".format(CLUSTER_S3_OBJECT_COMMON_PREFIX)
 
     def __init__(self, name_id):
         super(AXClusterConfigPath, self).__init__(name_id)
@@ -177,6 +179,9 @@ class AXClusterConfigPath(with_metaclass(Singleton, AXConfigBase)):
 
     def current_state(self):
         return self.CLUSTER_S3_CURRENT_STATE.format(name=self._cluster_name, id=self._cluster_id)
+
+    def portal_support(self):
+        return self.CLUSTER_S3_PORTAL_SUPPORT.format(name=self._cluster_name, id=self._cluster_id)
 
 
 class AXClusterDataPath(with_metaclass(Singleton, AXConfigBase)):

--- a/platform/source/lib/ax/platform/ax_cluster_info.py
+++ b/platform/source/lib/ax/platform/ax_cluster_info.py
@@ -63,6 +63,7 @@ class AXClusterInfo(with_metaclass(Singleton, object)):
         self._s3_platform_manifest_dir = config_path.platform_manifest_dir()
         self._s3_platform_config = config_path.platform_config()
         self._s3_cluster_current_state = config_path.current_state()
+        self._s3_portal_support_flag = config_path.portal_support()
 
         self._s3_master_config_prefix = config_path.master_config_dir()
         self._s3_master_attributes_path = config_path.master_attributes_path()
@@ -261,6 +262,23 @@ class AXClusterInfo(with_metaclass(Singleton, object)):
         if not self._bucket.put_object(key=self._s3_cluster_current_state, data=state):
             raise AXPlatformException("Failed to upload cluster current state info for {}".format(self._cluster_name_id))
         logger.info("Uploading cluster current state ... DONE")
+
+    def enable_portal_support(self):
+        logger.info("Setting portal support flag ...")
+        if not self._bucket.put_object(key=self._s3_portal_support_flag, data="True"):
+            raise AXPlatformException("Failed to upload cluster status before pause")
+        logger.info("Setting portal support flag ... DONE")
+
+    def disable_portal_support(self):
+        logger.info("Deleting portal support flag ...")
+        if not self._bucket.delete_object(key=self._s3_portal_support_flag):
+            raise AXPlatformException("Failed to upload cluster status before pause")
+        logger.info("Deleted portal support flag")
+
+    def is_cluster_supported_by_portal(self):
+        logger.info("Checking portal support flag ...")
+        data = self._bucket.get_object(key=self._s3_portal_support_flag)
+        return False if not data else True
 
     def get_kube_config_file_path(self):
         """


### PR DESCRIPTION
Resolves #145 

When a cluster is registered to portal, portal is going to put a flag in its s3 bucket. argocluster CLI is checking this flag, if set, it aborts operation from CLI. Verified that CLI is aborted by manually setting the flag in S3