### PR TITLE
Issue #202: fix broken cluster state machine unit test

### DIFF
--- a/.argo/argo-platform-unit-tests.yaml
+++ b/.argo/argo-platform-unit-tests.yaml
@@ -17,7 +17,7 @@ steps:
         pytest -vv /src/platform/tests/util/ &&
         pytest -vv /src/platform/tests/lib/ax/platform/ax_asg_test.py &&
         pytest -vv /src/platform/tests/axmon/operations_test.py &&
-        pytest -vv /src/platform/tests/cluster_state_machine/ &&
+        python2 -m pytest -s -vv /src/platform/tests/cluster_state_machine/ &&
         python2 -m pytest -s -vv /src/platform/tests/minion_manager/aws/aws_minion_manager_test.py &&
         python2 -m pytest -s -vv /src/platform/tests/minion_manager/aws/aws_bid_advisor_test.py &&
         python2 -m pytest -s -vv /src/platform/tests/minion_manager/broker_test.py


### PR DESCRIPTION
Fixes #202 Looks like there is a python3 incompatibility with the test. Unit test should run under python2 environment. The added module is used for argocluster command only and currently it runs only under python2 so it's fine.

Unit test is now passed. https://dev.applatix.net/app/timeline/jobs/8074e6a6-976a-11e7-89cf-0a58c0a88335;tab=workflow