### PR TITLE
Install Argo on user-provided AWS clusters.

### DIFF
--- a/common/python/ax/cluster_management/app/cluster_installer.py
+++ b/common/python/ax/cluster_management/app/cluster_installer.py
@@ -28,6 +28,7 @@ from ax.platform.cluster_buckets import AXClusterBuckets
 from ax.platform.cluster_config import AXClusterConfig, SpotInstanceOption, AXClusterSize
 from ax.platform.ax_cluster_info import AXClusterInfo
 from ax.platform.ax_kube_up_down import AXKubeUpDown
+from ax.platform.cluster_config.consts import ClusterProvider
 from ax.platform.kube_env_config import prepare_kube_install_config
 from ax.platform.platform import AXPlatform
 from ax.platform.resource import KubeMasterResourceConfig
@@ -49,6 +50,7 @@ CLUSTER_CONFIG_TEMPLATES = {
         "medium": "cloud_template_medium.json",
         "large": "cloud_template_large.json",
         "xlarge": "cloud_template_xlarge.json",
+        "user_provided": "cloud_template_user_provided.json"
 }
 
 DEFAULT_NODE_SPOT_PRICE = "0.1512"
@@ -107,6 +109,7 @@ class ClusterInstaller(ClusterOperationBase):
             return
         cluster_dns, username, password = self._ensure_argo_microservices()
 
+    def persist_username_password_locally(self, username, password, cluster_dns):
         # Dump Argo cluster profile
         if username and password:
             logger.info("Generating Argo cluster profile ...")
@@ -146,6 +149,20 @@ please contact your administrator for more information to configure your argo CL
         )
         logger.info("Cluster information:\n%s%s%s\n", COLOR_GREEN, summary, COLOR_NORM)
 
+    def run(self):
+        """
+        Main install routine
+        :return:
+        """
+        self._pre_install()
+        self._ensure_kubernetes_cluster()
+        if self._cfg.dry_run:
+            logger.info("DRY RUN: not installing cluster")
+            return
+        cluster_dns, username, password = self._ensure_argo_microservices()
+
+        self.persist_username_password_locally(username, password, cluster_dns)
+
     def _pre_install(self):
         """
         Pre install ensures the following stuff:
@@ -169,7 +186,6 @@ please contact your administrator for more information to configure your argo CL
 
         # Generate raw config dict
         raw_cluster_config_dict = self._generate_raw_cluster_config_dict()
-
         # Set cluster config object with raw cluster config dict
         self._cluster_config.set_config(raw_cluster_config_dict)
 
@@ -247,6 +263,48 @@ please contact your administrator for more information to configure your argo CL
 
         logger.info("Cluster installation step: Ensure Kubernetes Cluster successfully finished")
 
+    def install_and_run_platform(self):
+        logger.info("Starting platform install")
+        # Install Argo micro-services
+        # Platform install
+        platform = AXPlatform(
+            cluster_name_id=self._name_id,
+            aws_profile=self._cfg.cloud_profile,
+            manifest_root=self._cfg.manifest_root,
+            config_file=self._cfg.bootstrap_config
+        )
+
+        install_platform_failed = False
+        install_platform_failure_message = ""
+        try:
+            platform.start()
+            platform.stop_monitor()
+        except Exception as e:
+            logger.exception(e)
+            install_platform_failed = True
+            install_platform_failure_message = str(e) + "\nPlease manually check the cluster status and retry installation with same command if the error is transient."
+
+        if install_platform_failed:
+            raise RuntimeError(install_platform_failure_message)
+
+        # In case platform is successfully installed,
+        # connect to axops to get initial username and password
+        username, password = self._get_initial_cluster_credentials()
+
+        logger.info("Done with platform install")
+        return platform.cluster_dns_name, username, password
+
+    def post_install(self):
+        # Persist manifests to S3
+        self._cluster_info.upload_platform_manifests_and_config(
+            platform_manifest_root=self._cfg.manifest_root,
+            platform_config=self._cfg.bootstrap_config
+        )
+
+        # Finally persist stage2 information
+        self._cluster_info.upload_staging_info(stage="stage2", msg="stage2")
+        logger.info("Cluster installation step: Ensure Argo Micro-services successfully finished")
+
     def _ensure_argo_microservices(self):
         """
         This step won't run if there is "--dry-run" specified.
@@ -308,31 +366,9 @@ please contact your administrator for more information to configure your argo CL
             max=axuser_max_count
         )
 
-        # Install Argo micro-services
-        # Platform install
-        platform = AXPlatform(
-            cluster_name_id=self._name_id,
-            aws_profile=self._cfg.cloud_profile,
-            manifest_root=self._cfg.manifest_root,
-            config_file=self._cfg.bootstrap_config
-        )
+        cluster_dns, username, password = self.install_and_run_platform()
 
-        install_platform_failed = False
-        install_platform_failure_message = ""
-        try:
-            platform.start()
-            platform.stop_monitor()
-        except Exception as e:
-            logger.exception(e)
-            install_platform_failed = True
-            install_platform_failure_message = str(e) + "\nPlease manually check the cluster status and retry installation with same command if the error is transient."
-
-        if install_platform_failed:
-            raise RuntimeError(install_platform_failure_message)
-
-        # In case platform is successfully installed,
-        # connect to axops to get initial username and password
-        username, password = self._get_initial_cluster_credentials()
+        self.post_install()
 
         # Remove access from 0.0.0.0/0 if this is not what user specifies
         if EC2IPPermission.AllIP not in trusted_cidrs:
@@ -342,16 +378,7 @@ please contact your administrator for more information to configure your argo CL
                 action_name="disallow-creator"
             )
 
-        # Persist manifests to S3
-        self._cluster_info.upload_platform_manifests_and_config(
-            platform_manifest_root=self._cfg.manifest_root,
-            platform_config=self._cfg.bootstrap_config
-        )
-
-        # Finally persist stage2 information
-        self._cluster_info.upload_staging_info(stage="stage2", msg="stage2")
-        logger.info("Cluster installation step: Ensure Argo Micro-services successfully finished")
-        return platform.cluster_dns_name, username, password
+        return cluster_dns_name, username, password
 
     @retry(wait_fixed=5, stop_max_attempt_number=10)
     def _get_initial_cluster_credentials(self):
@@ -431,19 +458,20 @@ please contact your administrator for more information to configure your argo CL
         axuser_node_type = config["cloud"]["configure"]["axuser_node_type"]
         axuser_node_max = config["cloud"]["configure"]["max_node_count"] - axsys_node_max
         cluster_type = config["cloud"]["configure"]["cluster_type"]
-        master_config = KubeMasterResourceConfig(
-            usr_node_type=axuser_node_type,
-            usr_node_max=axuser_node_max,
-            ax_node_type=axsys_node_type,
-            ax_node_max=axsys_node_max,
-            cluster_type=cluster_type
-        )
-        if self._cfg.cluster_size == AXClusterSize.CLUSTER_MVC:
-            # MVC cluster does not follow the heuristics we used to configure master
-            config["cloud"]["configure"]["master_type"] = "m3.xlarge"
-        else:
-            config["cloud"]["configure"]["master_type"] = master_config.master_instance_type
-        config["cloud"]["configure"]["master_config_env"] = master_config.kube_up_env
+        if self._cfg.cluster_size != AXClusterSize.CLUSTER_USER_PROVIDED:
+            master_config = KubeMasterResourceConfig(
+                usr_node_type=axuser_node_type,
+                usr_node_max=axuser_node_max,
+                ax_node_type=axsys_node_type,
+                ax_node_max=axsys_node_max,
+                cluster_type=cluster_type
+            )
+            if self._cfg.cluster_size == AXClusterSize.CLUSTER_MVC:
+                # MVC cluster does not follow the heuristics we used to configure master
+                config["cloud"]["configure"]["master_type"] = "m3.xlarge"
+            else:
+                config["cloud"]["configure"]["master_type"] = master_config.master_instance_type
+            config["cloud"]["configure"]["master_config_env"] = master_config.kube_up_env
 
         # TODO (#121) Need to revise the relationship between user_on_demand_nodes and node minimum, system node count
         config["cloud"]["configure"]["axuser_on_demand_nodes"] = self._cfg.user_on_demand_nodes
@@ -470,3 +498,18 @@ please contact your administrator for more information to configure your argo CL
         """
         config["cloud"]["trusted_cidr"] = self._cfg.trusted_cidrs
         return config
+
+    def update_and_save_config(self, cluster_bucket=None):
+        """
+        Update the config to use the given bucket and upload cluster_config and kubeconfig
+        to the given bucket.
+        """
+        raw_cluster_config_dict = self._generate_raw_cluster_config_dict()
+        self._cluster_config.set_config(raw_cluster_config_dict)
+        self._cluster_config.set_cluster_provider(ClusterProvider.USER)
+        self._cluster_config.set_support_object_store_name(cluster_bucket)
+
+        # Save config file to s3.
+        self._cluster_config.save_config()
+
+        self._cluster_info.upload_kube_config()

--- a/common/python/ax/cluster_management/app/options/__init__.py
+++ b/common/python/ax/cluster_management/app/options/__init__.py
@@ -3,7 +3,7 @@
 # Copyright 2015-2017 Applatix, Inc. All rights reserved.
 #
 
-from .install_options import add_install_flags, ClusterInstallConfig, ClusterInstallDefaults
+from .install_options import add_install_flags, add_platform_only_flags, ClusterInstallConfig, ClusterInstallDefaults, PlatformOnlyInstallConfig
 from .misc_operation_config import add_misc_flags, ClusterMiscOperationConfig
 from .pause_options import add_pause_flags, ClusterPauseConfig
 from .restart_options import add_restart_flags, ClusterRestartConfig

--- a/common/python/ax/kubernetes/ax_kube_yaml_update.py
+++ b/common/python/ax/kubernetes/ax_kube_yaml_update.py
@@ -17,7 +17,7 @@ from ax.meta import AXClusterId, AXCustomerId
 from ax.kubernetes.ax_kube_dict import KubeKindToV1KubeSwaggerObject
 from ax.kubernetes.swagger_client import ApiClient, V1Pod, V1beta1StatefulSet, V1beta1Deployment, V1beta1DaemonSet, \
     V1PersistentVolumeClaim, V1Container, V1Service, V1EnvVar, V1EnvVarSource, V1ObjectFieldSelector
-from ax.platform.cluster_config import AXClusterConfig
+from ax.platform.cluster_config import AXClusterConfig, ClusterProvider
 from ax.platform.component_config import SoftwareInfo
 from ax.platform.resource import AXSYSResourceConfig
 from ax.util.resource import ResourceValueConverter
@@ -37,8 +37,17 @@ class AXSYSKubeYamlUpdater(object):
         self._config_file = config_file_path
         self._cluster_name_id = AXClusterId().get_cluster_name_id()
         self._cluster_config = AXClusterConfig(cluster_name_id=self._cluster_name_id)
-        self.cpu_mult, self.mem_mult, self.disk_mult, \
-            self.daemon_cpu_mult, self.daemon_mem_mult = self._get_resource_multipliers()
+
+        if self._cluster_config.get_cluster_provider() != ClusterProvider.USER:
+            self.cpu_mult, self.mem_mult, self.disk_mult, \
+                self.daemon_cpu_mult, self.daemon_mem_mult = self._get_resource_multipliers()
+        else:
+            self.cpu_mult = 1
+            self.mem_mult = 1
+            self.disk_mult = 1
+            self.daemon_cpu_mult = 1
+            self.daemon_mem_mult = 1
+
         self._swagger_components = []
         self._yaml_components = []
         self._updated_raw = ""

--- a/common/python/ax/meta/cluster_id.py
+++ b/common/python/ax/meta/cluster_id.py
@@ -47,7 +47,7 @@ class AXClusterId(with_metaclass(Singleton, object)):
 
         # Set bucket
         self._customer_id = AXCustomerId().get_customer_id()
-        self._bucket_name = self._bucket_template.format(account=self._customer_id, seq=0)
+        self._bucket_name = os.getenv("ARGO_DATA_BUCKET_NAME") or self._bucket_template.format(account=self._customer_id, seq=0)
         self._bucket = None
 
         # These values will be set when user calls get/create cluster name id

--- a/common/python/ax/meta/config_s3_path.py
+++ b/common/python/ax/meta/config_s3_path.py
@@ -90,7 +90,7 @@ class AXUpgradeConfigPath(with_metaclass(Singleton, AXConfigBase)):
     def __init__(self, name_id):
         super(AXUpgradeConfigPath, self).__init__(name_id)
         self._bucket_template = "applatix-upgrade-{account}-{seq}"
-        self._bucket_name = self._bucket_template.format(account=self._account, seq=0)
+        self._bucket_name = os.getenv("ARGO_DATA_BUCKET_NAME") or self._bucket_template.format(account=self._account, seq=0)
         self._external = True
         logger.info("Using AX upgrade config path %s", self._bucket_name)
 
@@ -128,7 +128,7 @@ class AXClusterConfigPath(with_metaclass(Singleton, AXConfigBase)):
     def __init__(self, name_id):
         super(AXClusterConfigPath, self).__init__(name_id)
         self._bucket_template = "applatix-cluster-{account}-{seq}"
-        self._bucket_name = self._bucket_template.format(account=self._account, seq=0)
+        self._bucket_name = os.getenv("ARGO_DATA_BUCKET_NAME") or self._bucket_template.format(account=self._account, seq=0)
         self._external = False
         logger.info("Using AX cluster config path %s", self._bucket_name)
 
@@ -188,7 +188,7 @@ class AXClusterDataPath(with_metaclass(Singleton, AXConfigBase)):
     def __init__(self, name_id):
         super(AXClusterDataPath, self).__init__(name_id)
         self._bucket_template = "applatix-data-{account}-{seq}"
-        self._bucket_name = self._bucket_template.format(account=self._account, seq=0)
+        self._bucket_name = os.getenv("ARGO_DATA_BUCKET_NAME") or self._bucket_template.format(account=self._account, seq=0)
         self._external = False
         logger.info("Using AX cluster data path %s", self._bucket_name)
 

--- a/devops/src/ax/devops/gateway/gateway.py
+++ b/devops/src/ax/devops/gateway/gateway.py
@@ -47,7 +47,7 @@ class Gateway(object):
 
     CLUSTER_NAME_ID = os.environ.get('AX_CLUSTER')
     CUSTOMER_ID = os.environ.get('AX_CUSTOMER_ID')
-    S3_BUCKET_NAME = 'applatix-cluster-{account}-{seq}'.format(account=CUSTOMER_ID, seq=0)
+    S3_BUCKET_NAME = os.getenv("ARGO_DATA_BUCKET_NAME") or 'applatix-cluster-{account}-{seq}'.format(account=CUSTOMER_ID, seq=0)
     s3_bucket = boto3.resource('s3').Bucket(S3_BUCKET_NAME)
 
     def __init__(self):

--- a/platform/config/cloud/standard/cloud_template_user_provided.json
+++ b/platform/config/cloud/standard/cloud_template_user_provided.json
@@ -1,0 +1,21 @@
+{
+    "cloud": {
+        "provider": "aws",
+        "version": 1,
+        "configure": {
+            "cluster_user": "",
+            "cluster_size": "user_provided",
+            "cluster_type": "standard",
+            "region": "us-west-2",
+            "placement": "us-west-2a",
+            "axsys_node_type": "m3.large",
+            "axuser_node_type": "c3.2xlarge",
+            "min_node_count": 0,
+            "max_node_count": 9223372036854775800,
+            "axsys_node_count": 0,
+            "node_tiers": "",
+            "ax_vol_size": 100,
+            "axuser_on_demand_nodes": 0
+        }
+    }
+}

--- a/platform/config/service/config/user_k8s_platform-bootstrap.cfg
+++ b/platform/config/service/config/user_k8s_platform-bootstrap.cfg
@@ -1,0 +1,190 @@
+#
+# NOTE: IF THIS FILE IS BEING MODIFIED, please look at platform.py start() to check if
+# the ordering guarantees are broken!
+#
+version: "v1"
+name: "Applatix Platform Config Standard"
+spec:
+  steps:
+    # Step 0: Create all kubernetes namespaces
+    - name: "Essential Kubernetes Namespaces"
+      policy: "CreateOnce"
+      consistency: "CreateIfNotExist"
+      objects:
+        - name: "axuser-namespace"
+          file: "axuser-namespace.yml.in"
+
+        - name: "axsys-namespace"
+          file: "axsys-namespace.yml.in"
+
+    # Step 1: Any kubernetes addons.
+    - name: "Essential Kubnernetes addons"
+
+    # Step 2: Applatix basics
+    # Including basic services, volumes and secrets. These object should be only created once
+    - name: "Basic Infrastructure"
+      policy: "CreateOnce"
+      consistency: "CreateIfNotExist"
+      objects:
+        - name: "axops-svc"
+          file: "axops-svc.yml.in"
+          namespace: "axsys"
+
+        - name: "axops-internal-svc"
+          file: "axops-internal-svc.yml.in"
+          namespace: "axsys"
+
+        - name: "applatix-svc"
+          file: "applatix-svc.yml.in"
+          namespace: "axsys"
+
+        - name: "kafka-zk-pvc"
+          file: "kafka-zk-pvc.yml.in"
+          namespace: "axsys"
+
+        - name: "redis-pvc"
+          file: "redis-pvc.yml.in"
+          namespace: "axsys"
+
+        - name: "prometheus-pvc"
+          file: "prometheus-pvc.yml.in"
+          namespace: "axsys"
+
+        - name: "gateway-pvc"
+          file: "gateway-pvc.yml.in"
+          namespace: "axsys"
+
+    # Step 3: Registry Secrets
+    - name: "Registry Secrets"
+      policy: "CreateOnce"
+      policy_predicate: "PrivateRegistryOnly"
+      consistency: "CreateIfNotExist"
+      objects:
+        - name: "registry-secrets-axsys"
+          file: "registry-secrets.yml.in"
+          namespace: "axsys"
+
+        - name: "registry-secrets-axuser"
+          file: "registry-secrets.yml.in"
+          namespace: "axuser"
+
+        - name: "registry-secrets-kube"
+          file: "registry-secrets.yml.in"
+          namespace: "kube-system"
+
+    # Step 4: Kafka (Heavy Hitter)
+    - name: "Kafka"
+      policy: "CreateMany"
+      consistency: "CreateIfNotExist"
+      objects:
+        - name: "kafka-zk-svc"
+          file: "kafka-zk-svc.yml.in"
+          namespace: "axsys"
+
+    # Step 5: Cassandra (Heavy Hitter)
+    - name: "Cassandra"
+      policy: "CreateMany"
+      consistency: "CreateIfNotExist"
+      objects:
+        - name: "axdb-svc"
+          file: "axdb-svc.yml.in"
+          namespace: "axsys"
+
+    # Step 6: Other heavy hitters and their dependencies
+    - name: "Heavy Hitters"
+      policy: "CreateMany"
+      consistency: "CreateIfNotExist"
+      objects:
+        - name: "prometheus"
+          file: "prometheus.yml.in"
+          namespace: "axsys"
+        - name: "gateway-svc"
+          file: "gateway-svc.yml.in"
+          namespace: "axsys"
+        - name: "axops"
+          file: "axops.yml.in"
+          namespace: "axsys"
+        - name: "axmon-svc"
+          file: "axmon-svc.yml.in"
+          namespace: "axsys"
+
+    # Step 7: Rest of Applatix services
+    - name: "Backend Micro Services"
+      policy: "CreateMany"
+      consistency: "CreateIfNotExist"
+      objects:
+        - name: "node-exporter"
+          file: "node-exporter.yml.in"
+          namespace: "kube-system"
+
+        - name: "fluentd"
+          file: "fluentd.yml.in"
+          namespace: "kube-system"
+
+        - name: "applet"
+          file: "applet.yml.in"
+          namespace: "kube-system"
+
+        - name: "ingress-controller"
+          file: "ingress-controller.yml.in"
+          namespace: "axsys"
+
+        - name: "platform-post-boot"
+          file: "platform-post-boot.yml.in"
+          namespace: "axsys"
+
+        - name: "cron"
+          file: "cron.yml.in"
+          namespace: "axsys"
+
+        - name: "axconsole-svc"
+          file: "axconsole-svc.yml.in"
+          namespace: "axsys"
+
+        - name: "axworkflowadc-svc"
+          file: "axworkflowadc-svc.yml.in"
+          namespace: "axsys"
+
+        - name: "notification-center-svc"
+          file: "notification-center-svc.yml.in"
+          namespace: "axsys"
+
+        - name: "fixturemanager-svc"
+          file: "fixturemanager-svc.yml.in"
+          namespace: "axsys"
+
+        - name: "ingress-controller-int"
+          file: "ingress-controller-int.yml.in"
+          namespace: "axsys"
+
+        - name: "axnotification-svc"
+          file: "axnotification-svc.yml.in"
+          namespace: "axsys"
+
+        - name: "axamm-svc"
+          file: "axamm-svc.yml.in"
+          namespace: "axsys"
+
+        - name: "default-http-backend"
+          file: "default-http-backend.yml.in"
+          namespace: "axsys"
+
+        - name: "redis-svc"
+          file: "redis-svc.yml.in"
+          namespace: "axsys"
+
+        - name: "axopsbootstrap"
+          file: "axopsbootstrap.yml.in"
+          namespace: "axsys"
+
+        - name: "axstats"
+          file: "axstats.yml.in"
+          namespace: "axsys"
+
+        - name: "axartifactmanager-svc"
+          file: "axartifactmanager-svc.yml.in"
+          namespace: "axsys"
+
+        - name: "axscheduler-svc"
+          file: "axscheduler-svc.yml.in"
+          namespace: "axsys"

--- a/platform/config/service/standard/applet.yml.in
+++ b/platform/config/service/standard/applet.yml.in
@@ -34,6 +34,8 @@ spec:
                 env:
                    - name: LOGMOUNT_PATH
                      value: /logs
+                   - name: ARGO_DATA_BUCKET_NAME
+                     value: "{ARGO_DATA_BUCKET_NAME}"
                 volumeMounts:
                    - name: handshake-socket
                      mountPath: /var/run

--- a/platform/config/service/standard/axartifactmanager-svc.yml.in
+++ b/platform/config/service/standard/axartifactmanager-svc.yml.in
@@ -38,6 +38,9 @@ spec:
             containers:
               - name: axartifactmanager
                 image: ${REGISTRY}/${NAMESPACE}/axartifactmanager:${VERSION}
+                env:
+                  - name: ARGO_DATA_BUCKET_NAME
+                    value: "${ARGO_DATA_BUCKET_NAME}"
                 ports:
                   - containerPort: 9892
                 resources:

--- a/platform/config/service/standard/axdb-svc-stateful.yml.in
+++ b/platform/config/service/standard/axdb-svc-stateful.yml.in
@@ -57,6 +57,8 @@ spec:
                 image: ${REGISTRY}/${NAMESPACE}/axdb:${VERSION}
                 imagePullPolicy: Always
                 env:
+                  - name: ARGO_DATA_BUCKET_NAME
+                    value: "${ARGO_DATA_BUCKET_NAME}"
                   - name: CASSANDRA_HOME
                     value: /ax/axdb/cassandra
                   - name: CASSANDRA_SERVICE

--- a/platform/config/service/standard/axdb-svc.yml.in
+++ b/platform/config/service/standard/axdb-svc.yml.in
@@ -77,6 +77,8 @@ spec:
                     value: "${NAMESPACE}"
                   - name: AX_VERSION
                     value: "${VERSION}"
+                  - name: ARGO_DATA_BUCKET_NAME
+                    value: "${ARGO_DATA_BUCKET_NAME}"
                 ports:
                   - containerPort: 8080
                     name: axdbport

--- a/platform/config/service/standard/axmon-svc.yml.in
+++ b/platform/config/service/standard/axmon-svc.yml.in
@@ -46,6 +46,8 @@ spec:
                 command: ["/ax/bin/axmon"]
                 #imagePullPolicy: Always
                 env:
+                  - name: ARGO_DATA_BUCKET_NAME
+                    value: "${ARGO_DATA_BUCKET_NAME}"
                   - name: ARGO_DIST_REGISTRY
                     value: "${REGISTRY}"
                   - name: ARGO_DIST_REGISTRY_SECRETS

--- a/platform/config/service/standard/axops.yml.in
+++ b/platform/config/service/standard/axops.yml.in
@@ -55,6 +55,8 @@ spec:
                     value: "${SANDBOX_ENABLED}"
                   - name: AX_MAX_PENDING_JOBS
                     value: "1000"
+                  - name: ARGO_DATA_BUCKET_NAME
+                    value: "${ARGO_DATA_BUCKET_NAME}"
                 resources:
                     requests:
                         cpu: 300m

--- a/platform/config/service/standard/axworkflowadc-svc.yml.in
+++ b/platform/config/service/standard/axworkflowadc-svc.yml.in
@@ -39,6 +39,9 @@ spec:
               - name: axworkflowadc
                 image: ${REGISTRY}/${NAMESPACE}/workflow:${VERSION}
                 command: ["/ax/src/ax/devops/workflow/adc", "--image-registry", "${REGISTRY}", "--image-namespace", "${NAMESPACE}", "--image-version", "${VERSION}"]
+                env:
+                  - name: ARGO_DATA_BUCKET_NAME
+                    value: "${ARGO_DATA_BUCKET_NAME}"
                 ports:
                   - containerPort: 8911
                 resources:

--- a/platform/config/service/standard/gateway-svc.yml.in
+++ b/platform/config/service/standard/gateway-svc.yml.in
@@ -51,6 +51,8 @@ spec:
               - name: gateway
                 image: ${REGISTRY}/${NAMESPACE}/gateway:${VERSION}
                 env:
+                  - name: ARGO_DATA_BUCKET_NAME
+                    value: "${ARGO_DATA_BUCKET_NAME}"
                   - name: AX_CLUSTER
                     value: "${AX_CLUSTER_NAME_ID}"
                   - name: AXOPS_EXT_DNS

--- a/platform/source/lib/ax/platform/ax_cluster_info.py
+++ b/platform/source/lib/ax/platform/ax_cluster_info.py
@@ -48,7 +48,8 @@ class AXClusterInfo(with_metaclass(Singleton, object)):
         self._cluster_name_id = cluster_name_id
 
         self._config = AXClusterConfig(cluster_name_id=cluster_name_id, aws_profile=aws_profile)
-        self._kube_config = kube_config if kube_config else self.default_config_path.format(cluster_name_id)
+        tmp_kube_config = kube_config if kube_config else self.default_config_path.format(cluster_name_id)
+        self._kube_config = os.getenv("ARGO_KUBE_CONFIG_PATH", tmp_kube_config)
         self._key_file = key_file if key_file else self.default_key_path.format(cluster_name_id)
         self._metadata_file = metadata if metadata else self.default_cluster_meta_path
 

--- a/platform/source/lib/ax/platform/cluster_config/__init__.py
+++ b/platform/source/lib/ax/platform/cluster_config/__init__.py
@@ -4,5 +4,5 @@
 # Copyright 2015-2017 Applatix, Inc. All rights reserved.
 #
 
-from .consts import AXClusterType, AXClusterSize, SpotInstanceOption
+from .consts import AXClusterType, AXClusterSize, SpotInstanceOption, ClusterProvider
 from .cluster_config import AXClusterConfig, AXClusterConfigMock

--- a/platform/source/lib/ax/platform/cluster_config/cluster_config.py
+++ b/platform/source/lib/ax/platform/cluster_config/cluster_config.py
@@ -200,6 +200,9 @@ class AXClusterConfig(with_metaclass(Singleton, object)):
     def get_kube_installer_config(self):
         return self._conf["cloud"]["kube_installer_config"]
 
+    def get_cluster_provider(self):
+        return self._conf["cloud"].get("cluster_provider", None)
+
     # Setters. Currently only a very limited items is mutable
     def set_ax_cluster_user(self, user):
         self._conf["cloud"]["configure"]["cluster_user"] = user
@@ -230,6 +233,12 @@ class AXClusterConfig(with_metaclass(Singleton, object)):
 
     def set_kube_installer_config(self, config):
         self._conf["cloud"]["kube_installer_config"] = config
+
+    def set_support_object_store_name(self, bucket_name):
+        self._conf["cloud"]["configure"]["support_object_store_name"] = bucket_name
+
+    def set_cluster_provider(self, cluster_provider):
+        self._conf["cloud"]["cluster_provider"] = cluster_provider
 
     def reload_config(self):
         """

--- a/platform/source/lib/ax/platform/cluster_config/consts.py
+++ b/platform/source/lib/ax/platform/cluster_config/consts.py
@@ -17,6 +17,7 @@ class AXClusterSize:
     CLUSTER_MEDIUM = "medium"
     CLUSTER_LARGE = "large"
     CLUSTER_XLARGE = "xlarge"
+    CLUSTER_USER_PROVIDED = "user_provided"
 
     # TODO (#36): mvc is currently broken so mark it as not valid
     VALID_CLUSTER_SIZES = [CLUSTER_SMALL, CLUSTER_MEDIUM, CLUSTER_LARGE, CLUSTER_XLARGE]
@@ -27,3 +28,8 @@ class SpotInstanceOption:
     PARTIAL_SPOT = "partial"
     ALL_SPOT = "all"
     VALID_SPOT_INSTANCE_OPTIONS = [NO_SPOT, PARTIAL_SPOT, ALL_SPOT]
+
+class ClusterProvider:
+    ARGO = "argo"
+    USER = "user"
+    VALID_CLUSTER_PROVIDERS = [ARGO, USER]

--- a/platform/source/lib/ax/platform/container_specs.py
+++ b/platform/source/lib/ax/platform/container_specs.py
@@ -65,6 +65,7 @@ class ArtifactsContainer(Container):
         self.add_env("AX_POD_NAMESPACE", value_from="metadata.namespace")
         self.add_env("AX_NODE_NAME", value_from="spec.nodeName")
         self.add_env("ARGO_LOG_BUCKET_NAME", os.getenv("ARGO_LOG_BUCKET_NAME", ""))
+        self.add_env("ARGO_DATA_BUCKET_NAME", os.getenv("ARGO_DATA_BUCKET_NAME", ""))
 
         annotation_vol = ContainerVolume("annotations", "/etc/axspec")
         annotation_vol.set_type("DOWNWARDAPI", "metadata.annotations")
@@ -103,7 +104,7 @@ class SidecarTask(WaitContainer):
         # Sidecar needs to manage logs so add the log path here
         logpath = ContainerVolume("containerlogs", "/logs")
         if Cloud().in_cloud_aws():
-            logpath.set_type("HOSTPATH", "/mnt/ephemeral/docker/containers")
+            logpath.set_type("HOSTPATH", "/var/lib/docker/containers")
         elif Cloud().in_cloud_gcp():
             logpath.set_type("HOSTPATH", "/var/lib/docker/containers")
         self.add_volume(logpath)

--- a/platform/source/lib/ax/platform/platform.py
+++ b/platform/source/lib/ax/platform/platform.py
@@ -29,7 +29,7 @@ from ax.platform.ax_asg import AXUserASGManager
 from ax.platform.ax_cluster_info import AXClusterInfo
 from ax.platform.ax_monitor import AXKubeMonitor
 from ax.platform.ax_monitor_helper import KubeObjStatusCode, KubeObjWaiter
-from ax.platform.cluster_config import AXClusterConfig, SpotInstanceOption
+from ax.platform.cluster_config import AXClusterConfig, SpotInstanceOption, ClusterProvider
 from ax.platform.cluster_version import AXVersion
 from ax.platform.component_config import SoftwareInfo
 from ax.platform.exceptions import AXPlatformException
@@ -148,6 +148,48 @@ class AXPlatform(object):
                     kube_namespace=namespace
                 )
 
+    def _generate_replacing_for_user_provisioned_cluster(self):
+        # Platform code are running in python 2.7, and therefore for trusted cidr list, the str() method
+        # will return something like [u'54.149.149.230/32', u'73.70.250.25/32', u'104.10.248.90/32'], and
+        # this 'u' prefix cannot be surpressed. With this prefix, our macro replacing would create invalid
+        # yaml files, and therefore we construct string manually here
+        trusted_cidr = self._cluster_config.get_trusted_cidr()
+        if isinstance(trusted_cidr, list):
+            trusted_cidr_str = "["
+            for cidr in trusted_cidr:
+                trusted_cidr_str += "\"{}\",".format(str(cidr))
+            trusted_cidr_str = trusted_cidr_str[:-1]
+            trusted_cidr_str += "]"
+        else:
+            trusted_cidr_str = "[{}]".format(trusted_cidr)
+
+        self._persist_node_resource_rsvp(0, 0)
+
+        with open("/kubernetes/cluster/version.txt", "r") as f:
+            cluster_install_version = f.read().strip()
+
+        return {
+            "REGISTRY": self._software_info.registry,
+            "REGISTRY_SECRETS": self._software_info.registry_secrets,
+            "NAMESPACE": self._software_info.image_namespace,
+            "VERSION": self._software_info.image_version,
+            "AX_CLUSTER_NAME_ID": self._cluster_name_id,
+            "AX_AWS_REGION": self._region,
+            "AX_AWS_ACCOUNT": self._account,
+            "AX_CUSTOMER_ID": AXCustomerId().get_customer_id(),
+            "TRUSTED_CIDR": trusted_cidr_str,
+            "NEW_KUBE_SALT_SHA1": os.getenv("NEW_KUBE_SALT_SHA1") or " ",
+            "NEW_KUBE_SERVER_SHA1": os.getenv("NEW_KUBE_SERVER_SHA1") or " ",
+            "AX_KUBE_VERSION": os.getenv("AX_KUBE_VERSION"),
+            "AX_CLUSTER_INSTALL_VERSION": cluster_install_version,
+            "SANDBOX_ENABLED": str(self._cluster_config.get_sandbox_flag()),
+            "ARGO_LOG_BUCKET_NAME": self._cluster_config.get_support_object_store_name(),
+            "AX_CLUSTER_META_URL_V1": self._bucket.get_object_url_from_key(key=self._cluster_config_path.cluster_metadata()),
+            "DNS_SERVER_IP": os.getenv("DNS_SERVER_IP", default_kube_up_env["DNS_SERVER_IP"]),
+            "ARGO_DATA_BUCKET_NAME": AXClusterConfigPath(self._cluster_name_id).bucket(),
+        }
+
+
     def _generate_replacing(self):
         # Platform code are running in python 2.7, and therefore for trusted cidr list, the str() method
         # will return something like [u'54.149.149.230/32', u'73.70.250.25/32', u'104.10.248.90/32'], and
@@ -260,7 +302,10 @@ class AXPlatform(object):
         # Generate kube-objects
         steps = self._config.steps
         self._load_kube_objects_from_steps(steps)
-        self._replacing = self._generate_replacing()
+        if self._cluster_config.get_cluster_provider() != ClusterProvider.USER:
+            self._replacing = self._generate_replacing()
+        else:
+            self._replacing = self._generate_replacing_for_user_provisioned_cluster()
 
         # TODO: remove component's dependencies to AXOPS_EXT_DNS env (#32)
         # At this moment, we MUST separate first step due to the above dependency
@@ -329,6 +374,9 @@ class AXPlatform(object):
 
         :param objects: AXPlatformObjectGroup
         """
+        if objects is None or len(objects.object_set) == 0:
+            return
+
         assert isinstance(objects, AXPlatformObjectGroup)
         if not self._should_create_group(
             policy=objects.policy,

--- a/platform/source/lib/ax/platform/rest.py
+++ b/platform/source/lib/ax/platform/rest.py
@@ -59,9 +59,6 @@ MINION_MANAGER_PORT = "6000"
 
 kubectl = KubernetesApiClient(use_proxy=True)
 cluster_name_id = os.getenv("AX_CLUSTER_NAME_ID", None)
-asg_manager = AXUserASGManager(os.getenv("AX_CLUSTER_NAME_ID"),
-                               AXClusterConfig().get_region())
-
 # Need a lock to serialize cluster config operation
 cfg_lock = RLock()
 
@@ -201,6 +198,9 @@ def put_spot_instance_config():
     else:
         raise ValueError("enabled must be string or boolean")
     payload = {'enabled': enabled_str}
+
+    asg_manager = AXUserASGManager(cluster_name_id,
+                                   AXClusterConfig().get_region())
 
     # Get "spot_instances_option" option
     (option,) = _get_optional_arguments('spot_instances_option')


### PR DESCRIPTION
Does the following:

1. Accepts the bucket and kubeconfig as input arguments.
2. Installs Argo platform on the user-provided cluster.

Limitations:

1. Only supports AWS.
2. Still needs nodes with the "ax.tier" labels.
3. Needs IAM role with s3, autoscaling, elasticloadbalancing and
certificate privileges.

Testing done:

1. Deployed Argo on user provided cluster (that was created with kops).
2. Workflows run correctly.
3. Artifacts and logs can be seen and downloaded.