### PR TITLE
Issue #17: take None as a valid cloud profile

### DIFF
--- a/common/python/ax/cluster_management/app/cluster_uninstaller.py
+++ b/common/python/ax/cluster_management/app/cluster_uninstaller.py
@@ -182,8 +182,6 @@ class ClusterUninstaller(ClusterOperationBase):
 
         if self._cfg.cloud_profile:
             env["AWS_DEFAULT_PROFILE"] = self._cfg.cloud_profile
-        else:
-            env["AWS_DEFAULT_PROFILE"] = AWS_DEFAULT_PROFILE
 
         logger.info("\n\n%sCalling kube-down ...%s\n", COLOR_GREEN, COLOR_NORM)
         AXKubeUpDown(cluster_name_id=self._name_id, env=env, aws_profile=self._cfg.cloud_profile).down()

--- a/common/python/ax/cluster_management/app/cluster_upgrader.py
+++ b/common/python/ax/cluster_management/app/cluster_upgrader.py
@@ -209,8 +209,6 @@ class ClusterUpgrader(ClusterOperationBase):
         
         if self._cfg.cloud_profile:
             env["ARGO_AWS_PROFILE"] = self._cfg.cloud_profile
-        else:
-            env["ARGO_AWS_PROFILE"] = AWS_DEFAULT_PROFILE
 
         logger.info("Upgrading Kubernetes with environments %s", pformat(env))
         env.update(os.environ)

--- a/common/python/ax/cluster_management/app/options/common.py
+++ b/common/python/ax/cluster_management/app/options/common.py
@@ -8,8 +8,12 @@ import argparse
 import os
 from future.utils import with_metaclass
 
-from ax.cloud.aws import AWS_DEFAULT_PROFILE
 from ax.platform.component_config import AXPlatformConfigDefaults, SoftwareInfo
+
+# We should set aws profile to None if user does not provide one
+# because in python None type is different from str, we convert None
+# to string first and then finally it to None
+AWS_NO_PROFILE = "None"
 
 
 def typed_raw_input_with_default(prompt, default, type_converter):
@@ -20,7 +24,7 @@ def typed_raw_input_with_default(prompt, default, type_converter):
 
 class ClusterOperationDefaults:
     CLOUD_PROVIDER = "aws"
-    CLOUD_PROFILE = AWS_DEFAULT_PROFILE
+    CLOUD_PROFILE = AWS_NO_PROFILE
     PLATFORM_SERVICE_MANIFEST_ROOT = AXPlatformConfigDefaults.DefaultManifestRoot
     PLATFORM_BOOTSTRAP_CONFIG_FILE = AXPlatformConfigDefaults.DefaultPlatformConfigFile
 
@@ -71,7 +75,7 @@ class ClusterManagementOperationConfigBase(with_metaclass(abc.ABCMeta, object)):
             if self.cloud_profile is None:
                 self.cloud_profile = typed_raw_input_with_default(
                     prompt="Please enter your cloud provider profile. If you don't provide one, we are going to use the default you configured on host.",
-                    default=AWS_DEFAULT_PROFILE,
+                    default=AWS_NO_PROFILE,
                     type_converter=str
                 )
 
@@ -81,6 +85,10 @@ class ClusterManagementOperationConfigBase(with_metaclass(abc.ABCMeta, object)):
             confirmation += "Cloud Profile:         {}\n".format(self.cloud_profile)
             confirmation += "\n\nPlease press ENTER to continue or press Ctrl-C to terminate:"
             raw_input(confirmation)
+
+        # TODO: revise this once we bring GCP into picture
+        if self.cloud_profile == AWS_NO_PROFILE:
+            self.cloud_profile = None
 
 
 def validate_software_info(software_info):

--- a/common/python/ax/cluster_management/app/options/install_options.py
+++ b/common/python/ax/cluster_management/app/options/install_options.py
@@ -11,11 +11,11 @@ import re
 from netaddr import IPAddress
 
 from ax.cloud import Cloud
-from ax.cloud.aws import EC2, AWS_DEFAULT_PROFILE
+from ax.cloud.aws import EC2
 from ax.platform.cluster_config import AXClusterSize, AXClusterType, SpotInstanceOption
 from ax.platform.component_config import SoftwareInfo
 from .common import add_common_flags, add_software_info_flags, validate_software_info, \
-    ClusterManagementOperationConfigBase, typed_raw_input_with_default
+    ClusterManagementOperationConfigBase, typed_raw_input_with_default, AWS_NO_PROFILE
 
 
 logger = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ class ClusterInstallDefaults:
     CLUSTER_SIZE = "small"
     CLUSTER_TYPE = "standard"
     CLOUD_REGION = "us-west-2"
-    CLOUD_PROFILE = AWS_DEFAULT_PROFILE
+    CLOUD_PROFILE = AWS_NO_PROFILE
     CLOUD_PLACEMENT = "us-west-2a"
     VPC_CIDR_BASE = "172.20"
     SUBNET_MASK_SIZE = 22
@@ -121,7 +121,7 @@ class ClusterInstallConfig(ClusterManagementOperationConfigBase):
             if self.cloud_profile is None:
                 self.cloud_profile = typed_raw_input_with_default(
                     prompt="Please enter your cloud provider profile. If you don't provide one, we are going to use the default you configured on host.",
-                    default=AWS_DEFAULT_PROFILE,
+                    default=AWS_NO_PROFILE,
                     type_converter=str
                 )
 
@@ -192,8 +192,12 @@ class ClusterInstallConfig(ClusterManagementOperationConfigBase):
             confirmation += "Trusted CIDRs:         {}\n".format(self.trusted_cidrs)
             confirmation += "Spot Instance Option:  {}\n".format(self.spot_instances_option)
             confirmation += "User On-Demand Nodes:  {}\n".format(self.user_on_demand_nodes)
-            confirmation += "\n\nPlease press ENTER to continue or press Ctrl-C to terminate the program if these configurations are not what you want:\n"
+            confirmation += "\n\nPlease press ENTER to continue or press Ctrl-C to terminate the program if these configurations are not what you want:"
             raw_input(confirmation)
+
+        # TODO: revise this once we bring GCP into picture
+        if self.cloud_profile == AWS_NO_PROFILE:
+            self.cloud_profile = None
 
 
 

--- a/platform/cluster/aws/util.sh
+++ b/platform/cluster/aws/util.sh
@@ -747,11 +747,19 @@ function delete-tag {
 
 # Creates the IAM roles (if they do not already exist)
 function create-iam-profiles {
-    /ax/bin/ax-upgrade-misc --ensure-aws-iam --cluster-name-id $CLUSTER_ID --aws-profile $AWS_DEFAULT_PROFILE --aws-region ${AWS_REGION}
+    local aws_profile_arg=""
+    if [[ ! -z ${AWS_DEFAULT_PROFILE+x} ]]; then
+        aws_profile_arg="--aws-profile ${AWS_DEFAULT_PROFILE}"
+    fi
+    /ax/bin/ax-upgrade-misc --ensure-aws-iam --cluster-name-id $CLUSTER_ID --aws-region ${AWS_REGION} ${aws_profile_arg}
 }
 
 function delete-iam-profiles {
-    /ax/bin/ax-upgrade-misc --delete-aws-iam --cluster-name-id $CLUSTER_ID --aws-profile $AWS_DEFAULT_PROFILE --aws-region ${AWS_REGION}
+    local aws_profile_arg=""
+    if [[ ! -z ${AWS_DEFAULT_PROFILE+x} ]]; then
+        aws_profile_arg="--aws-profile ${AWS_DEFAULT_PROFILE}"
+    fi
+    /ax/bin/ax-upgrade-misc --delete-aws-iam --cluster-name-id $CLUSTER_ID --aws-region ${AWS_REGION} ${aws_profile_arg}
 }
 
 # Wait for instance to be in specified state

--- a/platform/source/lib/ax/platform/kube_env_config.py
+++ b/platform/source/lib/ax/platform/kube_env_config.py
@@ -201,8 +201,6 @@ def prepare_kube_install_config(name_id, aws_profile, cluster_info, cluster_conf
 
     if aws_profile:
         env["AWS_DEFAULT_PROFILE"] = aws_profile
-    else:
-        env["AWS_DEFAULT_PROFILE"] = AWS_DEFAULT_PROFILE
 
     optional_env = {
         # Start off directly with all spot instances only for dev clusters.

--- a/platform/source/tools/ax-upgrade-misc.py
+++ b/platform/source/tools/ax-upgrade-misc.py
@@ -47,7 +47,6 @@ if __name__ == "__main__":
     if args.ensure_aws_iam or args.delete_aws_iam:
         from ax.platform.cluster_instance_profile import AXClusterInstanceProfile
         assert args.cluster_name_id, "Missing cluster name id to ensure aws iam"
-        assert args.aws_region, "Missing AWS region to ensure aws iam"
         if args.ensure_aws_iam:
             AXClusterInstanceProfile(args.cluster_name_id, args.aws_region, aws_profile=args.aws_profile).update()
         elif args.delete_aws_iam:
@@ -58,10 +57,8 @@ if __name__ == "__main__":
         name_id = args.cluster_name_id
         aws_profile = args.aws_profile
         aws_region = args.aws_region
-        assert name_id and aws_profile and aws_region, \
-            "Missing parameters to ensure s3. name_id: {}, aws_profile: {}, aws_region: {}".format(name_id,
-                                                                                                   aws_profile,
-                                                                                                   aws_region)
+        assert name_id and aws_region, \
+            "Missing parameters to ensure s3. name_id: {}, aws_region: {}".format(name_id, aws_region)
 
         AXClusterBuckets(name_id, aws_profile, aws_region).update()
 

--- a/platform/source/tools/master_manager.py
+++ b/platform/source/tools/master_manager.py
@@ -17,7 +17,7 @@ def run():
     parser.add_argument("cluster_name_id", help="Name of the cluster")
     parser.add_argument("command", help="Command, server or upgrade")
     parser.add_argument("--region", help="Region name")
-    parser.add_argument("--profile", help="Profile name")
+    parser.add_argument("--profile", default=None, help="Profile name")
     parser.add_argument('--version', action='version', version="%(prog)s {}".format(__version__))
     usr_args = parser.parse_args()
 


### PR DESCRIPTION
Fixes #17 

We need to set profile to None (NoneType) if user does not provide one, in this case, we fully leaves boto3 client to figure out credentials.

Tested all cluster operations without specifying cloud profile