### PR TITLE
Issue #232: allow cluster management operations in portal for registered clusters

### DIFF
--- a/common/python/ax/cluster_management/app/cluster_pauser.py
+++ b/common/python/ax/cluster_management/app/cluster_pauser.py
@@ -26,7 +26,7 @@ from ax.util.const import COLOR_GREEN, COLOR_NORM
 from ax.util.network import get_public_ip
 
 from .common import ClusterOperationBase, check_cluster_staging, ensure_manifest_temp_dir,\
-    TEMP_PLATFORM_MANIFEST_ROOT, TEMP_PLATFORM_CONFIG_PATH
+    TEMP_PLATFORM_MANIFEST_ROOT, TEMP_PLATFORM_CONFIG_PATH, is_portal_env
 from .options import ClusterPauseConfig
 
 logger = logging.getLogger(__name__)
@@ -66,7 +66,7 @@ class ClusterPauser(ClusterOperationBase):
         self._cidr = str(get_public_ip()) + "/32"
 
     def pre_run(self):
-        if self._cluster_info.is_cluster_supported_by_portal():
+        if not is_portal_env() and self._cluster_info.is_cluster_supported_by_portal():
             raise RuntimeError("Cluster is currently supported by portal. Please login to portal to perform cluster management operations.")
         if self._csm.is_paused():
             logger.info("Cluster is already paused.")

--- a/common/python/ax/cluster_management/app/cluster_restarter.py
+++ b/common/python/ax/cluster_management/app/cluster_restarter.py
@@ -27,7 +27,7 @@ from ax.util.const import COLOR_GREEN, COLOR_NORM
 from ax.util.network import get_public_ip
 
 from .common import ClusterOperationBase, check_cluster_staging, ensure_manifest_temp_dir,\
-    TEMP_PLATFORM_CONFIG_PATH, TEMP_PLATFORM_MANIFEST_ROOT
+    TEMP_PLATFORM_CONFIG_PATH, TEMP_PLATFORM_MANIFEST_ROOT, is_portal_env
 from .options import ClusterRestartConfig
 
 logger = logging.getLogger(__name__)
@@ -79,7 +79,7 @@ class ClusterResumer(ClusterOperationBase):
         )
 
     def pre_run(self):
-        if self._cluster_info.is_cluster_supported_by_portal():
+        if not is_portal_env() and self._cluster_info.is_cluster_supported_by_portal():
             raise RuntimeError("Cluster is currently supported by portal. Please login to portal to perform cluster management operations.")
 
         if self._csm.is_running():

--- a/common/python/ax/cluster_management/app/cluster_uninstaller.py
+++ b/common/python/ax/cluster_management/app/cluster_uninstaller.py
@@ -15,7 +15,6 @@ import subprocess
 import yaml
 
 from ax.cloud import Cloud
-from ax.cloud.aws import AWS_DEFAULT_PROFILE
 from ax.cloud.aws.ebs import delete_tagged_ebs
 from ax.cloud.aws.elb import ManagedElb
 from ax.cloud.aws.server_cert import delete_server_certificate
@@ -28,7 +27,7 @@ from ax.platform.consts import COMMON_CLOUD_RESOURCE_TAG_KEY
 from ax.util.const import COLOR_GREEN, COLOR_NORM, COLOR_YELLOW
 from ax.util.network import get_public_ip
 
-from .common import ClusterOperationBase, check_cluster_staging
+from .common import ClusterOperationBase, check_cluster_staging, is_portal_env
 from .options import ClusterUninstallConfig
 
 logger = logging.getLogger(__name__)
@@ -61,7 +60,7 @@ class ClusterUninstaller(ClusterOperationBase):
         self._cidr = str(get_public_ip()) + "/32"
 
     def pre_run(self):
-        if self._cluster_info.is_cluster_supported_by_portal():
+        if not is_portal_env() and self._cluster_info.is_cluster_supported_by_portal():
             raise RuntimeError("Cluster is currently supported by portal. Please login to portal to perform cluster management operations.")
         # Abort operation if cluster is not successfully installed
         if not check_cluster_staging(cluster_info_obj=self._cluster_info, stage="stage2") and not self._cfg.force_uninstall:

--- a/common/python/ax/cluster_management/app/cluster_upgrader.py
+++ b/common/python/ax/cluster_management/app/cluster_upgrader.py
@@ -17,7 +17,6 @@ import yaml
 from pprint import pformat
 
 from ax.cloud import Cloud
-from ax.cloud.aws import AWS_DEFAULT_PROFILE
 from ax.meta import AXCustomerId
 from ax.platform.ax_cluster_info import AXClusterInfo
 from ax.platform.bootstrap import AXBootstrap
@@ -28,7 +27,7 @@ from ax.util.const import COLOR_GREEN, COLOR_YELLOW, COLOR_NORM
 from ax.util.network import get_public_ip
 
 from .common import ClusterOperationBase, check_cluster_staging, ensure_manifest_temp_dir,\
-    TEMP_PLATFORM_MANIFEST_ROOT, TEMP_PLATFORM_CONFIG_PATH
+    TEMP_PLATFORM_MANIFEST_ROOT, TEMP_PLATFORM_CONFIG_PATH, is_portal_env
 from .options import ClusterUpgradeConfig
 
 logger = logging.getLogger(__name__)
@@ -70,7 +69,7 @@ class ClusterUpgrader(ClusterOperationBase):
         self._upgrade_service_needed = True
 
     def pre_run(self):
-        if self._cluster_info.is_cluster_supported_by_portal():
+        if not is_portal_env() and self._cluster_info.is_cluster_supported_by_portal():
             raise RuntimeError("Cluster is currently supported by portal. Please login to portal to perform cluster management operations.")
 
         if not check_cluster_staging(cluster_info_obj=self._cluster_info, stage="stage2"):

--- a/common/python/ax/cluster_management/app/common.py
+++ b/common/python/ax/cluster_management/app/common.py
@@ -22,6 +22,10 @@ TEMP_PLATFORM_MANIFEST_ROOT = "/tmp/platform/manifests/"
 TEMP_PLATFORM_CONFIG_PATH = "/tmp/platform/platform-bootstrap.cfg"
 
 
+def is_portal_env():
+    return bool(os.getenv("ARGO_PORTAL_HOST"))
+
+
 def ensure_manifest_temp_dir():
     if not os.path.exists(TEMP_PLATFORM_MANIFEST_ROOT):
         os.makedirs(TEMP_PLATFORM_MANIFEST_ROOT)


### PR DESCRIPTION
Fixes #232 
If the cluster is registered to portal, we should abort cluster management operations if executed from local CLI. We should allow if its executed in portal

Adding an env ARGO_PORTAL_HOST, which is portal dns name, this might be useful in the future