### PR TITLE
#246:  Use Kubernetes secrets as encrypted secrets

### DIFF
--- a/.argo/test-yamls/test-secrets.yaml
+++ b/.argo/test-yamls/test-secrets.yaml
@@ -1,0 +1,45 @@
+---
+type: workflow
+version: 1
+name: test-secret-management-workflow
+description: This is the workflow to test whether secret encrytion works
+inputs:
+  parameters:
+    COMMIT:
+      default: "%%session.commit%%"
+    REPO:
+      default: "%%session.repo%%"
+    MYSECRET:
+      default: "%%secrets.admin@internal.testme.mysecret%%"
+#    MYENV:
+#      default: "%%secrets.admin@internal.testme.myenv%%"
+#    MYENV2:
+#      default: "%%secrets.admin@internal.testme.myenv2%%"
+steps:
+  - CHECKOUT:
+      template: argo-checkout
+  - SECRET-MANAGEMENT:
+      template: test-secret-management
+
+---
+type: container
+version: 1
+name: test-secret-management
+description: Test whether secret in ENV works as expected
+image: argobase/alpine:3.5
+command: ["sh", "-c"]
+args: ["echo %%inputs.parameters.REPO%% && echo %%inputs.parameters.MYSECRET%% && echo $TESTENV && echo $TESTENV2"]
+resources:
+  mem_mib: 400
+  cpu_cores: 0.1
+#ENV:
+#  - name: TESTENV
+#    value: "%%inputs.parameters.MYENV%%"
+#  - name: TESTENV2
+#    value: "%%inputs.parameters.MYENV2%%"
+inputs:
+  parameters:
+    REPO:
+    MYSECRET:
+#    MYENV:
+#    MYENV2:

--- a/devops/src/ax/devops/axsys/axsys_client.py
+++ b/devops/src/ax/devops/axsys/axsys_client.py
@@ -569,3 +569,7 @@ class AxsysClient(object):
         """
         logger.info('Delete ingress policy for endpoint: %s', dnsname)
         return self.axmon_client.delete(INGRESS_METHOD + '/' + dnsname, value_only=True)
+
+    def get_secret(self, namespace, name):
+        logger.info('Get Kubernetes secret for namespace %s and name %s', namespace, name)
+        return self.axmon_client.get('/secret/{}/{}'.format(namespace, name), value_only=True)

--- a/platform/source/lib/ax/platform/pod.py
+++ b/platform/source/lib/ax/platform/pod.py
@@ -15,7 +15,7 @@ from retrying import retry
 
 from ax.cloud import Cloud
 from ax.kubernetes import swagger_client
-from ax.kubernetes.client import KubernetesApiClient, parse_kubernetes_exception
+from ax.kubernetes.client import KubernetesApiClient, parse_kubernetes_exception, retry_unless
 from ax.kubernetes.kube_object import KubeObject
 from ax.meta import AXClusterId, AXClusterDataPath
 from ax.platform.exceptions import AXPlatformException
@@ -187,7 +187,7 @@ class Pod(KubeObject):
                                    jobname, self.name, count)
                     return False
                 try:
-                    status = self.client.api.read_namespaced_pod_status(self.namespace, self.name).status
+                    status = self._get_status_obj().status
                     assert isinstance(status, swagger_client.V1PodStatus)
                     status_dict = swagger_client.ApiClient().sanitize_for_serialization(status)
                     break
@@ -288,6 +288,7 @@ class Pod(KubeObject):
 
         raise AXPlatformException("Pod for a task needs to have a non-wait container")
 
+    @retry_unless(status_code=[404, 409, 422])
     def _get_status_obj(self):
         status = self.client.api.read_namespaced_pod_status(self.namespace, self.name)
         assert isinstance(status, swagger_client.V1Pod), "Status object should be of type V1Pod"

--- a/platform/source/lib/ax/platform/resources.py
+++ b/platform/source/lib/ax/platform/resources.py
@@ -130,6 +130,10 @@ class AXResources(object):
             "resource": val
         }
 
+    def insert_all(self, objs):
+        for obj in objs:
+            self.insert(obj)
+
     def remove(self, name):
         res = self._resources.pop(name)
 
@@ -140,6 +144,12 @@ class AXResources(object):
         for _, val in self._resources.iteritems():
             yield val["resource"]
         return
+
+    def exists(self, obj):
+        name = obj.get_resource_name()
+        restype = obj.get_resource_type()
+        key = "{}/{}".format(restype, name)
+        return self._resources.get(key, None) is not None
 
     def finalize(self, obj):
         """

--- a/platform/source/lib/ax/platform/secrets.py
+++ b/platform/source/lib/ax/platform/secrets.py
@@ -6,11 +6,15 @@
 """
 This module manages kubernetes secrets
 """
+import base64
+import json
 import logging
 
 from retrying import retry
-from future.utils import with_metaclass
+from future.utils import with_metaclass, iteritems
 
+from ax.platform.resources import AXResource
+from ax.util.hash import generate_hash
 from ax.util.singleton import Singleton
 from ax.kubernetes import swagger_client
 from ax.kubernetes.client import KubernetesApiClient, parse_kubernetes_exception, retry_unless
@@ -24,6 +28,71 @@ def reformat_name(name):
     https://kubernetes.io/docs/user-guide/identifiers/#names
     """
     return name.replace(":", "-")
+
+
+class SecretResource(AXResource):
+
+    @staticmethod
+    def create_object_from_info(info):
+        cfg_ns = info["config_namespace"]
+        cfg_name = info["config_name"]
+        workflow_step = info["step_name"]
+        namespace_step = info["step_namespace"]
+        return SecretResource(cfg_ns, cfg_name, workflow_step, namespace_step)
+
+    def __init__(self, cfg_ns, cfg_name, workflow_step, namespace_step):
+        self.namespace_step = namespace_step
+        self._orig_secret_name = ConfigToSecret(cfg_ns, cfg_name).gen_name()
+        self._step_secret_name = generate_hash("config-{}-{}".format(workflow_step, self._orig_secret_name))
+        self._manager = SecretsManager()
+        self.ax_meta = {
+            "config_namespace": cfg_ns,
+            "config_name": cfg_name,
+            "step_name": workflow_step,
+            "step_namespace": namespace_step
+        }
+
+    def create(self):
+        self._manager.copy_generic_to(self._orig_secret_name, self._step_secret_name, to_namespace=self.namespace_step)
+
+    def delete(self):
+        self._manager.delete_generic(self._step_secret_name, namespace=self.namespace_step)
+
+    def status(self):
+        return {}
+
+    def get_resource_name(self):
+        return self._step_secret_name
+
+    def get_resource_info(self):
+        return self.ax_meta
+
+    def __str__(self):
+        return "ConfigSecret {}".format(json.dumps(self.ax_meta))
+
+
+class ConfigToSecret(object):
+
+    def __init__(self, cfg_ns, cfg_name):
+        self.namespace = cfg_ns
+        self.name = cfg_name
+        self._manager = SecretsManager()
+        self._secret_name = self.gen_name()
+
+    def create(self, data, metadata=None):
+        meta = metadata or {}
+        meta["config-name"] = self.name
+        meta["config-namespace"] = self.namespace
+        self._manager.create_generic(self._secret_name, data, metadata=meta)
+
+    def delete(self):
+        self._manager.delete_generic(self._secret_name)
+
+    def get(self):
+        return self._manager.get_generic(self._secret_name)
+
+    def gen_name(self):
+        return generate_hash("config-{}-{}".format(self.namespace, self.name))
 
 
 class SecretsManager(with_metaclass(Singleton, object)):
@@ -103,6 +172,75 @@ class SecretsManager(with_metaclass(Singleton, object)):
 
         self._create_in_provider(to_ns, new_secret)
 
+    #
+    # CRUD operations for generic secrets
+    #
+    def create_generic(self, name, data, metadata=None, namespace="axsys"):
+        """
+        Create/update a generic kubernetes secret from configuration
+        :param name: name of secret
+        :param data: key, value pairs
+        :param metadata: key, value pairs of metadata to store with secret
+                         metadata is not loaded with secret into the container
+        :param namespace: The namespace to create secret in
+        NOTE: update only if secret already exists in the namespace.
+        """
+        logger.debug("Create secret {}/{}".format(name, namespace))
+        obj = swagger_client.V1Secret()
+        obj.metadata = swagger_client.V1ObjectMeta()
+        obj.metadata.name = name
+        obj.metadata.annotations = {
+            "user_metadata": json.dumps(metadata)
+        }
+        obj.type = "Opaque"
+        enc_data = {}
+        for k,v in iteritems(data):
+            enc_data[k] = base64.b64encode(v)
+        obj.data = enc_data
+        self._create_in_provider(namespace, obj)
+        logger.debug("Create secret {}/{} complete".format(name, namespace))
+
+    def delete_generic(self, name, namespace="axsys"):
+        """
+        Delete the secret
+        :param name: secret name
+        :param namespace: namespace of secret
+        """
+        logger.debug("Delete secret {}/{}".format(name, namespace))
+        self._delete_in_provider(namespace, name)
+        logger.debug("Delete secret {}/{} complete".format(name, namespace))
+
+    def copy_generic_to(self, name, new_name, from_namespace="axsys", to_namespace="axuser"):
+        """
+        This create a copy of the secret with a new name to a new namespace
+        :param secret: secret to copy
+        :param new_secret: new secret to create
+        :param from_namespace: the namespace of the original secret
+        :param to_namespace: the namespace to copy to
+        """
+        logger.debug("copy secret {}/{} => {}/{}".format(name, from_namespace, new_name, to_namespace))
+        (data, meta) = self.get_generic(name, from_namespace)
+        self.create_generic(new_name, data, metadata=meta, namespace=to_namespace)
+        logger.debug("copy secret {}/{} => {}/{} complete".format(name, from_namespace, new_name, to_namespace))
+
+    def get_generic(self, name, namespace="axsys"):
+        """
+        Return the metadata and data for the secret
+        :param secret: name of secret
+        :param namespace: namespace of secret
+        :return: tuple of data and metadata
+        """
+        logger.debug("Get secret {}/{}".format(name, namespace))
+        obj = self._get_from_provider(namespace, name)
+        dec_data = {}
+        for k,v in iteritems(obj.data):
+            dec_data[k] = base64.b64decode(v)
+        metadata = obj.metadata.annotations.get("user_metadata", None)
+        if metadata:
+            metadata = json.loads(metadata)
+        logger.debug("Get secret {}/{} complete".format(name, namespace))
+        return dec_data, metadata
+
     @retry_unless(swallow_code=[409], status_code=[422])
     def _create_in_provider(self, namespace, secret):
         try:
@@ -114,3 +252,13 @@ class SecretsManager(with_metaclass(Singleton, object)):
                 self.client.api.replace_namespaced_secret(secret, namespace, secret.metadata.name)
             else:
                 raise e
+
+    @retry_unless(swallow_code=[404], status_code=[409, 422])
+    def _delete_in_provider(self, namespace, secret):
+        options = swagger_client.V1DeleteOptions()
+        options.grace_period_seconds = 0
+        self.client.api.delete_namespaced_secret(options, namespace, secret)
+
+    @retry_unless(status_code=[404, 409, 422])
+    def _get_from_provider(self, namespace, secret):
+        return self.client.api.read_namespaced_secret(namespace, secret)

--- a/saas/axops/src/applatix.io/axops/configuration/schema.go
+++ b/saas/axops/src/applatix.io/axops/configuration/schema.go
@@ -4,8 +4,9 @@ import "applatix.io/axdb"
 
 const (
 	ConfigurationTableName   = "configuration"
-	ConfigurationUserName    = "user"
+	ConfigurationUserName    = "user" // will use this as namespace
 	ConfigurationName        = "name"
+	ConfigurationIsSecrets   = "is_secret"
 	ConfigurationDescription = "description"
 	ConfigurationValue       = "value"
 	ConfigurationDateCreated = "ctime"
@@ -19,6 +20,7 @@ var ConfigurationSchema = axdb.Table{
 	Columns: map[string]axdb.Column{
 		ConfigurationUserName:    axdb.Column{Type: axdb.ColumnTypeString, Index: axdb.ColumnIndexPartition},
 		ConfigurationName:        axdb.Column{Type: axdb.ColumnTypeString, Index: axdb.ColumnIndexClustering},
+		ConfigurationIsSecrets:   axdb.Column{Type: axdb.ColumnTypeBoolean, Index: axdb.ColumnIndexNone},
 		ConfigurationDescription: axdb.Column{Type: axdb.ColumnTypeString, Index: axdb.ColumnIndexNone},
 		ConfigurationValue:       axdb.Column{Type: axdb.ColumnTypeMap, Index: axdb.ColumnIndexNone},
 		ConfigurationDateCreated: axdb.Column{Type: axdb.ColumnTypeInteger, Index: axdb.ColumnIndexNone},

--- a/saas/axops/src/applatix.io/axops/router.go
+++ b/saas/axops/src/applatix.io/axops/router.go
@@ -469,8 +469,8 @@ func GetRounter(internal bool) *gin.Engine {
 			configuration.GET("", ListConfigurations())
 			configuration.GET("/:user", GetConfigurationsByUser())
 			configuration.GET("/:user/:name", GetConfigurationsByUserName())
-			configuration.POST("/:user/:name", CreateConfiguration())
-			configuration.PUT("/:user/:name", ModifyConfiguration())
+			configuration.POST("", CreateConfiguration())
+			configuration.PUT("", ModifyConfiguration())
 			configuration.DELETE("/:user/:name", DeleteConfiguration())
 		}
 


### PR DESCRIPTION
1. Change Axops configuration rest apis to allow configure as Kubernetes secret
2. Payload: additional field: "is_secret". Example:
`{
  "description": "testtest",
  "is_secret": true,
  "name": "testme",
  "user": "admin@internal",
  "value": {
    "mysecret": "work hard",
  }
}`
3. In outer_container_executor.py, substitute all %%secrets%% in the command by calling axmon secret api.