### PR TITLE
Create PlatformOnlyInstallConfig and related objects.

### DIFF
--- a/common/python/ax/cluster_management/app/options/__init__.py
+++ b/common/python/ax/cluster_management/app/options/__init__.py
@@ -3,7 +3,7 @@
 # Copyright 2015-2017 Applatix, Inc. All rights reserved.
 #
 
-from .install_options import add_install_flags, add_platform_only_flags, ClusterInstallConfig, ClusterInstallDefaults
+from .install_options import add_install_flags, add_platform_only_flags, PlatformOnlyInstallConfig, ClusterInstallConfig, ClusterInstallDefaults
 from .misc_operation_config import add_misc_flags, ClusterMiscOperationConfig
 from .pause_options import add_pause_flags, ClusterPauseConfig
 from .restart_options import add_restart_flags, ClusterRestartConfig

--- a/common/python/ax/cluster_management/app/options/common.py
+++ b/common/python/ax/cluster_management/app/options/common.py
@@ -118,7 +118,7 @@ def add_common_flags(parser):
     assert isinstance(parser, argparse.ArgumentParser)
     parser.add_argument("--cluster-name", default=None, help="Target Argo cluster name")
     parser.add_argument("--cluster-id", default=None, help="A pre-generated cluster id")
-    parser.add_argument("--cloud-provider", default=ClusterOperationDefaults.CLOUD_PROVIDER, help="Cloud type: aws or gcp")
+    parser.add_argument("--cloud-provider", default=ClusterOperationDefaults.CLOUD_PROVIDER, help="Cloud type: aws or minikube")
     parser.add_argument("--cloud-profile", default=None, help="Cloud profile name (e.g. aws profile)")
     parser.add_argument("--dry-run", default=False, action="store_true", help="Dry run operation")
     parser.add_argument("--silent", "-s", default=False, action="store_true", help="Perform cluster management operation using silent mode (automatically fill in defaults)")

--- a/common/python/ax/cluster_management/app/options/install_options.py
+++ b/common/python/ax/cluster_management/app/options/install_options.py
@@ -15,7 +15,7 @@ from ax.cloud.aws import EC2
 from ax.platform.cluster_config import AXClusterSize, AXClusterType, SpotInstanceOption
 from ax.platform.component_config import SoftwareInfo
 from .common import add_common_flags, add_software_info_flags, validate_software_info, \
-    ClusterManagementOperationConfigBase, typed_raw_input_with_default, AWS_NO_PROFILE
+    ClusterOperationDefaults, ClusterManagementOperationConfigBase, typed_raw_input_with_default, AWS_NO_PROFILE
 
 
 logger = logging.getLogger(__name__)
@@ -334,6 +334,25 @@ class ClusterInstallConfig(ClusterManagementOperationConfigBase):
             ))
 
         return all_errs
+
+
+class PlatformOnlyInstallConfig(ClusterManagementOperationConfigBase):
+    def __init__(self, cfg):
+        cfg.cluster_size = AXClusterSize.CLUSTER_USER_PROVIDED
+        super(PlatformOnlyInstallConfig, self).__init__(cfg)
+
+        self.cluster_size = cfg.cluster_size
+        if cfg.cloud_provider == "minikube":
+            self.service_manifest_root = "/ax/config/service/basic"
+            self.platform_bootstrap_config = "/ax/config/service/config/basic-platform-bootstrap.cfg"
+        else:
+            self.service_manifest_root = cfg.service_manifest_root
+            self.platform_bootstrap_config = cfg.platform_bootstrap_config
+
+        return
+
+    def validate(self):
+        return None
 
 
 def add_install_flags(parser):

--- a/common/python/ax/cluster_management/argo_cluster_manager.py
+++ b/common/python/ax/cluster_management/argo_cluster_manager.py
@@ -15,7 +15,7 @@ from ax.util.const import COLOR_NORM, COLOR_RED
 from .app import ClusterInstaller, ClusterPauser, ClusterResumer, ClusterUninstaller, ClusterUpgrader, \
     CommonClusterOperations
 from .app.options import add_install_flags, add_platform_only_flags, ClusterInstallConfig, add_pause_flags, ClusterPauseConfig, \
-    add_restart_flags, ClusterRestartConfig, add_uninstall_flags, ClusterUninstallConfig, \
+    add_restart_flags, PlatformOnlyInstallConfig, ClusterRestartConfig, add_uninstall_flags, ClusterUninstallConfig, \
     add_upgrade_flags, ClusterUpgradeConfig, add_misc_flags, ClusterMiscOperationConfig
 
 logger = logging.getLogger(__name__)
@@ -131,8 +131,9 @@ class ArgoClusterManager(object):
         ClusterUpgrader(upgrade_config).start()
 
     def install_platform_only(self, args):
-        # TODO(shri): Add more meat!
-        logger.info("Installing platform only using args: %s", args)
+        logger.info("Installing platform only ...")
+        platform_install_config = PlatformOnlyInstallConfig(cfg=args)
+        # TODO(shri): Do more with platform_install_config!
         return
 
     @staticmethod

--- a/platform/config/service/basic/access-key-secret.yml.in
+++ b/platform/config/service/basic/access-key-secret.yml.in
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argo-access-key
+  labels:
+    app: argoaccess
+type: Opaque
+data:
+  argo-access-key: ${ARGO_S3_ACCESS_KEY_ID}

--- a/platform/config/service/basic/axartifactmanager-svc.yml.in
+++ b/platform/config/service/basic/axartifactmanager-svc.yml.in
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: axartifactmanager
+    labels:
+        app: axartifactmanager
+        tier: devops
+        role: axcritical
+spec:
+    selector:
+        app: axartifactmanager-deployment
+    ports:
+      - port: 9892
+        targetPort: 9892
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+    name: axartifactmanager-deployment
+spec:
+    replicas: 1
+    template:
+        metadata:
+            labels:
+                app: axartifactmanager-deployment
+                tier: devops
+                role: axcritical
+            annotations:
+                pod.alpha.kubernetes.io/init-containers: '[
+                    {
+                        "name": "pre",
+                        "image": "${REGISTRY}/${NAMESPACE}/kube-init:${VERSION}",
+                        "imagePullPolicy": "IfNotPresent",
+                        "command": ["timeout", "1200", "sh", "-c", "wait_http http://axops-internal:8085/v1/ping"]
+                    }
+                ]'
+        spec:
+            containers:
+              - name: axartifactmanager
+                image: ${REGISTRY}/${NAMESPACE}/axartifactmanager:${VERSION}
+                env:
+                  - name: ARGO_DATA_BUCKET_NAME
+                    value: "${ARGO_DATA_BUCKET_NAME}"
+                ports:
+                  - containerPort: 9892
+                resources:
+                    requests:
+                        cpu: 50m
+                        memory: 50Mi
+                    limits:
+                        cpu: 50m
+                        memory: 100Mi
+            imagePullSecrets:
+              - name: applatix-registry

--- a/platform/config/service/basic/axdb-svc.yml.in
+++ b/platform/config/service/basic/axdb-svc.yml.in
@@ -1,0 +1,120 @@
+apiVersion: v1
+kind: Service
+metadata:
+    labels:
+        app: axdb
+        tier: platform
+        role: critical
+    name: axdb
+spec:
+    ports:
+      - port: 8083
+        targetPort: 8080
+    selector:
+        app: axdbstatefulset
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+    name: axdb
+spec:
+    serviceName: "axdb"
+    replicas: 1
+    template:
+        metadata:
+            labels:
+                app: axdbstatefulset
+                tier: platform
+                role: critical
+            annotations:
+                pod.alpha.kubernetes.io/initialized: "true"
+                pod.alpha.kubernetes.io/init-containers: '[
+                        {
+                            "name": "pre",
+                            "image": "${REGISTRY}/${NAMESPACE}/kube-init:${VERSION}",
+                            "command": ["sh", "-c", "wait_volume; wait_tcp kafka-zk:9092"],
+                            "env": [
+                                {
+                                    "name": "AX_SIGNATURE",
+                                    "value": "${AX_CLUSTER_NAME_ID}-axdb-svc"
+                                },
+                                {
+                                    "name": "USE_AXDB",
+                                    "value": "use_axdb"
+                                }
+                            ],
+                            "volumeMounts": [
+                                {
+                                    "name": "pdata",
+                                    "mountPath": "/axsigdata"
+                                }
+                            ]
+                        }
+                    ]'
+        spec:
+            containers:
+              - name: axdb
+                image: ${REGISTRY}/${NAMESPACE}/axdb:${VERSION}
+                imagePullPolicy: Always
+                env:
+                  - name: CASSANDRA_HOME
+                    value: /ax/axdb/cassandra
+                  - name: CASSANDRA_SERVICE
+                    value: axdb
+                  - name: CASSANDRA_MEM_LIMIT
+                    value: "950"
+                  - name: NUMBER_OF_NODES
+                    value: "1"
+                  - name: POD_NAMESPACE
+                    valueFrom:
+                        fieldRef:
+                            fieldPath: metadata.namespace
+                  - name: POD_IP
+                    valueFrom:
+                        fieldRef:
+                            fieldPath: status.podIP
+                  - name: AX_NAMESPACE
+                    value: "${NAMESPACE}"
+                  - name: AX_VERSION
+                    value: "${VERSION}"
+                  - name: ARGO_DATA_BUCKET_NAME
+                    value: "${ARGO_DATA_BUCKET_NAME}"
+                ports:
+                  - containerPort: 8080
+                    name: axdbport
+                resources:
+                    requests:
+                        cpu: 400m
+                        memory: 1024Mi
+                    limits:
+                        cpu: 400m
+                        memory: 1024Mi
+                volumeMounts:
+                  - name: pdata
+                    mountPath: /ax/axdb/cassandra
+                lifecycle:
+                    preStop:
+                        exec:
+                            command: ["/ax/axdb/flush.sh"]
+                readinessProbe:
+                    exec:
+                        command:
+                          - /bin/bash
+                          - -c
+                          - /ax/axdb/health.sh
+                    initialDelaySeconds: 1
+                    timeoutSeconds: 10
+                    periodSeconds: 10
+            terminationGracePeriodSeconds: 60
+            imagePullSecrets:
+              - name: applatix-registry
+    volumeClaimTemplates:
+      - metadata:
+            name: pdata
+            annotations:
+                volume.alpha.kubernetes.io/storage-class: anything
+        spec:
+            accessModes: [ "ReadWriteOnce" ]
+            resources:
+                requests:
+                    storage: 10Gi

--- a/platform/config/service/basic/axmon-svc.yml.in
+++ b/platform/config/service/basic/axmon-svc.yml.in
@@ -1,0 +1,98 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: axmon
+    labels:
+        app: axmon
+        tier: platform
+        role: axcritical
+spec:
+    selector:
+        app: axmon-deployment
+    ports:
+      - port: 8901
+        targetPort: 8901
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+    name: axmon-deployment
+spec:
+    replicas: 1
+    template:
+        metadata:
+            labels:
+                app: axmon-deployment
+                tier: platform
+                role: axcritical
+            annotations:
+                pod.alpha.kubernetes.io/init-containers: '[
+                    {
+                        "name": "pre",
+                        "image": "${REGISTRY}/${NAMESPACE}/kube-init:${VERSION}",
+                        "imagePullPolicy": "IfNotPresent",
+                        "command": ["timeout", "1200", "sh", "-c", "wait_http http://axdb:8083/v1/axdb/status"]
+                    }
+                ]'
+                prometheus.io/port: "8902"
+                prometheus.io/scrape: "true"
+        spec:
+            # This has two containers. One is the axmon container that does
+            # all tasks related to axmon rest api and the other sets up a 
+            # proxy to the API server
+            containers:
+              - name: axmon
+                image: ${REGISTRY}/${NAMESPACE}/axmon:${VERSION}
+                command: ["/ax/bin/axmon"]
+                #imagePullPolicy: Always
+                env:
+                  - name: ARGO_DATA_BUCKET_NAME
+                    value: "${ARGO_DATA_BUCKET_NAME}"
+                  - name: ARGO_DIST_REGISTRY
+                    value: "${REGISTRY}"
+                  - name: ARGO_DIST_REGISTRY_SECRETS
+                    value: "${REGISTRY_SECRETS}"
+                  - name: AX_NAMESPACE
+                    value: "${NAMESPACE}"
+                  - name: AX_VERSION
+                    value: "${VERSION}"
+                  - name: AX_CLUSTER_META_URL_V1
+                    value: "${AX_CLUSTER_META_URL_V1}"
+                  - name: ARGO_LOG_BUCKET_NAME
+                    value: "${ARGO_LOG_BUCKET_NAME}"
+                ports:
+                  - containerPort: 8901
+                volumeMounts:
+                  - name: docker-socket-dir
+                    mountPath: /var/run
+                securityContext:
+                    privileged: true
+                resources:
+                    requests:
+                        cpu: 50m
+                        memory: 50Mi
+                    limits:
+                        memory: 100Mi
+                livenessProbe:
+                    httpGet:
+                        path: /v1/axmon/ping
+                        port: 8901
+                    initialDelaySeconds: 120
+                    periodSeconds: 60
+              - name: kubectl-proxy
+                image: argoproj/kubectl:v1.6.7
+                args: ["proxy", "-p", "8001"]
+                resources:
+                    requests:
+                        cpu: 25m
+                        memory: 20Mi
+                    limits:
+                        memory: 80Mi
+            nodeSelector:
+                ax.tier: applatix
+            imagePullSecrets:
+                - name: applatix-registry
+            volumes:
+                - name: docker-socket-dir
+                  hostPath:
+                      path: /var/run/

--- a/platform/config/service/basic/axops-internal-svc.yml.in
+++ b/platform/config/service/basic/axops-internal-svc.yml.in
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: axops-internal
+    labels:
+        app: axops-internal
+        tier: platform
+        role: axcritical
+spec:
+    selector:
+        app: axops-deployment
+    ports:
+      - name: api
+        port: 8085
+        targetPort: 8085

--- a/platform/config/service/basic/axops-svc.yml.in
+++ b/platform/config/service/basic/axops-svc.yml.in
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: axops
+    labels:
+        app: axops
+        tier: platform
+        role: axcritical
+spec:
+    selector:
+        app: axops-deployment
+    ports:
+      - name: http
+        port: 80
+        targetPort: 8081
+      - name: https
+        port: 443
+        targetPort: 8086
+    type: ${LOAD_BALANCER_TYPE}
+    loadBalancerSourceRanges: ${TRUSTED_CIDR}

--- a/platform/config/service/basic/axops.yml.in
+++ b/platform/config/service/basic/axops.yml.in
@@ -1,0 +1,80 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+    name: axops-deployment
+spec:
+    replicas: 1
+    template:
+        metadata:
+            labels:
+                app: axops-deployment
+                tier: platform
+                role: axcritical
+            annotations:
+                # Add axnotificaiton.
+                pod.alpha.kubernetes.io/init-containers: '[
+                    {
+                        "name": "pre",
+                        "image": "${REGISTRY}/${NAMESPACE}/kube-init:${VERSION}",
+                        "imagePullPolicy": "IfNotPresent",
+                        "command": ["timeout", "1200", "sh", "-c", "wait_http http://axdb:8083/v1/axdb/status"]
+                    }
+                ]'
+        spec:
+            containers:
+              - name: axops
+                image: ${REGISTRY}/${NAMESPACE}/axops:${VERSION}
+                env:
+                  - name: AXDB
+                    value: "http://axdb:8083/v1"
+                  - name: GATEWAY
+                    value: "http://gateway:8889/v1"
+                  - name: AXWORKFLOWADC
+                    value: "http://axworkflowadc:8911/v1/adc"
+                  - name: AXMON
+                    value: "http://axmon:8901/v1/axmon"
+                  - name: AXNOTIFIER
+                    value: "http://axnotification:9889/v1/notifications"
+                  - name: FIXMANAGER
+                    value: "http://fixturemanager:8912/v1"
+                  - name: SCHEDULER
+                    value: "http://axscheduler:9890/v1"
+                  - name: AXARTIFACTMANAGER
+                    value: "http://axartifactmanager:9892/v1"
+                  - name: AX_CLUSTER
+                    value: "${AX_CLUSTER_NAME_ID}"
+                  - name: AXOPS_EXT_DNS
+                    value: "${AXOPS_EXT_DNS}"
+                  - name: AX_REGION
+                    value: "${AX_AWS_REGION}"
+                  - name: AX_NAMESPACE
+                    value: "${NAMESPACE}"
+                  - name: AX_VERSION
+                    value: "${VERSION}"
+                  - name: SANDBOX_ENABLED
+                    value: "${SANDBOX_ENABLED}"
+                  - name: AX_MAX_PENDING_JOBS
+                    value: "1000"
+                  - name: ARGO_DATA_BUCKET_NAME
+                    value: "${ARGO_DATA_BUCKET_NAME}"
+                resources:
+                    requests:
+                        cpu: 100m
+                        memory: 100Mi
+                    limits:
+                        cpu: 100m
+                        memory: 150Mi
+              - name: kubectl-proxy
+                image: argoproj/kubectl:v1.6.7
+                args: ["proxy", "-p", "8001"]
+                resources:
+                    requests:
+                        cpu: 10m
+                        memory: 20Mi
+                    limits:
+                        cpu: 100m
+                        memory: 40Mi
+            nodeSelector:
+                ax.tier: applatix
+            imagePullSecrets:
+              - name: applatix-registry

--- a/platform/config/service/basic/axsys-namespace.yml.in
+++ b/platform/config/service/basic/axsys-namespace.yml.in
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app: "applatix"
+  name: axsys

--- a/platform/config/service/basic/axuser-namespace.yml.in
+++ b/platform/config/service/basic/axuser-namespace.yml.in
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app: "user"
+  name: axuser

--- a/platform/config/service/basic/axworkflowadc-svc.yml.in
+++ b/platform/config/service/basic/axworkflowadc-svc.yml.in
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: axworkflowadc
+    labels:
+        app: axworkflowadc
+        tier: platform
+        role: axcritical
+spec:
+    selector:
+        app: axworkflowadc-deployment
+    ports:
+      - port: 8911
+        targetPort: 8911
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+    name: axworkflowadc-deployment
+spec:
+    replicas: 1
+    template:
+        metadata:
+            labels:
+                app: axworkflowadc-deployment
+                tier: platform
+                role: axcritical
+            annotations:
+                pod.alpha.kubernetes.io/init-containers: '[
+                    {
+                        "name": "pre",
+                        "image": "${REGISTRY}/${NAMESPACE}/kube-init:${VERSION}",
+                        "imagePullPolicy": "IfNotPresent",
+                        "command": ["timeout", "1200", "sh", "-c", "wait_http http://axdb:8083/v1/axdb/status"]
+                    }
+                ]'
+        spec:
+            containers:
+              - name: axworkflowadc
+                image: ${REGISTRY}/${NAMESPACE}/workflow:${VERSION}
+                command: ["/ax/src/ax/devops/workflow/adc", "--image-registry", "${REGISTRY}", "--image-namespace", "${NAMESPACE}", "--image-version", "${VERSION}"]
+                env:
+                  - name: ARGO_DATA_BUCKET_NAME
+                    value: "${ARGO_DATA_BUCKET_NAME}"
+                ports:
+                  - containerPort: 8911
+                resources:
+                    requests:
+                        cpu: 75m
+                        memory: 100Mi
+                    limits:
+                        cpu: 200m
+                        memory: 200Mi
+            imagePullSecrets:
+                - name: applatix-registry

--- a/platform/config/service/basic/gateway-pvc.yml.in
+++ b/platform/config/service/basic/gateway-pvc.yml.in
@@ -1,0 +1,14 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: gateway-persistent-storage
+    annotations:
+        volume.alpha.kubernetes.io/storage-class: anything
+    labels:
+        app: gateway
+spec:
+    accessModes: [ "ReadWriteOnce" ]
+    resources:
+        requests:
+            storage: 3Gi

--- a/platform/config/service/basic/gateway-svc.yml.in
+++ b/platform/config/service/basic/gateway-svc.yml.in
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: gateway
+    labels:
+        app: gateway
+        tier: devops
+        role: axcritical
+spec:
+    selector:
+        app: gateway-deployment
+    ports:
+      - port: 8889
+        targetPort: 8889
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+    name: gateway-deployment
+spec:
+    replicas: 1
+    template:
+        metadata:
+            labels:
+                app: gateway-deployment
+                tier: devops
+                role: axcritical
+            annotations:
+                pod.alpha.kubernetes.io/init-containers: '[
+                    {
+                        "name": "pre",
+                        "image": "${REGISTRY}/${NAMESPACE}/kube-init:${VERSION}",
+                        "imagePullPolicy": "IfNotPresent",
+                        "command": ["sh", "-c", "wait_volume"],
+                        "env": [
+                            {
+                                "name": "AX_SIGNATURE",
+                                "value": "${AX_CLUSTER_NAME_ID}-gateway-svc"
+                            }
+                        ],
+                        "volumeMounts": [
+                            {
+                                "name": "gateway-persistent-storage",
+                                "mountPath": "/axsigdata"
+                            }
+                        ]
+                    }
+                ]'
+        spec:
+            containers:
+              - name: gateway
+                image: ${REGISTRY}/${NAMESPACE}/gateway:${VERSION}
+                env:
+                  - name: ARGO_DATA_BUCKET_NAME
+                    value: "${ARGO_DATA_BUCKET_NAME}"
+                  - name: AX_CLUSTER
+                    value: "${AX_CLUSTER_NAME_ID}"
+                  - name: AXOPS_EXT_DNS
+                    value: "${AXOPS_EXT_DNS}"
+                ports:
+                  - containerPort: 8889
+                resources:
+                    requests:
+                        cpu: 75m
+                        memory: 200Mi
+                    limits:
+                        cpu: 100m
+                        memory: 200Mi
+                volumeMounts:
+                  - mountPath: /ax/data
+                    name: gateway-persistent-storage
+                livenessProbe:
+                    httpGet:
+                        path: /v1/ping
+                        port: 8889
+                    initialDelaySeconds: 600
+                    periodSeconds: 120
+            nodeSelector:
+                ax.tier: applatix
+            imagePullSecrets:
+                - name: applatix-registry
+            volumes:
+              - name: gateway-persistent-storage
+                persistentVolumeClaim:
+                    claimName: gateway-persistent-storage
+

--- a/platform/config/service/basic/kafka-zk-pvc.yml.in
+++ b/platform/config/service/basic/kafka-zk-pvc.yml.in
@@ -1,0 +1,14 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: kdata-1
+    annotations:
+        volume.alpha.kubernetes.io/storage-class: anything
+    labels:
+        app: kafka-zk-1
+spec:
+    accessModes: [ "ReadWriteOnce" ]
+    resources:
+        requests:
+            storage: 10Gi

--- a/platform/config/service/basic/kafka-zk-svc.yml.in
+++ b/platform/config/service/basic/kafka-zk-svc.yml.in
@@ -1,0 +1,146 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: kafka-zk
+    labels:
+        name: kafka-zk
+        app: kafka-zk-svc
+        service: kafka-zk
+spec:
+    ports:
+      - name: broker
+        port: 9092
+      - name: client
+        port: 2181
+    selector:
+        service: kafka-zk
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: kafka-zk-1
+    labels:
+        name: kafka-zk-1
+        app: kafka-zk-1-svc
+        service: kafka-zk
+spec:
+    ports:
+      - name: broker
+        port: 9092
+      - name: client
+        port: 2181
+      - name: follower
+        port: 2888
+      - name: election
+        port: 3888
+    selector:
+        app: kafka-zk-1
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+    name: kafka-zk-1
+    labels:
+        name: kafka-zk-1
+spec:
+    replicas: 1
+    template:
+        metadata:
+            labels:
+                app: kafka-zk-1
+                service: kafka-zk
+            annotations:
+                pod.alpha.kubernetes.io/init-containers: '[
+                    {
+                        "name": "pre",
+                        "image": "${REGISTRY}/${NAMESPACE}/kube-init:${VERSION}",
+                        "imagePullPolicy": "IfNotPresent",
+                        "command": ["sh", "-c", "wait_volume"],
+                        "env": [
+                            {
+                                "name": "AX_SIGNATURE",
+                                "value": "${AX_CLUSTER_NAME_ID}-kafka-zk-1"
+                            }
+                        ],
+                        "volumeMounts": [
+                            {
+                                "name": "kafka-persistent-storage-1",
+                                "mountPath": "/axsigdata"
+                            }
+                        ]
+                    }
+                ]'
+        spec:
+            containers:
+              - name: kafka
+                image: ${REGISTRY}/${NAMESPACE}/kafka:${VERSION}
+                imagePullPolicy: Always
+                resources:
+                    limits:
+                        cpu: 200m
+                        memory: 300Mi
+                    requests:
+                        cpu: 200m
+                        memory: 300Mi
+                env:
+                  - name: KAFKA_MEM_SIZE
+                    value: "500"
+                  - name: BROKER_ID
+                    value: "1"
+                  - name: NUM_PARTITIONS
+                    value: "8"
+                  - name: ADVERTISED_HOSTNAME
+                    value: "kafka-zk-1.axsys"
+                  - name: ZOOKEEPER_CONNECT
+                    value: "localhost:2181"
+                  - name: REPLICATION_FACTOR
+                    value: "1"
+                  - name: DEFAULT_REPLICATION_FACTOR
+                    value: "1"
+                ports:
+                  - containerPort: 9092
+                volumeMounts:
+                  - mountPath: /ax/kafka
+                    name: kafka-persistent-storage-1
+              - name: zookeeper
+                image: ${REGISTRY}/${NAMESPACE}/zookeeper:${VERSION}
+                imagePullPolicy: Always
+                resources:
+                    limits:
+                        cpu: 200m
+                        memory: 550Mi
+                    requests:
+                        cpu: 100m
+                        memory: 550Mi
+                env:
+                  - name: ZK_SERVER_HEAP
+                    value: "64"
+                  - name: ZK_MEM_SIZE
+                    value: "96"
+                  - name: ZK_MYID
+                    value: "1"
+                  - name: ZK_NUMBER_OF_NODES
+                    value: "1"
+                  - name: ZK_SERVICE_NAME
+                    value: "kafka-zk"
+                ports:
+                  - containerPort: 2181
+                  - containerPort: 2888
+                  - containerPort: 3888
+                volumeMounts:
+                  - mountPath: /ax/zookeeper
+                    name: kafka-persistent-storage-1
+                livenessProbe:
+                    exec:
+                        command:
+                          - /ax/bin/health.sh
+                    initialDelaySeconds: 240
+                    timeoutSeconds: 15
+                    failureThreshold: 1
+            imagePullSecrets:
+              - name: applatix-registry
+            volumes:
+              - name: kafka-persistent-storage-1
+                persistentVolumeClaim:
+                    claimName: kdata-1

--- a/platform/config/service/basic/redis-pvc.yml.in
+++ b/platform/config/service/basic/redis-pvc.yml.in
@@ -1,0 +1,15 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: redis-pvc
+    annotations:
+        # Current 1.2 alpha feature. Key is needed but value doesn't matter.
+        volume.alpha.kubernetes.io/storage-class: foo
+    labels:
+        app: redis
+spec:
+    accessModes:
+        ["ReadWriteOnce"]
+    resources:
+        requests:
+            storage: 1Gi

--- a/platform/config/service/basic/redis-svc.yml.in
+++ b/platform/config/service/basic/redis-svc.yml.in
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: redis
+    labels:
+        app: redis
+        tier: platform
+        role: axcritical
+spec:
+    selector:
+        app: redis-deployment
+    ports:
+      - port: 6379
+        targetPort: 6379
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+    name: redis-deployment
+spec:
+    replicas: 1
+    template:
+        metadata:
+            labels:
+                app: redis-deployment
+                tier: platform
+                role: axcritical
+            annotations:
+                pod.alpha.kubernetes.io/init-containers: '[
+                    {
+                        "name": "pre",
+                        "image": "${REGISTRY}/${NAMESPACE}/kube-init:${VERSION}",
+                        "imagePullPolicy": "IfNotPresent",
+                        "command": ["sh", "-c", "wait_volume"],
+                        "env": [
+                            {
+                                "name": "AX_SIGNATURE",
+                                "value": "${AX_CLUSTER_NAME_ID}-redis-svc"
+                            }
+                        ],
+                        "volumeMounts": [
+                            {
+                                "name": "redis-data",
+                                "mountPath": "/axsigdata"
+                            }
+                        ]
+                    }
+                ]'
+        spec:
+            containers:
+              - name: redis
+                image: ${REGISTRY}/${NAMESPACE}/redis:${VERSION}
+                ports:
+                  - containerPort: 6379
+                resources:
+                    requests:
+                        cpu: 50m
+                        memory: 50Mi
+                    limits:
+                        cpu: 100m
+                        memory: 120Mi
+                volumeMounts:
+                  - mountPath: "/data"
+                    name: redis-data
+            volumes:
+              - name: redis-data
+                persistentVolumeClaim:
+                    claimName: redis-pvc
+            imagePullSecrets:
+              - name: applatix-registry

--- a/platform/config/service/basic/registry-secrets.yml.in
+++ b/platform/config/service/basic/registry-secrets.yml.in
@@ -1,0 +1,16 @@
+#
+# Copyright 2015-2016 Applatix, Inc. All rights reserved.
+#
+
+# Registry secrets for distribution registry
+
+apiVersion: v1
+kind: Secret
+metadata:
+    name: applatix-registry
+    labels:
+        app: axsecret
+data:
+    .dockerconfigjson: ${REGISTRY_SECRETS}
+type:
+    kubernetes.io/dockerconfigjson

--- a/platform/config/service/basic/registry-svc.yml.in
+++ b/platform/config/service/basic/registry-svc.yml.in
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: registry
+    labels:
+        app: registry
+        tier: platform
+        role: axcritical
+spec:
+    selector:
+        app: registry-deployment
+    ports:
+      - port: 443
+        targetPort: 443
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+    name: registry-deployment
+spec:
+    replicas: 1
+    template:
+        metadata:
+            labels:
+                app: registry-deployment
+                tier: platform
+                role: axcritical
+        spec:
+            containers:
+              - name: registry
+                image: ${REGISTRY}/${NAMESPACE}/registry:${VERSION}
+                env:
+                  - name: AX_REGISTRY_MODE
+                    value: test
+                ports:
+                  - containerPort: 443
+            nodeSelector:
+                ax.tier: applatix
+            imagePullSecrets:
+              - name: applatix-registry

--- a/platform/config/service/basic/secret-key-secret.yml.in
+++ b/platform/config/service/basic/secret-key-secret.yml.in
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argo-secret-key
+  labels:
+    app: argosecret
+type: Opaque
+data:
+  argo-secret-key: ${ARGO_S3_ACCESS_KEY_SECRET}

--- a/platform/config/service/config/basic-platform-bootstrap.cfg
+++ b/platform/config/service/config/basic-platform-bootstrap.cfg
@@ -1,0 +1,138 @@
+#
+# NOTE: IF THIS FILE IS BEING MODIFIED, please look at platform.py start() to check if
+# the ordering guarantees are broken!
+#
+version: "v1"
+name: "Argo Platform Config Only"
+spec:
+  steps:
+    # Step 0: Create all kubernetes namespaces
+    - name: "Essential Kubernetes Namespaces"
+      policy: "CreateOnce"
+      consistency: "CreateIfNotExist"
+      objects:
+        - name: "axuser-namespace"
+          file: "axuser-namespace.yml.in"
+
+        - name: "axsys-namespace"
+          file: "axsys-namespace.yml.in"
+
+    # Step 1: Any kubernetes addons/secrets
+    - name: "Essential Kubnernetes addons"
+      policy: "CreateOnce"
+      consistency: "CreateIfNotExist"
+      objects:
+        - name: "access-key-secret"
+          file: "access-key-secret.yml.in"
+          namespace: "axsys"
+
+        - name: "secret-key-secret"
+          file: "secret-key-secret.yml.in"
+          namespace: "axsys"
+
+
+    # Step 2: Applatix basics
+    # Including basic services, volumes and secrets. These object should be only created once
+    - name: "Basic Infrastructure"
+      policy: "CreateOnce"
+      consistency: "CreateIfNotExist"
+      objects:
+        - name: "axops-svc"
+          file: "axops-svc.yml.in"
+          namespace: "axsys"
+
+        - name: "axops-internal-svc"
+          file: "axops-internal-svc.yml.in"
+          namespace: "axsys"
+
+        - name: "applatix-svc"
+          file: "applatix-svc.yml.in"
+          namespace: "axsys"
+
+        - name: "kafka-zk-pvc"
+          file: "kafka-zk-pvc.yml.in"
+          namespace: "axsys"
+
+        - name: "redis-pvc"
+          file: "redis-pvc.yml.in"
+          namespace: "axsys"
+
+        - name: "prometheus-pvc"
+          file: "prometheus-pvc.yml.in"
+          namespace: "axsys"
+
+        - name: "gateway-pvc"
+          file: "gateway-pvc.yml.in"
+          namespace: "axsys"
+
+    # Step 3: Registry Secrets
+    - name: "Registry Secrets"
+      policy: "CreateOnce"
+      policy_predicate: "PrivateRegistryOnly"
+      consistency: "CreateIfNotExist"
+      objects:
+        - name: "registry-secrets-axsys"
+          file: "registry-secrets.yml.in"
+          namespace: "axsys"
+
+        - name: "registry-secrets-axuser"
+          file: "registry-secrets.yml.in"
+          namespace: "axuser"
+
+        - name: "registry-secrets-kube"
+          file: "registry-secrets.yml.in"
+          namespace: "kube-system"
+
+    # Step 4: Kafka (Heavy Hitter)
+    - name: "Kafka"
+      policy: "CreateMany"
+      consistency: "CreateIfNotExist"
+      objects:
+        - name: "kafka-zk-svc"
+          file: "kafka-zk-svc.yml.in"
+          namespace: "axsys"
+
+    # Step 5: Cassandra (Heavy Hitter)
+    - name: "Cassandra"
+      policy: "CreateMany"
+      consistency: "CreateIfNotExist"
+      objects:
+        - name: "axdb-svc"
+          file: "axdb-svc.yml.in"
+          namespace: "axsys"
+
+    # Step 6: Other heavy hitters and their dependencies
+    - name: "Heavy Hitters"
+      policy: "CreateMany"
+      consistency: "CreateIfNotExist"
+      objects:
+        - name: "gateway-svc"
+          file: "gateway-svc.yml.in"
+          namespace: "axsys"
+        - name: "axops"
+          file: "axops.yml.in"
+          namespace: "axsys"
+        - name: "axmon-svc"
+          file: "axmon-svc.yml.in"
+          namespace: "axsys"
+
+    # Step 7: Rest of Argo services
+    - name: "Backend Micro Services"
+      policy: "CreateMany"
+      consistency: "CreateIfNotExist"
+      objects:
+        - name: "axworkflowadc-svc"
+          file: "axworkflowadc-svc.yml.in"
+          namespace: "axsys"
+
+        - name: "redis-svc"
+          file: "redis-svc.yml.in"
+          namespace: "axsys"
+
+        - name: "axopsbootstrap"
+          file: "axopsbootstrap.yml.in"
+          namespace: "axsys"
+
+        - name: "axartifactmanager-svc"
+          file: "axartifactmanager-svc.yml.in"
+          namespace: "axsys"

--- a/platform/source/lib/ax/platform/cluster_config/consts.py
+++ b/platform/source/lib/ax/platform/cluster_config/consts.py
@@ -17,9 +17,10 @@ class AXClusterSize:
     CLUSTER_MEDIUM = "medium"
     CLUSTER_LARGE = "large"
     CLUSTER_XLARGE = "xlarge"
+    CLUSTER_USER_PROVIDED = "user_provided"
 
     # TODO (#36): mvc is currently broken so mark it as not valid
-    VALID_CLUSTER_SIZES = [CLUSTER_SMALL, CLUSTER_MEDIUM, CLUSTER_LARGE, CLUSTER_XLARGE]
+    VALID_CLUSTER_SIZES = [CLUSTER_SMALL, CLUSTER_MEDIUM, CLUSTER_LARGE, CLUSTER_XLARGE, CLUSTER_USER_PROVIDED]
 
 
 class SpotInstanceOption:

--- a/platform/tests/install_options_tests.py
+++ b/platform/tests/install_options_tests.py
@@ -1,0 +1,41 @@
+"""The file has unit tests for the install_options."""
+
+import argparse
+import unittest
+
+from ax.cluster_management.app.options import PlatformOnlyInstallConfig
+
+
+class InstallOptionsTest(unittest.TestCase):
+    """
+    Tests for the InstallOptionsTest
+    """
+    def add_default_options(self, cfg):
+        cfg.cluster_bucket = "argo-bucket"
+        cfg.cluster_name = "argo-cluster"
+        cfg.cluster_id = "argo-cluster-id"
+        cfg.kubeconfig = "/tmp/kconfig"
+        cfg.cloud_provider = "minikube"
+        cfg.cloud_profile = "default"
+        cfg.service_manifest_root = "/tmp/service_manifest_root"
+        cfg.platform_bootstrap_config = cfg.service_manifest_root + "/platform-bootstrap.cfg"
+        cfg.silent = False
+        cfg.dry_run = False
+
+    def test_platform_only_install_basic(self):
+        cfg = argparse.ArgumentParser()
+        self.add_default_options(cfg)
+
+        # Explicitly set the provider to aws and verify that the manifest root and bootstrap_config are set
+        # correctly.
+        cfg.cloud_provider = "aws"
+        p1 = PlatformOnlyInstallConfig(cfg)
+        assert p1.service_manifest_root == "/tmp/service_manifest_root"
+        assert p1.platform_bootstrap_config == p1.service_manifest_root + "/platform-bootstrap.cfg"
+
+        # Same as above but with minikube
+        cfg.cloud_provider = "minikube"
+        p2 = PlatformOnlyInstallConfig(cfg)
+        assert p2.service_manifest_root == "/ax/config/service/basic"
+        assert p2.platform_bootstrap_config == "/ax/config/service/config/basic-platform-bootstrap.cfg"
+


### PR DESCRIPTION
In this commit, simply the PlatformOnlyInstallConfig object is created.
In subsequent commits, more functionality will be added to this for
actually installing Argo.

Added unit-tests related to PlatformOnlyInstallConfig.

Also tested manually. install-platform-only does nothing right now.
Simply logs a message and exits.