### PR TITLE
Create PlatformOnlyInstaller object.

### DIFF
--- a/common/python/ax/cluster_management/app/__init__.py
+++ b/common/python/ax/cluster_management/app/__init__.py
@@ -4,7 +4,7 @@
 #
 
 from .common import CommonClusterOperations
-from .cluster_installer import ClusterInstaller
+from .cluster_installer import ClusterInstaller, PlatformOnlyInstaller
 from .cluster_pauser import ClusterPauser
 from .cluster_restarter import ClusterResumer
 from .cluster_uninstaller import ClusterUninstaller

--- a/common/python/ax/cluster_management/argo_cluster_manager.py
+++ b/common/python/ax/cluster_management/argo_cluster_manager.py
@@ -13,7 +13,7 @@ from ax.cloud import Cloud
 from ax.cloud.aws import SecurityToken
 from ax.util.const import COLOR_NORM, COLOR_RED
 from .app import ClusterInstaller, ClusterPauser, ClusterResumer, ClusterUninstaller, ClusterUpgrader, \
-    CommonClusterOperations
+    CommonClusterOperations, PlatformOnlyInstaller
 from .app.options import add_install_flags, add_platform_only_flags, ClusterInstallConfig, add_pause_flags, ClusterPauseConfig, \
     add_restart_flags, PlatformOnlyInstallConfig, ClusterRestartConfig, add_uninstall_flags, ClusterUninstallConfig, \
     add_upgrade_flags, ClusterUpgradeConfig, add_misc_flags, ClusterMiscOperationConfig
@@ -133,7 +133,7 @@ class ArgoClusterManager(object):
     def install_platform_only(self, args):
         logger.info("Installing platform only ...")
         platform_install_config = PlatformOnlyInstallConfig(cfg=args)
-        # TODO(shri): Do more with platform_install_config!
+        PlatformOnlyInstaller(platform_install_config).run()
         return
 
     @staticmethod

--- a/platform/config/cloud/standard/cloud_template_user_provided.json
+++ b/platform/config/cloud/standard/cloud_template_user_provided.json
@@ -1,0 +1,21 @@
+{
+    "cloud": {
+        "provider": "aws",
+        "version": 1,
+        "configure": {
+            "cluster_user": "",
+            "cluster_size": "user_provided",
+            "cluster_type": "standard",
+            "region": "us-west-2",
+            "placement": "us-west-2a",
+            "axsys_node_type": "m3.large",
+            "axuser_node_type": "c3.2xlarge",
+            "min_node_count": 0,
+            "max_node_count": 9223372036854776000,
+            "axsys_node_count": 0,
+            "node_tiers": "master/applatix/user",
+            "ax_vol_size": 100,
+            "axuser_on_demand_nodes": 0
+        }
+    }
+}

--- a/platform/source/lib/ax/platform/ax_cluster_info.py
+++ b/platform/source/lib/ax/platform/ax_cluster_info.py
@@ -374,3 +374,8 @@ class AXClusterInfo(with_metaclass(Singleton, object)):
                 }
             }
         }
+
+    def set_kube_config(self, kube_config):
+        self._kube_config = kube_config
+        logger.info("Setting kube_config to %s", kube_config)
+

--- a/platform/source/lib/ax/platform/cluster_config/__init__.py
+++ b/platform/source/lib/ax/platform/cluster_config/__init__.py
@@ -4,5 +4,5 @@
 # Copyright 2015-2017 Applatix, Inc. All rights reserved.
 #
 
-from .consts import AXClusterType, AXClusterSize, SpotInstanceOption
+from .consts import AXClusterType, AXClusterSize, SpotInstanceOption, ClusterProvider
 from .cluster_config import AXClusterConfig, AXClusterConfigMock

--- a/platform/source/lib/ax/platform/cluster_config/cluster_config.py
+++ b/platform/source/lib/ax/platform/cluster_config/cluster_config.py
@@ -200,6 +200,9 @@ class AXClusterConfig(with_metaclass(Singleton, object)):
     def get_kube_installer_config(self):
         return self._conf["cloud"]["kube_installer_config"]
 
+    def get_cluster_provider(self):
+        return self._conf["cloud"].get("cluster_provider", None)
+
     # Setters. Currently only a very limited items is mutable
     def set_ax_cluster_user(self, user):
         self._conf["cloud"]["configure"]["cluster_user"] = user
@@ -230,6 +233,12 @@ class AXClusterConfig(with_metaclass(Singleton, object)):
 
     def set_kube_installer_config(self, config):
         self._conf["cloud"]["kube_installer_config"] = config
+
+    def set_support_object_store_name(self, bucket_name):
+        self._conf["cloud"]["configure"]["support_object_store_name"] = bucket_name
+
+    def set_cluster_provider(self, cluster_provider):
+        self._conf["cloud"]["cluster_provider"] = cluster_provider
 
     def reload_config(self):
         """

--- a/platform/source/lib/ax/platform/cluster_config/consts.py
+++ b/platform/source/lib/ax/platform/cluster_config/consts.py
@@ -28,3 +28,8 @@ class SpotInstanceOption:
     PARTIAL_SPOT = "partial"
     ALL_SPOT = "all"
     VALID_SPOT_INSTANCE_OPTIONS = [NO_SPOT, PARTIAL_SPOT, ALL_SPOT]
+
+class ClusterProvider:
+    ARGO = "argo"
+    USER = "user"
+    VALID_CLUSTER_PROVIDERS = [ARGO, USER]

--- a/platform/tests/install_options_tests.py
+++ b/platform/tests/install_options_tests.py
@@ -22,6 +22,9 @@ class InstallOptionsTest(unittest.TestCase):
         cfg.silent = False
         cfg.dry_run = False
 
+        cfg.cloud_region = "us-west-2"
+        cfg.cloud_placement = "us-west-2a"
+
     def test_platform_only_install_basic(self):
         cfg = argparse.ArgumentParser()
         self.add_default_options(cfg)


### PR DESCRIPTION
The run() method of the PlatformOnlyInstaller object will actually
install Argo components.

Testing done:

1. Modified the install_options_test and they run.
2. Verified that existing cluster installation is unaffected.