### PR TITLE
Use EMPTYDIR for dind only for non-aws environments.

### DIFF
--- a/platform/source/lib/ax/platform/container_specs.py
+++ b/platform/source/lib/ax/platform/container_specs.py
@@ -189,9 +189,9 @@ class SidecarDockerDaemon(Container):
 
         # Add per node dgs to sidecar
         dgs_vol = ContainerVolume("docker-graph-storage", "/var/lib/docker")
-        if Cloud().target_cloud_aws():
+        if Cloud().own_cloud() == Cloud.CLOUD_AWS:
             dgs_vol.set_type("DOCKERGRAPHSTORAGE", size_in_mb)
-        elif Cloud().target_cloud_gcp():
+        else:
             dgs_vol.set_type("EMPTYDIR")
         self.add_volume(dgs_vol)
 


### PR DESCRIPTION
Testing Done:

1. The dind-test-wf workflow hangs without this change. The description
of the pod shows that docker-graph-storage has type "unknown".

2. With this change, the docker-graph-storage volume has type EMPTYDIR
and the workflow completes successfully.