### PR TITLE
changes to artifact management to support any s3 compliant object store

### DIFF
--- a/common/python/ax/cloud/aws/aws_s3.py
+++ b/common/python/ax/cloud/aws/aws_s3.py
@@ -117,6 +117,20 @@ class AXS3Bucket(object):
     def get_bucket_name(self):
         return self._name
 
+    @staticmethod
+    def supports_encryption():
+        # only s3proxy doesn't support encryption
+        # TODO: replace with check for cloud != minikube
+        return not os.environ.get("ARGO_S3_ENDPOINT", None)
+
+    @staticmethod
+    def supports_signed_url():
+        # use signed url for aws s3 only
+        # aws s3 is assumed when s3 endpoint is not specified
+        # TODO: replace with check for cloud == aws
+        return not os.environ.get("ARGO_S3_ENDPOINT", None)
+
+
     @retry(
         retry_on_exception=head_bucket_retry,
         wait_exponential_multiplier=1000,

--- a/devops/src/ax/devops/artifact/artifactmanager.py
+++ b/devops/src/ax/devops/artifact/artifactmanager.py
@@ -17,6 +17,8 @@ from ax.devops.artifact.constants import DEFAULT_PROCESS_INTERVAL, MILLISECONDS_
 from ax.devops.utility.utilities import aggregate_numeric_dictionaries, ax_profiler, get_epoch_time_in_ms, get_error_code, retry_on_errors
 from ax.exceptions import AXApiInvalidParam, AXApiInternalError
 
+from ax.cloud.aws import AXS3Bucket
+
 logger = logging.getLogger(__name__)
 logging.getLogger('ax.devops.axrequests').setLevel(logging.CRITICAL)
 logging.getLogger('ax.devops.utility.utilities').setLevel(logging.ERROR)
@@ -1118,7 +1120,11 @@ class ArtifactManager(object):
             try:
                 s3_path = artifact['storage_path']
                 bucket, key = s3_path['bucket'], s3_path['key']
-                location = Cloud().get_bucket(bucket).generate_signed_url(key)
+                s3_bucket = Cloud().get_bucket(bucket)
+                location = s3_bucket.generate_signed_url(key) if AXS3Bucket.supports_signed_url() else "/v1/s3object" \
+                                                                                                      "?bucket=" + \
+                                                                                                      bucket + "&key=" \
+                                                                                                      + key
                 logger.info("redirect to %s", location)
                 return location, None
             except Exception as e:

--- a/platform/config/service/argo-wfe/axops-svc.yml.in
+++ b/platform/config/service/argo-wfe/axops-svc.yml.in
@@ -12,9 +12,6 @@ spec:
     ports:
       - name: http
         port: 80
-        targetPort: 8081
-      - name: https
-        port: 443
-        targetPort: 8086
+        targetPort: 8082
     type: ${LOAD_BALANCER_TYPE}
     loadBalancerSourceRanges: ${TRUSTED_CIDR}

--- a/platform/config/service/argo-wfe/s3proxy.yml
+++ b/platform/config/service/argo-wfe/s3proxy.yml
@@ -1,0 +1,73 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: s3proxy-pvc
+    annotations:
+        # Current 1.2 alpha feature. Key is needed but value doesn't matter.
+        volume.alpha.kubernetes.io/storage-class: foo
+    labels:
+        app: s3proxy
+spec:
+    accessModes:
+        ["ReadWriteOnce"]
+    resources:
+        requests:
+            storage: 2Gi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: s3proxy
+    labels:
+        app: s3proxy
+        tier: platform
+        role: axcritical
+spec:
+    selector:
+        app: s3proxy-deployment
+    ports:
+      - port: 9000
+        targetPort: 80
+    type: LoadBalancer
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+    name: s3proxy-deployment
+spec:
+    replicas: 1
+    template:
+        metadata:
+            labels:
+                app: s3proxy-deployment
+                tier: platform
+                role: axcritical
+            annotations:
+        spec:
+            containers:
+              - name: s3proxy
+                image: andrewgaul/s3proxy
+                env:
+                  - name: S3PROXY_AUTHORIZATION
+                    value: "none"
+                  - name: LOG_LEVEL
+                    value: "trace"
+                ports:
+                  - containerPort: 80
+                resources:
+                    requests:
+                        cpu: 100m
+                        memory: 150Mi
+                    limits:
+                        cpu: 100m
+                        memory: 150Mi
+                volumeMounts:
+                  - mountPath: "/data"
+                    name: s3proxy-data
+            volumes:
+              - name: s3proxy-data
+                persistentVolumeClaim:
+                    claimName: s3proxy-pvc
+

--- a/platform/source/tools/container_outer_executor.py
+++ b/platform/source/tools/container_outer_executor.py
@@ -1128,13 +1128,15 @@ class ContainerOuterExecutor(object):
 
                 data = open(file_path, 'rb')
                 params = {
-                    'ACL': 'bucket-owner-full-control',
                     'Metadata': meta_data,
-                    'ServerSideEncryption': 'AES256',
                     'StorageClass': 'STANDARD',
                     'ContentDisposition': content_disposition,
                     'ContentLength': source_size
                 }
+                if AXS3Bucket.supports_encryption():
+                    params["ACL"] = "bucket-owner-full-control"
+                    params["ServerSideEncryption"] = "AES256"
+
                 if content_md5:
                     params['ContentMD5'] = content_md5
 
@@ -1157,10 +1159,12 @@ class ContainerOuterExecutor(object):
                 try:
                     data = file_structure.encode('utf-8')
                     structure_params = {
-                        'ACL': 'bucket-owner-full-control',
-                        'ServerSideEncryption': 'AES256',
                         'StorageClass': 'STANDARD'
                     }
+                    if AXS3Bucket.supports_encryption():
+                        structure_params["ACL"] = "bucket-owner-full-control"
+                        structure_params["ServerSideEncryption"] = "AES256"
+
                     if not s3_bucket.put_object(key=structure_key, data=data, **structure_params):
                         raise Exception("Failed to put object")
                     upload_structure = True

--- a/saas/axops/src/applatix.io/axops/s3.go
+++ b/saas/axops/src/applatix.io/axops/s3.go
@@ -31,7 +31,11 @@ func GetS3Object() gin.HandlerFunc {
 			return
 		}
 		c.Header("Content-Type", *output.ContentType)
-		c.Header("Content-Disposition", "attachment; filename="+key)
+		if output.ContentDisposition != nil {
+			c.Header("Content-Disposition", *output.ContentDisposition)
+		}else {
+			c.Header("Content-Disposition", "attachment; filename=" + key)
+		}
 		_, err = io.Copy(c.Writer, output.Body)
 		output.Body.Close()
 		return


### PR DESCRIPTION
- manifest for s3proxy
- for minikube expose 8082 port for axops since https with minikube has some issues
- s3 features like server side encryption and acl are not used when cloud is minikube 
- s3 signed url feature is used only when cloud is aws

resolves: #312