### PR TITLE
argo-checkout should fallback to passwordless mode if axops API is not available

### DIFF
--- a/devops/src/ax/devops/scm/factory.py
+++ b/devops/src/ax/devops/scm/factory.py
@@ -34,9 +34,13 @@ def _find_axops_tool_config(repo):
     try:
         tools = axops_client.get_tools(category='scm')
     except Exception as e:
-        logger.warning("Cannot get tools from axops-internal. Your cluster needs upgrade. Error: %s", e)
-        logger.info("Getting tools from axops instead of axops-internal")
-        tools = axops_client_old.get_tools(category='scm')
+        try:
+            logger.warning("Cannot get tools from axops-internal. Your cluster needs upgrade. Error: %s", e)
+            logger.info("Getting tools from axops instead of axops-internal")
+            tools = axops_client_old.get_tools(category='scm')
+        except Exception as e:
+            logger.warning("Cannot get tools from axops. Error: %s", e)
+            tools = []
 
     for tool in tools:
         if repo in tool.get('repos', []):


### PR DESCRIPTION
Resolves: https://github.com/argoproj/argo/issues/365