### PR TITLE
Misc. fixes to install argo-only.

### DIFF
--- a/common/python/ax/cloud/aws/aws_s3.py
+++ b/common/python/ax/cloud/aws/aws_s3.py
@@ -166,7 +166,11 @@ class AXS3Bucket(object):
             # Assume we don't have AWS metadata server access
             for r in PARTITION_DEFAULT_REGIONS:
                 logger.debug("Trying partition default region %s to get bucket region.", r)
-                bucket_region = _do_get_region(r)
+                bucket_region = None
+                try:
+                    bucket_region = _do_get_region(r)
+                except ClientError as e:
+                    logger.info("Get region failed with: %s. Assuming region is None ...", e)
                 if bucket_region:
                     return bucket_region
         return None

--- a/common/python/ax/cluster_management/app/options/install_options.py
+++ b/common/python/ax/cluster_management/app/options/install_options.py
@@ -435,7 +435,7 @@ def add_platform_only_flags(parser):
     parser.add_argument("--cloud-placement", default=None, help="A valid cloud placement")
 
     # Add bucket
-    parser.add_argument("--cluster-bucket", default=None, required=True, help="S3 complaint bucket to use")
+    parser.add_argument("--cluster-bucket", default=None, help="S3 complaint bucket to use")
     parser.add_argument("--bucket-endpoint", default=None, help="HTTP Endpoint for the cluster-bucket")
     parser.add_argument("--access-key", default=None, help="Access key for accessing the bucket")
     parser.add_argument("--secret-key", default=None, help="Secret key for accessing the bucket")

--- a/common/python/ax/cluster_management/argo_cluster_manager.py
+++ b/common/python/ax/cluster_management/argo_cluster_manager.py
@@ -230,17 +230,27 @@ class ArgoClusterManager(object):
     def install_platform_only(self, args):
         logger.info("Installing Argo platform ...")
 
+        try:
+            assert args.cluster_name
+        except Exception:
+            print("--cluster-name needs to be specified")
+            sys.exit(1)
+
         if args.cloud_provider == "minikube" and not args.bucket_endpoint:
+            Cloud(target_cloud="aws")
             args.cluster_bucket = "argo"
             # TODO:revisit
             # access key and secret is required by code in aws_s3
             # use dummy access key and secret for s3proxy
-            args.access_key = "abc"
-            args.secret_key = "abc"
+            args.access_key = "fake-access-key"
+            args.secret_key = "fake-secret-key"
             self._install_s3_proxy(args.kubeconfig)
             args.bucket_endpoint = self._get_s3_proxy_endpoint(args.kubeconfig)
             # Create bucket
             self._create_s3_proxy_bucket(args.bucket_endpoint, args.cluster_bucket)
+        elif args.cloud_provider == "aws":
+            assert args.cluster_bucket, "--cluster-bucket is required"
+            assert args.cloud_region, "--cloud-region is required"
 
         logger.info("s3 bucket endpoint: %s", args.bucket_endpoint)
 


### PR DESCRIPTION
1. Make cluster-bucket optional for minikube. And mandatory for AWS.
2. Create Cloud object early.
3. Make cluster-name mandatory.
4. Ignore get_region exceptions is boto client can't be created.