### PR TITLE
Remove explicit ACLs when installing cluster_version.

### DIFF
--- a/platform/source/lib/ax/platform/cluster_version.py
+++ b/platform/source/lib/ax/platform/cluster_version.py
@@ -44,17 +44,14 @@ class AXVersion(object):
         # Update current version in cluster bucket.
         cluster_version_key = AXClusterConfigPath(self._cluster_name_id).versions()
         self._cluster_bucket.put_object(cluster_version_key,
-                                        yaml.dump(new),
-                                        ACL="bucket-owner-full-control")
+                                        yaml.dump(new))
 
         # Update current version in support bucket.
         support_version_key = AXSupportConfigPath(self._cluster_name_id).current_versions()
         self._support_bucket.put_object(support_version_key,
-                                        yaml.dump(new),
-                                        ACL="bucket-owner-full-control")
+                                        yaml.dump(new))
 
         # Update version history in support bucket.
         support_version_history_key = AXSupportConfigPath(self._cluster_name_id).version_history()
         self._support_bucket.put_object(support_version_history_key,
-                                        yaml.dump(history),
-                                        ACL="bucket-owner-full-control")
+                                        yaml.dump(history))


### PR DESCRIPTION
This should be safe to do since the ACL mentioned in the code is the
same as the default ACL set by AWS [1].

Having the explicitl ACL is not good for S3 proxy. S3proxy barfs on a
put_object call when the ACL is specified.

[1] http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html