### PR TITLE
Run fixturemanager when installing "argo-all".

### DIFF
--- a/platform/config/service/config/argo-all-platform-bootstrap.cfg
+++ b/platform/config/service/config/argo-all-platform-bootstrap.cfg
@@ -114,6 +114,10 @@ spec:
           file: "axamm-svc.yml.in"
           namespace: "axsys"
 
+        - name: "fixturemanager-svc"
+          file: "fixturemanager-svc.yml.in"
+          namespace: "axsys"
+
         - name: "ingress-controller"
           file: "ingress-controller.yml.in"
           namespace: "axsys"


### PR DESCRIPTION
This allows creation and use of volumes in Applications.

Closes #383.