### PR TITLE
Support minikube install without inlining certificates

### DIFF
--- a/saas/argocli/src/applatix.io/argo/cmd/cluster.go
+++ b/saas/argocli/src/applatix.io/argo/cmd/cluster.go
@@ -73,6 +73,9 @@ func clusterShell(cmd *cobra.Command, args []string) {
 	volKube := fmt.Sprintf("%s/.kube:/tmp/ax_kube", homePath)
 	volSSH := fmt.Sprintf("%s/.ssh:/root/.ssh", homePath)
 	volArgo := fmt.Sprintf("%s/.argo:/root/.argo", homePath)
+	// User's home dir is mounted to support configs that reference other files inside the users home
+	// (e.g. minikube CA certificates)
+	volHome := fmt.Sprintf("%s:%s", homePath, homePath)
 
 	envRegistry := fmt.Sprintf("ARGO_DIST_REGISTRY=%s", registry)
 	envNamespace := fmt.Sprintf("AX_NAMESPACE=%s", namespace)
@@ -81,7 +84,7 @@ func clusterShell(cmd *cobra.Command, args []string) {
 
 	runCmdTTY(dockerPath, "run",
 		"-it", "--net", "host",
-		"-v", volAWS, "-v", volKube, "-v", volSSH, "-v", volArgo, // map required volumes from home directory
+		"-v", volAWS, "-v", volKube, "-v", volSSH, "-v", volArgo, "-v", volHome, // map required volumes from home directory
 		"-e", envRegistry, "-e", envNamespace, "-e", envVersion, "-e", envRegistrySecrets, // Create env vars required for cluster manager
 		clusterManagerImage)
 }


### PR DESCRIPTION
This change does two things:

1) During `argo cluster`, additionally mounts the user's home directory to the same location inside axclustermanager
2) Adds the ability to authenticate using client certificates to the python kubernetes client (both in the swagger api client and the requests session)

Combined, this enables argocluster to install minikube without the extra step of inline certificates and generating the token field.
