### PR TITLE
Argo Executor init container

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -20,6 +20,12 @@
   version = "v1.1.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/dustin/go-humanize"
+  packages = ["."]
+  revision = "6d15c0ae71e55ed645c21ac4945aaadbc0e9a590"
+
+[[projects]]
   name = "github.com/emicklei/go-restful"
   packages = [".","log"]
   revision = "5741799b275a3c4a5a9623a993576d7545cf7b5c"
@@ -36,6 +42,12 @@
   packages = ["."]
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/go-ini/ini"
+  packages = ["."]
+  revision = "f280b3ba517bf5fc98922624f21fb0e7a92adaec"
+  version = "v1.30.3"
 
 [[projects]]
   branch = "master"
@@ -144,6 +156,18 @@
   name = "github.com/mailru/easyjson"
   packages = ["buffer","jlexer","jwriter"]
   revision = "2a92e673c9a6302dd05c3a691ae1f24aef46457d"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/minio/go-homedir"
+  packages = ["."]
+  revision = "21304a94172ae3a09dee2cd86a12fb6f842138c7"
+
+[[projects]]
+  name = "github.com/minio/minio-go"
+  packages = [".","pkg/credentials","pkg/encrypt","pkg/policy","pkg/s3signer","pkg/s3utils","pkg/set"]
+  revision = "4e0f567303d4cc90ceb055a451959fb9fc391fb9"
+  version = "3.0.3"
 
 [[projects]]
   branch = "master"
@@ -274,6 +298,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "abd8f296d9c048a8c4d27477621ef053f1d40c21a5d77c518c723f8f4b97ea02"
+  inputs-digest = "2a5ae27eff19d3bff3edb4afc1fdd28ee3d4eaeda6fb5d03dd0053c0300e1a10"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -17,3 +17,11 @@
 [[constraint]]
   name = "github.com/stretchr/testify"
   version = "1.1.4"
+
+[[constraint]]
+  name = "github.com/aws/aws-sdk-go"
+  version = "1.12.19"
+
+[[constraint]]
+  name = "github.com/minio/minio-go"
+  version = "3.0.2"

--- a/api/workflow/v1/types.go
+++ b/api/workflow/v1/types.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"fmt"
-
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/cmd/argoexec/commands/artifacts.go
+++ b/cmd/argoexec/commands/artifacts.go
@@ -1,7 +1,23 @@
 package commands
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	wfv1 "github.com/argoproj/argo/api/workflow/v1"
+	"github.com/argoproj/argo/errors"
+	"github.com/argoproj/argo/workflow/common"
+	"github.com/argoproj/argo/workflow/executor"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	//"k8s.io/client-go/tools/clientcmd"
+	//b64 "encoding/base64"
 )
 
 func init() {
@@ -23,6 +39,131 @@ var artifactsLoadCmd = &cobra.Command{
 	Run:   loadArtifacts,
 }
 
-func loadArtifacts(cmd *cobra.Command, args []string) {
+// Open the Kubernetes downward api file and
+// read the pod annotation file that contains template and then
+// unmarshal the template
+func GetTemplateFromPodAnnotations(annotationsPath string, template *wfv1.Template) error {
+	// Read the annotation file
+	file, err := os.Open(annotationsPath)
+	if err != nil {
+		fmt.Printf("ERROR opening annotation file from %s\n", annotationsPath)
+		return errors.InternalWrapError(err)
+	}
 
+	defer file.Close()
+	reader := bufio.NewReader(file)
+
+	// Prefix of template property in the annotation file
+	prefix := fmt.Sprintf("%s=", common.PodAnnotationsTemplatePropertyName)
+
+	for {
+		// Read line-by-line
+		var buffer bytes.Buffer
+
+		var l []byte
+		var isPrefix bool
+		for {
+			l, isPrefix, err = reader.ReadLine()
+			buffer.Write(l)
+
+			// If we've reached the end of the line, stop reading.
+			if !isPrefix {
+				break
+			}
+
+			// If we're just at the EOF, break
+			if err != nil {
+				break
+			}
+		}
+
+		// The end of the annotation file
+		if err == io.EOF {
+			break
+		}
+
+		line := buffer.String()
+
+		// Read template property
+		if strings.HasPrefix(line, prefix) {
+			// Trim the prefix
+			templateContent := strings.TrimPrefix(line, prefix)
+
+			// This part is a bit tricky in terms of unmarshalling
+			// The content in the file will be something like,
+			// `"{\"type\":\"container\",\"inputs\":{},\"outputs\":{}}"`
+			// which is required to unmarshal twice
+
+			// First unmarshal to a string without escaping characters
+			var templateString string
+			err = json.Unmarshal([]byte(templateContent), &templateString)
+			if err != nil {
+				fmt.Printf("Error unmarshalling annotation into template string, %s, %v\n", templateContent, err)
+				return errors.InternalWrapError(err)
+			}
+
+			// Second unmarshal to a template
+			err = json.Unmarshal([]byte(templateString), template)
+			if err != nil {
+				fmt.Printf("Error unmarshalling annotation into template, %s, %v\n", templateString, err)
+				return errors.InternalWrapError(err)
+			}
+			return nil
+		}
+	}
+
+	if err != io.EOF {
+		return errors.InternalWrapError(err)
+	}
+
+	// If reaching here, then no template prefix in the file
+	return errors.Errorf(errors.CodeInternal, "No template property found from annotation file: %s", annotationsPath)
+}
+
+func LoadInputArtifacts(template *wfv1.Template) error {
+	return nil
+}
+
+func loadArtifacts(cmd *cobra.Command, args []string) {
+	podAnnotationsPath := common.PodMetadataAnnotationsPath
+
+	// Use the path specified from the flag
+	if GlobalArgs.podAnnotationsPath != "" {
+		podAnnotationsPath = GlobalArgs.podAnnotationsPath
+	}
+
+	var wfTemplate wfv1.Template
+
+	// Read template
+	err := GetTemplateFromPodAnnotations(podAnnotationsPath, &wfTemplate)
+	if err != nil {
+		fmt.Printf("Error getting template %v\n", err)
+		os.Exit(1)
+	}
+
+	// Initialize in-cluster Kubernetes client
+	config, err := rest.InClusterConfig()
+	//config, err := clientcmd.BuildConfigFromFlags("", "/Users/Tianhe/.kube/cluster_minikube.conf")
+	if err != nil {
+		panic(err.Error())
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	// Initialize workflow executor
+	wfExecutor := executor.WorkflowExecutor{
+		Template:  wfTemplate,
+		ClientSet: clientset,
+	}
+
+	// Download input artifacts
+	err = wfExecutor.LoadArtifacts()
+	if err != nil {
+		fmt.Printf("Error downloading input artifacts, %v\n", err)
+		os.Exit(1)
+	}
+
+	os.Exit(0)
 }

--- a/cmd/argoexec/commands/artifacts.go
+++ b/cmd/argoexec/commands/artifacts.go
@@ -16,8 +16,6 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	//"k8s.io/client-go/tools/clientcmd"
-	//b64 "encoding/base64"
 )
 
 func init() {
@@ -54,7 +52,7 @@ func GetTemplateFromPodAnnotations(annotationsPath string, template *wfv1.Templa
 	reader := bufio.NewReader(file)
 
 	// Prefix of template property in the annotation file
-	prefix := fmt.Sprintf("%s=", common.PodAnnotationsTemplatePropertyName)
+	prefix := fmt.Sprintf("%s=", common.AnnotationKeyTemplate)
 
 	for {
 		// Read line-by-line
@@ -117,11 +115,7 @@ func GetTemplateFromPodAnnotations(annotationsPath string, template *wfv1.Templa
 	}
 
 	// If reaching here, then no template prefix in the file
-	return errors.Errorf(errors.CodeInternal, "No template property found from annotation file: %s", annotationsPath)
-}
-
-func LoadInputArtifacts(template *wfv1.Template) error {
-	return nil
+	return errors.InternalErrorf("No template property found from annotation file: %s", annotationsPath)
 }
 
 func loadArtifacts(cmd *cobra.Command, args []string) {
@@ -143,10 +137,10 @@ func loadArtifacts(cmd *cobra.Command, args []string) {
 
 	// Initialize in-cluster Kubernetes client
 	config, err := rest.InClusterConfig()
-	//config, err := clientcmd.BuildConfigFromFlags("", "/Users/Tianhe/.kube/cluster_minikube.conf")
 	if err != nil {
 		panic(err.Error())
 	}
+
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		panic(err.Error())

--- a/cmd/argoexec/commands/root.go
+++ b/cmd/argoexec/commands/root.go
@@ -18,7 +18,7 @@ var (
 	argoexec *executor.WorkflowExecutor
 
 	// Global CLI flags
-	globalArgs globalFlags
+	GlobalArgs globalFlags
 )
 
 func init() {
@@ -40,8 +40,8 @@ type globalFlags struct {
 }
 
 func init() {
-	RootCmd.PersistentFlags().StringVar(&globalArgs.hostIP, "host-ip", common.EnvVarHostIP, fmt.Sprintf("IP of host. (Default: %s)", common.EnvVarHostIP))
-	RootCmd.PersistentFlags().StringVar(&globalArgs.podAnnotationsPath, "pod-annotations", common.PodMetadataAnnotationsPath, fmt.Sprintf("Pod annotations fiel from k8s downward API. (Default: %s)", common.PodMetadataAnnotationsPath))
+	RootCmd.PersistentFlags().StringVar(&GlobalArgs.hostIP, "host-ip", common.EnvVarHostIP, fmt.Sprintf("IP of host. (Default: %s)", common.EnvVarHostIP))
+	RootCmd.PersistentFlags().StringVar(&GlobalArgs.podAnnotationsPath, "pod-annotations", common.PodMetadataAnnotationsPath, fmt.Sprintf("Pod annotations fiel from k8s downward API. (Default: %s)", common.PodMetadataAnnotationsPath))
 }
 
 // initExecutor is a helper to initialize the global argoexec instance

--- a/examples/input-artifact-s3.yaml
+++ b/examples/input-artifact-s3.yaml
@@ -12,8 +12,8 @@ spec:
         path: /src
         s3:
           endpoint: storage.googleapis.com
-          bucket: tianhe-test
-          key: testfile
+          bucket: my-bucket-name
+          key: path/in/bucket
           accessKeySecret:
             name: my-s3-credentials
             key: accessKey

--- a/examples/input-artifact-s3.yaml
+++ b/examples/input-artifact-s3.yaml
@@ -11,9 +11,9 @@ spec:
       - name: CODE
         path: /src
         s3:
-          endpoint: https://storage.googleapis.com
-          bucket: my-bucket-name
-          key: path/in/bucket
+          endpoint: storage.googleapis.com
+          bucket: tianhe-test
+          key: testfile
           accessKeySecret:
             name: my-s3-credentials
             key: accessKey

--- a/examples/install.yaml
+++ b/examples/install.yaml
@@ -4,7 +4,7 @@ metadata:
   name: workflow-controller-configmap
 data:
   config: |
-    executorImage: sytianhe/argoexec:latest
+    executorImage: argoproj/argoexec:latest
     artifactRepository:
       s3:
         bucket: my-bucket
@@ -16,32 +16,32 @@ data:
           name: my-s3-credentials
           key: secretKey
 
-#
-#---
-#apiVersion: apps/v1beta1
-#kind: Deployment
-#metadata:
-#  name: workflow-controller-deployment
-#spec:
-#  selector:
-#    matchLabels:
-#      app: workflow-controller
-#  template:
-#    metadata:
-#      labels:
-#        app: workflow-controller
-#    spec:
-#      containers:
-#      - name: workflow-controller
-#        image: argoproj/workflow-controller:latest
-#        command: [/bin/workflow-controller]
-#        args: [--configmap, workflow-controller-configmap]
-#
-#---
-#apiVersion: v1
-#kind: Secret
-#metadata:
-#  name: artifacts-s3-credentials
-#data:
-#  accessKey: AAABBBCCC01234567890
-#  secretKey: abc123XYZ456ABC123aaabbbcccddd1112223334
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: workflow-controller-deployment
+spec:
+  selector:
+    matchLabels:
+      app: workflow-controller
+  template:
+    metadata:
+      labels:
+        app: workflow-controller
+    spec:
+      containers:
+      - name: workflow-controller
+        image: argoproj/workflow-controller:latest
+        command: [/bin/workflow-controller]
+        args: [--configmap, workflow-controller-configmap]
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: artifacts-s3-credentials
+data:
+  accessKey: AAABBBCCC01234567890
+  secretKey: abc123XYZ456ABC123aaabbbcccddd1112223334

--- a/examples/install.yaml
+++ b/examples/install.yaml
@@ -4,43 +4,44 @@ metadata:
   name: workflow-controller-configmap
 data:
   config: |
-    executorImage: argoproj/argoexec:latest
+    executorImage: sytianhe/argoexec:latest
     artifactRepository:
       s3:
         bucket: my-bucket
         endpoint: https://storage.googleapis.com
         accessKeySecret:
-          name: artifacts-s3-credentials
+          name: my-s3-credentials
           key: accessKey
         secretKeySecret:
-          name: artifacts-s3-credentials
+          name: my-s3-credentials
           key: secretKey
 
----
-apiVersion: apps/v1beta1
-kind: Deployment
-metadata:
-  name: workflow-controller-deployment
-spec:
-  selector:
-    matchLabels:
-      app: workflow-controller
-  template:
-    metadata:
-      labels:
-        app: workflow-controller
-    spec:
-      containers:
-      - name: workflow-controller
-        image: argoproj/workflow-controller:latest
-        command: [/bin/workflow-controller]
-        args: [--configmap, workflow-controller-configmap]
-
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: artifacts-s3-credentials
-data:
-  accessKey: AAABBBCCC01234567890
-  secretKey: abc123XYZ456ABC123aaabbbcccddd1112223334
+#
+#---
+#apiVersion: apps/v1beta1
+#kind: Deployment
+#metadata:
+#  name: workflow-controller-deployment
+#spec:
+#  selector:
+#    matchLabels:
+#      app: workflow-controller
+#  template:
+#    metadata:
+#      labels:
+#        app: workflow-controller
+#    spec:
+#      containers:
+#      - name: workflow-controller
+#        image: argoproj/workflow-controller:latest
+#        command: [/bin/workflow-controller]
+#        args: [--configmap, workflow-controller-configmap]
+#
+#---
+#apiVersion: v1
+#kind: Secret
+#metadata:
+#  name: artifacts-s3-credentials
+#data:
+#  accessKey: AAABBBCCC01234567890
+#  secretKey: abc123XYZ456ABC123aaabbbcccddd1112223334

--- a/workflow/artifacts/artifacts.go
+++ b/workflow/artifacts/artifacts.go
@@ -1,9 +1,13 @@
 package executor
 
+import (
+	wfv1 "github.com/argoproj/argo/api/workflow/v1"
+)
+
 // ArtifactDriver is the interface for loading and saving of artifacts
 type ArtifactDriver interface {
 	// Load accepts an artifact source URL and places it at path
-	Load(sourceURL string, path string) error
+	Load(inputArtifact *wfv1.Artifact) error
 
 	// Save uploads the path to a destination URL
 	Save(path string, destURL string) (string, error)

--- a/workflow/artifacts/s3/s3.go
+++ b/workflow/artifacts/s3/s3.go
@@ -1,17 +1,48 @@
 package s3
 
+import (
+	"fmt"
+	"path"
+
+	wfv1 "github.com/argoproj/argo/api/workflow/v1"
+	"github.com/argoproj/argo/errors"
+	"github.com/argoproj/argo/workflow/common"
+	"github.com/minio/minio-go"
+)
+
+// S3ArtifactDriver is a driver for AWS S3
 type S3ArtifactDriver struct {
-	Endpoint  string
 	AccessKey string
 	SecretKey string
 }
 
-func (s3 *S3ArtifactDriver) Load(sourceURL string, path string) error {
+// Download artifacts from S3 compliant storage using Minio Go SDK
+func (s3Driver *S3ArtifactDriver) Load(inputArtifact *wfv1.Artifact) error {
+	// Todo: need to handle volumes if the container uses volumes
+	// File path to save the artifact
+	artPath := path.Join(common.ExecutorArtifactBaseDir, inputArtifact.Name)
 
+	// Initialize minio client object.
+	minioClient, err := minio.New(inputArtifact.S3.Endpoint, s3Driver.AccessKey, s3Driver.SecretKey, true)
+
+	if err != nil {
+		fmt.Println("Failed to initialize Minio client")
+		return errors.InternalWrapError(err)
+	}
+
+	// Download the file to a local file path
+	err = minioClient.FGetObject(inputArtifact.S3.Bucket, inputArtifact.S3.Key, artPath)
+
+	if err != nil {
+		fmt.Printf("Failed to download input artifact, %s\n", artPath)
+		return errors.InternalWrapError(err)
+	}
+
+	fmt.Printf("Successfully download file, %s\n", artPath)
 	return nil
 }
 
-func (s3 *S3ArtifactDriver) Save(path string, destURL string) (string, error) {
+func (s3Driver *S3ArtifactDriver) Save(path string, destURL string) (string, error) {
 
 	return destURL, nil
 }

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -27,6 +27,8 @@ const (
 	PodMetadataAnnotationsPath = PodMetadataMountPath + "/" + PodMetadataAnnotationsVolumePath
 	//
 	PodStatusVolumePath = "podstatus"
+	// PodAnnotationsTemplatePropertyName is the property name for template in the annotation file
+	PodAnnotationsTemplatePropertyName = "workflows.argoproj.io/template"
 
 	// DockerLibVolumeName is the volume name for the /var/lib/docker host path volume
 	DockerLibVolumeName = "docker-lib"

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -27,8 +27,6 @@ const (
 	PodMetadataAnnotationsPath = PodMetadataMountPath + "/" + PodMetadataAnnotationsVolumePath
 	//
 	PodStatusVolumePath = "podstatus"
-	// PodAnnotationsTemplatePropertyName is the property name for template in the annotation file
-	PodAnnotationsTemplatePropertyName = "workflows.argoproj.io/template"
 
 	// DockerLibVolumeName is the volume name for the /var/lib/docker host path volume
 	DockerLibVolumeName = "docker-lib"

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -301,6 +301,7 @@ func (woc *wfOperationCtx) addInputArtifactsVolumes(pod *apiv1.Pod, tmpl *wfv1.T
 
 			// HACK: debug purposes. sleep to experiment with init container artifacts
 			initCtr.Command = []string{"sh", "-c"}
+			//initCtr.Args = []string{"argoexec artifacts load"}
 			initCtr.Args = []string{"sleep 999999; echo done"}
 
 			pod.Spec.InitContainers[i] = initCtr

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -1,23 +1,65 @@
 package executor
 
 import (
-	"path"
-
+	"fmt"
 	wfv1 "github.com/argoproj/argo/api/workflow/v1"
-	artifacts "github.com/argoproj/argo/workflow/artifacts"
-	"github.com/argoproj/argo/workflow/common"
+	"github.com/argoproj/argo/errors"
+	artifact "github.com/argoproj/argo/workflow/artifacts"
+	"github.com/argoproj/argo/workflow/artifacts/s3"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
+// Executor implements the mechanisms within a single Kubernetes pod
 type WorkflowExecutor struct {
-	Template       wfv1.Template
-	ArtifactDriver artifacts.ArtifactDriver
-	//kubeletCl
+	Template  wfv1.Template
+	ClientSet *kubernetes.Clientset
+}
+
+// Use Kubernetes client to retrieve the Kubernetes secrets
+func (we *WorkflowExecutor) getSecrets(namespace string, name string, key string) (string, error) {
+	secrets, err := we.ClientSet.CoreV1().Secrets(namespace).Get(name, metav1.GetOptions{})
+
+	if err != nil {
+		return "", errors.InternalWrapError(err)
+	}
+
+	return string(secrets.Data[key]), nil
 }
 
 func (we *WorkflowExecutor) LoadArtifacts() error {
-	for artName, art := range we.Template.Inputs.Artifacts {
-		artPath := path.Join(common.ExecutorArtifactBaseDir, artName)
-		we.ArtifactDriver.Load(string(art.From), artPath)
+	fmt.Println("Start loading input artifacts...")
+
+	// Todo get the current namespace from environment variable
+	namespace := apiv1.NamespaceDefault
+	for _, art := range we.Template.Inputs.Artifacts {
+		fmt.Printf("Downloading artifact, %s\n", art.Name)
+		var artDriver artifact.ArtifactDriver
+		if art.S3 != nil {
+			accessKey, err := we.getSecrets(namespace, art.S3.AccessKeySecret.Name, art.S3.AccessKeySecret.Key)
+			if err != nil {
+				return err
+			}
+			secretKey, err := we.getSecrets(namespace, art.S3.SecretKeySecret.Name, art.S3.SecretKeySecret.Key)
+			if err != nil {
+				return err
+			}
+			artDriver = &s3.S3ArtifactDriver{
+				AccessKey: accessKey,
+				SecretKey: secretKey,
+			}
+		} else {
+			fmt.Printf("Do not support input artifact type other than S3, did not download artifact, %s/n", art.Name)
+			// Todo currently only support S3
+			//return errors.Errorf(errors.CodeInternal, "Do not support input artifact type other than S3 for artifact, %s", artName)
+			return nil
+		}
+
+		err := artDriver.Load(&art)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
- Argo executor init container first commit
- Init container is responsible for downloading input artifacts for the user container
- Reading the Kubernetes downward api to interpret the workflow template (annotation file)
- Using minio go sdk to support private (minio), aws s3 and google api.