### PR TITLE
Introduce Template.ArchiveLocation to store all related step level artifacts to a job, understood by executor

### DIFF
--- a/cmd/argoexec/commands/root.go
+++ b/cmd/argoexec/commands/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/argoproj/argo"
 	wfv1 "github.com/argoproj/argo/api/workflow/v1"
 	"github.com/argoproj/argo/util/cmd"
 	"github.com/argoproj/argo/workflow/common"
@@ -82,6 +83,6 @@ func initExecutor() *executor.WorkflowExecutor {
 		ClientSet: clientset,
 	}
 	yamlBytes, _ := yaml.Marshal(&wfExecutor.Template)
-	log.Infof("Executor initialized with template:\n%s", string(yamlBytes))
+	log.Infof("Executor (version: %s) initialized with template:\n%s", argo.FullVersion, string(yamlBytes))
 	return &wfExecutor
 }


### PR DESCRIPTION
Adds a field in template to indicate the archive path for all step level artifacts. Populated by default in the controller, but can be overridden in template manifest. Teach executor to understand and handle the archive location, enabling users to override where their artifacts should reside.