### PR TITLE
Restore and formalize sidecar kill functionality as part of executor

### DIFF
--- a/cmd/argo/commands/list.go
+++ b/cmd/argo/commands/list.go
@@ -44,12 +44,21 @@ func listWorkflows(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-	fmt.Fprintln(w, "NAME\tSTATUS\tAGE")
+	if listArgs.allNamespaces {
+		fmt.Fprintln(w, "NAMESPACE\tNAME\tSTATUS\tAGE")
+	} else {
+		fmt.Fprintln(w, "NAME\tSTATUS\tAGE")
+	}
+
 	for _, wf := range wfList.Items {
 		cTime := time.Unix(wf.ObjectMeta.CreationTimestamp.Unix(), 0)
 		now := time.Now()
 		hrTimeDiff := humanize.RelTime(cTime, now, "", "")
-		fmt.Fprintf(w, "%s\t%s\t%s\n", wf.ObjectMeta.Name, worklowStatus(&wf), hrTimeDiff)
+		if listArgs.allNamespaces {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", wf.ObjectMeta.Namespace, wf.ObjectMeta.Name, worklowStatus(&wf), hrTimeDiff)
+		} else {
+			fmt.Fprintf(w, "%s\t%s\t%s\n", wf.ObjectMeta.Name, worklowStatus(&wf), hrTimeDiff)
+		}
 	}
 	w.Flush()
 }

--- a/cmd/argoexec/commands/root.go
+++ b/cmd/argoexec/commands/root.go
@@ -79,12 +79,17 @@ func initExecutor() *executor.WorkflowExecutor {
 	if !ok {
 		log.Fatalf("Unable to determine pod name from environment variable %s", common.EnvVarPodName)
 	}
+	namespace, ok := os.LookupEnv(common.EnvVarNamespace)
+	if !ok {
+		log.Fatalf("Unable to determine pod namespace from environment variable %s", common.EnvVarNamespace)
+	}
 
 	// Initialize workflow executor
 	wfExecutor := executor.WorkflowExecutor{
 		PodName:   podName,
 		Template:  wfTemplate,
 		ClientSet: clientset,
+		Namespace: namespace,
 	}
 	yamlBytes, _ := yaml.Marshal(&wfExecutor.Template)
 	log.Infof("Executor (version: %s) initialized with template:\n%s", argo.FullVersion, string(yamlBytes))

--- a/cmd/argoexec/commands/sidecar.go
+++ b/cmd/argoexec/commands/sidecar.go
@@ -29,8 +29,8 @@ var sidecarWaitCmd = &cobra.Command{
 
 func waitContainer(cmd *cobra.Command, args []string) {
 	wfExecutor := initExecutor()
-	// Wait for main container to be ready
-	err := wfExecutor.WaitForReady()
+	// Wait for main container to complete and kill sidecars
+	err := wfExecutor.Wait()
 
 	// Todo: Decide wether to always exit non-zero if error happens in the sidecar
 	if err != nil {

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -262,6 +262,9 @@ func (wfc *WorkflowController) handlePodUpdate(pod *apiv1.Pod) {
 		f := false
 		newDaemonStatus = &f
 	case apiv1.PodFailed:
+		// TODO: we may need to distinguish between the main container suceeding and ignoring the sidekick
+		// statuses. This is because executor may have had to forcibly kill a sidekick resulting in an
+		// overall pod status as failed, but we really only care about the main container status.
 		newStatus = wfv1.NodeStatusFailed
 		f := false
 		newDaemonStatus = &f


### PR DESCRIPTION
Restores the functionality of executor killing a sidecar as part of the `wait` command