### PR TITLE
Add support for output as parameter

### DIFF
--- a/api/workflow/v1/types.go
+++ b/api/workflow/v1/types.go
@@ -92,6 +92,7 @@ type Parameter struct {
 	Name    string  `json:"name"`
 	Value   *string `json:"value,omitempty"`
 	Default *string `json:"default,omitempty"`
+	Path    string  `json:"path,omitempty"`
 }
 
 // Artifact indicates an artifact to place at a specified path

--- a/cmd/argoexec/commands/artifacts.go
+++ b/cmd/argoexec/commands/artifacts.go
@@ -139,10 +139,17 @@ func loadArtifacts(cmd *cobra.Command, args []string) {
 
 func saveArtifacts(cmd *cobra.Command, args []string) {
 	wfExecutor := initExecutor()
+	// Saving output artifacts
 	err := wfExecutor.SaveArtifacts()
 	if err != nil {
 		log.Fatalf("Error saving output artifacts, %+v", err)
 	}
+	// Saving output parameters
+	err = wfExecutor.SaveParameters()
+	if err != nil {
+		log.Fatalf("Error saving output parameters, %+v", err)
+	}
+	// Capture output script result
 	err = wfExecutor.CaptureScriptResult()
 	if err != nil {
 		log.Fatalf("Error capturing script output, %+v", err)

--- a/examples/output-parameter.yaml
+++ b/examples/output-parameter.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1
+kind: Workflow
+metadata:
+  generateName: output-artifact-
+spec:
+  entrypoint: whalesay
+  templates:
+  - name: whalesay
+    container:
+      image: docker/whalesay:latest
+      command: [sh, -c]
+      args: ["echo -n hello world > /tmp/hello_world.txt"]
+    outputs:
+      # Output as parameters, this enables user to store certain file content
+      # into a parameter. In the other steps, user can reference this parameter
+      parameters:
+      - name: message
+        path: /tmp/hello_world.txt

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -186,6 +186,47 @@ func (we *WorkflowExecutor) SaveArtifacts() error {
 	return nil
 }
 
+// SaveParameters will save the content in the specified file path as output parameter value
+func (we *WorkflowExecutor) SaveParameters() error {
+	log.Infof("Saving output parameters")
+	if len(we.Template.Outputs.Parameters) == 0 {
+		log.Infof("No output parameters, nothing to do")
+		return nil
+	}
+	mainCtrID, err := we.GetMainContainerID()
+	if err != nil {
+		return err
+	}
+	log.Infof("Main container identified as: %s", mainCtrID)
+
+	for i, param := range we.Template.Outputs.Parameters {
+		log.Infof("Saving out parameter: %s", param.Name)
+		// Determine the file path of where to find the parameter
+		if param.Path == "" {
+			return errors.InternalErrorf("Output parameter %s did not specify a file path", param.Name)
+		}
+		// Use docker cp command to print out the content of the file
+		// Node docker cp CONTAINER:SRC_PATH DEST_PATH|- streams the contents of the resource
+		// as a tar archive to STDOUT if using - as DEST_PATH. Thus, we need to extract the
+		// content from the tar archive and output into stdout. In this way, we do not need to
+		// create and copy the content into a file from the wait container.
+		dockerCpCmd := fmt.Sprintf("docker cp -a %s:%s - | tar -ax -O", mainCtrID, param.Path)
+		cmd := exec.Command("sh", "-c", dockerCpCmd)
+		log.Info(cmd.Args)
+		out, err := cmd.Output()
+		if err != nil {
+			if exErr, ok := err.(*exec.ExitError); ok {
+				log.Errorf("`%s` stderr:\n%s", cmd.Args, string(exErr.Stderr))
+			}
+			return errors.InternalWrapError(err)
+		}
+		output := string(out)
+		we.Template.Outputs.Parameters[i].Value = &output
+		log.Infof("Successfully saved output parameter: %s", param.Name)
+	}
+	return nil
+}
+
 func (we *WorkflowExecutor) InitDriver(art wfv1.Artifact) (artifact.ArtifactDriver, error) {
 	if art.S3 != nil {
 		// Getting Kubernetes namespace from the environment variables


### PR DESCRIPTION
- Output as parameter will get content from a user-specified file and save as output parameter
- The parameter then can be referenced from the later steps