### PR TITLE
Harden the IsURL check

### DIFF
--- a/util/cmd/cmd.go
+++ b/util/cmd/cmd.go
@@ -44,6 +44,14 @@ func MustHomeDir() string {
 
 // IsURL returns whether or not a string is a URL
 func IsURL(u string) bool {
-	_, err := url.ParseRequestURI(u)
-	return err == nil
+	var parsedURL *url.URL
+	var err error
+
+	parsedURL, err = url.ParseRequestURI(u)
+	if err == nil {
+		if parsedURL != nil && parsedURL.Host != "" {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
The IsURL check simply called url.ParseRequestURI and relied on whether it errors
or not to detect whether the given string is a url or not. Turns out that
url.ParseRequestURI does not error out if the given string is a complete
filesystem path /path/to/file.

This commit hardens the IsURL check. It checks whether the returned URL object
by url.ParseRequestURI() has an actual Host component or not. If not, isURL returns
false.

Testing Done:

* argo submit failed with a full-path prior to this change. Worked after.

* argo submit succeeded with a url before and after.


Refs #509.