### PR TITLE
Add example of GIF processing using ImageMagick

### DIFF
--- a/examples/fun_with_gifs.yaml
+++ b/examples/fun_with_gifs.yaml
@@ -1,0 +1,101 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+    generateName: fun-with-gifs-
+spec:
+  entrypoint: run-workflow
+  volumeClaimTemplates:
+  - metadata:
+      name: workdir
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi
+  templates:
+  - name: run-workflow
+    steps:
+    - - name: step 1
+        template: create-output-dir
+    - - name: step 2
+        template: download-images
+    - - name: step 3
+        template: create-gif
+    - - name: step 4
+        template: black-and-white
+    - - name: step 5.1
+        template: combine-horizontal
+      - name: step 5.2
+        template: combine-vertical
+    - - name: step 6
+        template: make-bigger
+    - - name: step 7
+        template: bundle-up
+
+  - name: create-output-dir
+    container:
+      image: alpine:3.6
+      command: ["mkdir", "/mnt/data/output"]
+      volumeMounts:
+      - name: workdir
+        mountPath: /mnt/data
+
+  - name: download-images
+    container:
+      image: mesosphere/aws-cli
+      command: ["aws", "--no-sign-request", "s3", "cp", "--recursive", "s3://argo-sample-data-public/cricket_gif_images", "/mnt/data/"]
+      volumeMounts:
+      - name: workdir
+        mountPath: /mnt/data
+
+  - name: create-gif
+    container:
+      image: v4tech/imagemagick
+      command: ["convert", "-delay", "20", "-loop", "0", "/mnt/data/*.gif", "/mnt/data/output/orig.gif"]
+      volumeMounts:
+      - name: workdir
+        mountPath: /mnt/data
+
+  - name: black-and-white
+    container:
+      image: v4tech/imagemagick
+      command: ["convert", "/mnt/data/output/orig.gif", "-colorspace", "Gray", "/mnt/data/output/black_white.gif"]
+      volumeMounts:
+      - name: workdir
+        mountPath: /mnt/data
+
+  - name: combine-horizontal
+    container:
+      image: v4tech/imagemagick
+      command: ["convert", "+append", "/mnt/data/*.gif", "/mnt/data/output/horizontal.gif"]
+      volumeMounts:
+      - name: workdir
+        mountPath: /mnt/data
+
+  - name: combine-vertical
+    container:
+      image: v4tech/imagemagick
+      command: ["convert", "-append", "/mnt/data/*.gif", "/mnt/data/output/vertical.gif"]
+      volumeMounts:
+      - name: workdir
+        mountPath: /mnt/data
+
+  - name: make-bigger
+    container:
+      image: starefossen/gifsicle
+      command: ["gifsicle", "/mnt/data/output/orig.gif", "--resize", "1000x800", "-o", "/mnt/data/output/orig_big.gif"]
+      volumeMounts:
+      - name: workdir
+        mountPath: /mnt/data
+
+  - name: bundle-up
+    container:
+      image: alpine:3.6
+      command: ["ls"]
+      volumeMounts:
+      - name: workdir
+        mountPath: /mnt/data
+    outputs:
+      artifacts:
+      - name: output_gif
+        path: /mnt/data/output


### PR DESCRIPTION
This commit adds an example of processing gifs using ImageMagick and gifsicle.
The workflow creates a PVC that is used for locally storing the downloaded
images and then running 'convert' and 'gifsicle' on these images.

The output gets written in the PV itself in a "output" directory. This directory
is then considered as an artifact and uploaded to the cloud.