### PR TITLE
Fix tests.

### DIFF
--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -17,14 +17,14 @@ type stackTracer interface {
 // TestErrorf tests the initializer of error package
 func TestErrorf(t *testing.T) {
 	err := errors.Errorf(errors.CodeInternal, "test internal")
-	assert.Equal(t, err.Error(), "[ERR_INTERNAL] test internal")
+	assert.Equal(t, err.Error(), "test internal")
 }
 
 // TestWrap ensures we can wrap an error and use Cause() to retrieve the original error
 func TestWrap(t *testing.T) {
 	err := fmt.Errorf("original error message")
 	argoErr := errors.Wrap(err, "WRAPPED", "wrapped message")
-	assert.Equal(t, "[WRAPPED] wrapped message", argoErr.Error())
+	assert.Equal(t, "wrapped message", argoErr.Error())
 	orig := errors.Cause(argoErr)
 	assert.Equal(t, err.Error(), orig.Error())
 }
@@ -32,19 +32,19 @@ func TestWrap(t *testing.T) {
 // TestInternalError verifies
 func TestInternalError(t *testing.T) {
 	err := errors.InternalError("test internal")
-	assert.Equal(t, "[ERR_INTERNAL] test internal", err.Error())
+	assert.Equal(t, "test internal", err.Error())
 
 	// Test wrapping errors
 	err = fmt.Errorf("random error")
 	intWrap := errors.InternalWrapError(err)
 	_ = intWrap.(stackTracer)
-	assert.Equal(t, "[ERR_INTERNAL] random error", intWrap.Error())
+	assert.Equal(t, "random error", intWrap.Error())
 	intWrap = errors.InternalWrapError(err, "different message")
 	_ = intWrap.(stackTracer)
-	assert.Equal(t, "[ERR_INTERNAL] different message", intWrap.Error())
+	assert.Equal(t, "different message", intWrap.Error())
 	intWrap = errors.InternalWrapErrorf(err, "hello %s", "world")
 	_ = intWrap.(stackTracer)
-	assert.Equal(t, "[ERR_INTERNAL] hello world", intWrap.Error())
+	assert.Equal(t, "hello world", intWrap.Error())
 }
 
 func TestStackTrace(t *testing.T) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -2,6 +2,43 @@ package e2e
 
 import (
 	"flag"
+	"os"
+	"path/filepath"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 var kubeConfig = flag.String("kubeconfig", "", "Path to Kubernetes config file")
+
+func homeDir() string {
+	if h := os.Getenv("HOME"); h != "" {
+		return h
+	}
+	return os.Getenv("USERPROFILE") // windows
+}
+
+func getKubernetesClient() *kubernetes.Clientset {
+	if *kubeConfig == "" {
+		if home := homeDir(); home != "" {
+			k := filepath.Join(home, ".kube", "config")
+			kubeConfig = &k
+		} else {
+			panic("Failed to find kubeConfig")
+		}
+	}
+
+	// use the current context in kubeconfig
+	config, err := clientcmd.BuildConfigFromFlags("", *kubeConfig)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	// create the clientset
+	clientSet, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	return clientSet
+}

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -6,29 +6,17 @@ import (
 
 	"github.com/argoproj/argo/cmd/argo/commands"
 	"github.com/argoproj/argo/workflow/common"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func checkIfInstalled() bool {
-	// use the current context in kubeconfig
-	config, err := clientcmd.BuildConfigFromFlags("", *kubeConfig)
-	if err != nil {
-		panic(err.Error())
-	}
-
-	// create the clientset
-	clientSet, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		panic(err.Error())
-	}
+	clientSet := getKubernetesClient()
 
 	// TODO(shri): Create a new namespace and simply install in that.
 	// Verify that Argo doesn't exist in the Kube-system namespace
-	_, err = clientSet.AppsV1beta2().Deployments(common.DefaultControllerNamespace).Get(
+	_, err := clientSet.AppsV1beta2().Deployments(common.DefaultControllerNamespace).Get(
 		common.DefaultControllerDeploymentName, metav1.GetOptions{})
 	if err == nil {
 		fmt.Println("Argo already installed...")

--- a/workflow/common/validate_test.go
+++ b/workflow/common/validate_test.go
@@ -67,7 +67,9 @@ spec:
     inputs:
       parameters:
       - name: dup
+        value: "value"
       - name: dup
+        value: "value"
     container:
       image: docker/whalesay:latest
 `
@@ -84,6 +86,7 @@ spec:
     inputs:
       parameters:
       - name: ""
+        value: "value"
     container:
       image: docker/whalesay:latest
 `
@@ -136,6 +139,7 @@ spec:
     inputs:
       parameters:
       - name: message
+        value: "value"
     container:
       image: docker/whalesay:latest
     outputs:


### PR DESCRIPTION
```
$ go test -v ./...argo list
can't load package: package list: cannot find package "list" in any of:
    /usr/local/Cellar/go/1.9.2/libexec/src/list (from $GOROOT)
    /Users/shri/ws/go/src/list (from $GOPATH)
shri@argo:[13:56](gke) go test -v ./...
shri@argo:[13:56](gke) go test -v ./...
?       github.com/argoproj/argo    [no test files]
?       github.com/argoproj/argo/api/workflow/v1alpha1    [no test files]
?       github.com/argoproj/argo/apiserver    [no test files]
?       github.com/argoproj/argo/apiserver/schema    [no test files]
?       github.com/argoproj/argo/cmd/argo    [no test files]
?       github.com/argoproj/argo/cmd/argo/commands    [no test files]
?       github.com/argoproj/argo/cmd/argo-apiserver    [no test files]
?       github.com/argoproj/argo/cmd/argoexec    [no test files]
?       github.com/argoproj/argo/cmd/argoexec/commands    [no test files]
?       github.com/argoproj/argo/cmd/workflow-controller    [no test files]
=== RUN   TestErrorf
--- PASS: TestErrorf (0.00s)
=== RUN   TestWrap
--- PASS: TestWrap (0.00s)
=== RUN   TestInternalError
--- PASS: TestInternalError (0.00s)
=== RUN   TestStackTrace
--- PASS: TestStackTrace (0.00s)
PASS
ok      github.com/argoproj/argo/errors    0.019s
=== RUN   TestInstall
Installing into namespace 'kube-system'
Proceeding with Kubernetes version 1.8.4-gke.0
CustomResourceDefinition 'workflows.argoproj.io' created
ServiceAccount 'argo' created
ClusterRoleBinding 'argo-cluster-role' created, bound 'argo' to 'cluster-admin'
ConfigMap 'workflow-controller-configmap' created
Using service account 'argo' for deployments
Deployment 'workflow-controller' created
Deployment 'argo-ui' created
--- PASS: TestInstall (1.01s)
=== RUN   TestRunWorkflowBasic
Name:             my-test
Namespace:        default
Status:           Pending
Created:          Wed Dec 06 13:56:30 -0800 (now)
Workflow my-test completed successfully--- PASS: TestRunWorkflowBasic (0.10s)
PASS
ok      github.com/argoproj/argo/test/e2e    1.258s
?       github.com/argoproj/argo/util/cmd    [no test files]
?       github.com/argoproj/argo/workflow/artifacts    [no test files]
?       github.com/argoproj/argo/workflow/artifacts/git    [no test files]
?       github.com/argoproj/argo/workflow/artifacts/http    [no test files]
?       github.com/argoproj/argo/workflow/artifacts/s3    [no test files]
?       github.com/argoproj/argo/workflow/client    [no test files]
=== RUN   TestUnknownField
--- SKIP: TestUnknownField (0.00s)
    validate_test.go:35: Cannot detect unknown fields yet
=== RUN   TestDuplicateOrEmptyNames
--- PASS: TestDuplicateOrEmptyNames (0.00s)
=== RUN   TestUnresolved
--- PASS: TestUnresolved (0.00s)
=== RUN   TestStepReference
--- PASS: TestStepReference (0.00s)
=== RUN   TestUnsatisfiedParam
--- PASS: TestUnsatisfiedParam (0.00s)
PASS
ok      github.com/argoproj/argo/workflow/common    0.067s
?       github.com/argoproj/argo/workflow/controller    [no test files]
?       github.com/argoproj/argo/workflow/executor    [no test files]