### PR TITLE
Multiple scalability improvements to controller

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -50,6 +50,12 @@
   version = "1.0.1"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/evanphx/json-patch"
+  packages = ["."]
+  revision = "944e07253867aacae43c04b2e6a239005443f33a"
+
+[[projects]]
   name = "github.com/ghodss/yaml"
   packages = ["."]
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
@@ -188,12 +194,6 @@
   version = "3.0.3"
 
 [[projects]]
-  name = "github.com/patrickmn/go-cache"
-  packages = ["."]
-  revision = "a3647f8e31d79543b2d0f0ae2fe5c379d72cedc0"
-  version = "v2.1.0"
-
-[[projects]]
   branch = "master"
   name = "github.com/petar/GoLLRB"
   packages = ["llrb"]
@@ -322,7 +322,7 @@
 [[projects]]
   branch = "release-5.0"
   name = "k8s.io/client-go"
-  packages = ["discovery","kubernetes","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/apps/v1beta1","kubernetes/typed/apps/v1beta2","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1beta1","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v2beta1","kubernetes/typed/batch/v1","kubernetes/typed/batch/v1beta1","kubernetes/typed/batch/v2alpha1","kubernetes/typed/certificates/v1beta1","kubernetes/typed/core/v1","kubernetes/typed/extensions/v1beta1","kubernetes/typed/networking/v1","kubernetes/typed/policy/v1beta1","kubernetes/typed/rbac/v1","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1beta1","kubernetes/typed/scheduling/v1alpha1","kubernetes/typed/settings/v1alpha1","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1beta1","pkg/version","plugin/pkg/client/auth/gcp","rest","rest/watch","third_party/forked/golang/template","tools/auth","tools/cache","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/metrics","tools/pager","tools/reference","tools/remotecommand","transport","transport/spdy","util/cert","util/exec","util/flowcontrol","util/homedir","util/integer","util/jsonpath"]
+  packages = ["discovery","kubernetes","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/apps/v1beta1","kubernetes/typed/apps/v1beta2","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1beta1","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v2beta1","kubernetes/typed/batch/v1","kubernetes/typed/batch/v1beta1","kubernetes/typed/batch/v2alpha1","kubernetes/typed/certificates/v1beta1","kubernetes/typed/core/v1","kubernetes/typed/extensions/v1beta1","kubernetes/typed/networking/v1","kubernetes/typed/policy/v1beta1","kubernetes/typed/rbac/v1","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1beta1","kubernetes/typed/scheduling/v1alpha1","kubernetes/typed/settings/v1alpha1","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1beta1","pkg/version","plugin/pkg/client/auth/gcp","rest","rest/watch","third_party/forked/golang/template","tools/auth","tools/cache","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/metrics","tools/pager","tools/reference","tools/remotecommand","transport","transport/spdy","util/cert","util/exec","util/flowcontrol","util/homedir","util/integer","util/jsonpath","util/workqueue"]
   revision = "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
 
 [[projects]]
@@ -334,6 +334,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d88d04abf40902c38a8af161ff9af4b73f8ff14d96aeef5111972926f414f6d8"
+  inputs-digest = "50fe255da32bfb1b1fdf6eb51ce135d161d394942c66b99432f3b359f6cb35e0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -14,6 +14,7 @@ const (
 	CodeBadRequest   = "ERR_BAD_REQUEST"
 	CodeForbidden    = "ERR_FORBIDDEN"
 	CodeNotFound     = "ERR_NOT_FOUND"
+	CodeTimeout      = "ERR_TIMEOUT"
 	CodeInternal     = "ERR_INTERNAL"
 )
 
@@ -148,4 +149,13 @@ func (e argoerr) Format(s fmt.State, verb rune) {
 	case 'q':
 		fmt.Fprintf(s, "%q", e.Error())
 	}
+}
+
+// IsCode is a helper to determine if the error is of a specific code
+func IsCode(code string, err error) bool {
+	if argoErr, ok := err.(argoerr); ok {
+		return argoErr.code == code
+	}
+	return false
+
 }

--- a/workflow/client/client.go
+++ b/workflow/client/client.go
@@ -5,6 +5,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	// load the gcp plugin (required to authenticate against GKE clusters).
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -48,7 +49,8 @@ func NewWorkflowClient(cl *rest.RESTClient, scheme *runtime.Scheme, namespace st
 func (f *WorkflowClient) CreateWorkflow(obj *wfv1.Workflow) (*wfv1.Workflow, error) {
 	var result wfv1.Workflow
 	err := f.cl.Post().
-		Namespace(f.namespace).Resource(wfv1.CRDPlural).
+		Namespace(f.namespace).
+		Resource(wfv1.CRDPlural).
 		Body(obj).Do().Into(&result)
 	return &result, err
 }
@@ -57,7 +59,8 @@ func (f *WorkflowClient) UpdateWorkflow(obj *wfv1.Workflow) (*wfv1.Workflow, err
 	var result wfv1.Workflow
 	err := f.cl.Put().
 		Name(obj.ObjectMeta.Name).
-		Namespace(f.namespace).Resource(wfv1.CRDPlural).
+		Namespace(f.namespace).
+		Resource(wfv1.CRDPlural).
 		Body(obj).Do().Into(&result)
 	return &result, err
 }
@@ -65,7 +68,8 @@ func (f *WorkflowClient) UpdateWorkflow(obj *wfv1.Workflow) (*wfv1.Workflow, err
 func (f *WorkflowClient) DeleteWorkflow(name string, options *metav1.DeleteOptions) error {
 	return f.cl.Delete().
 		Name(name).
-		Namespace(f.namespace).Resource(wfv1.CRDPlural).
+		Namespace(f.namespace).
+		Resource(wfv1.CRDPlural).
 		Body(options).Do().
 		Error()
 }
@@ -73,15 +77,30 @@ func (f *WorkflowClient) DeleteWorkflow(name string, options *metav1.DeleteOptio
 func (f *WorkflowClient) GetWorkflow(name string) (*wfv1.Workflow, error) {
 	var result wfv1.Workflow
 	err := f.cl.Get().
-		Namespace(f.namespace).Resource(wfv1.CRDPlural).
+		Namespace(f.namespace).
+		Resource(wfv1.CRDPlural).
 		Name(name).Do().Into(&result)
+	return &result, err
+}
+
+// PatchWorkflow applies the patch and returns the patched workflow.
+func (f *WorkflowClient) PatchWorkflow(name string, pt types.PatchType, data []byte, subresources ...string) (*wfv1.Workflow, error) {
+	var result wfv1.Workflow
+	err := f.cl.Patch(pt).
+		Namespace(f.namespace).
+		Resource(wfv1.CRDPlural).
+		SubResource(subresources...).
+		Name(name).
+		Body(data).
+		Do().Into(&result)
 	return &result, err
 }
 
 func (f *WorkflowClient) ListWorkflows(opts metav1.ListOptions) (*wfv1.WorkflowList, error) {
 	var result wfv1.WorkflowList
 	err := f.cl.Get().
-		Namespace(f.namespace).Resource(wfv1.CRDPlural).
+		Namespace(f.namespace).
+		Resource(wfv1.CRDPlural).
 		VersionedParams(&opts, f.codec).
 		Do().Into(&result)
 	return &result, err


### PR DESCRIPTION
1. Switch to using SharedIndexInformer to provide shared resource
   state with other controllers.
2. Use workqueue in lieue of channels which prevents work backlog,
   stale state, true concurrency, and enable future improvements
   such as rate limited retry and backoff.
3. Add ability to PATCH workflows to prevent errors related to having
   too old resource versions.
4. Pod updates no longer result in an 1:1 workflow update and instead
   adds the workflow name back to the workqueue. This allow database
   updates to be batched in a single db update.