### PR TITLE
Skip e2e tests if Kubeconfig is not provided.

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -2,8 +2,6 @@ package e2e
 
 import (
 	"flag"
-	"os"
-	"path/filepath"
 
 	"github.com/argoproj/argo/cmd/argo/commands"
 	"github.com/argoproj/argo/workflow/common"
@@ -15,21 +13,9 @@ import (
 
 var kubeConfig = flag.String("kubeconfig", "", "Path to Kubernetes config file")
 
-func homeDir() string {
-	if h := os.Getenv("HOME"); h != "" {
-		return h
-	}
-	return os.Getenv("USERPROFILE") // windows
-}
-
 func getKubernetesClient() *kubernetes.Clientset {
 	if *kubeConfig == "" {
-		if home := homeDir(); home != "" {
-			k := filepath.Join(home, ".kube", "config")
-			kubeConfig = &k
-		} else {
-			panic("Failed to find kubeConfig")
-		}
+		panic("Kubeconfig not provided")
 	}
 
 	// use the current context in kubeconfig

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -18,6 +18,12 @@ type InstallSuite struct {
 	testNamespace string
 }
 
+func (suite *InstallSuite) SetupSuite() {
+	if *kubeConfig == "" {
+		suite.T().Skip("Skipping test. Kubeconfig not provided")
+	}
+}
+
 // Make sure that a new namespace is created before each test
 func (suite *InstallSuite) SetupTest() {
 	suite.testNamespace = createNamespaceForTest()

--- a/test/e2e/workflow_test.go
+++ b/test/e2e/workflow_test.go
@@ -19,6 +19,10 @@ type WorkflowSuite struct {
 }
 
 func (suite *WorkflowSuite) SetupSuite() {
+	if *kubeConfig == "" {
+		suite.T().Skip("Skipping test. Kubeconfig not provided")
+		return
+	}
 	suite.testNamespace = createNamespaceForTest()
 	if !checkIfInstalled(suite.testNamespace) {
 		installArgoInNamespace(suite.testNamespace)


### PR DESCRIPTION
This will make it possible to run "go test" without having to configure a Kubernetes
cluster.