### PR TITLE
Issue #549 - Prepare argo v1 build config

### DIFF
--- a/.argo/build.yaml
+++ b/.argo/build.yaml
@@ -1,0 +1,90 @@
+---
+type: workflow
+version: 1
+name: build
+inputs:
+  parameters:
+    COMMIT:
+      default: "%%session.commit%%"
+    REPO:
+      default: "%%session.repo%%"
+steps:
+- CHECKOUT:
+    template: checkout
+- CONTROLLER-IMAGE:
+    template: make
+    arguments:
+      parameters.TARGET: controller-image
+      artifacts.CODE: "%%steps.CHECKOUT.outputs.artifacts.CODE%%"
+  EXECUTOR-IMAGE:
+    template: make
+    arguments:
+      parameters.TARGET: executor-image
+      artifacts.CODE: "%%steps.CHECKOUT.outputs.artifacts.CODE%%"
+  CLI-LINUX:
+    template: make
+    arguments:
+      parameters.TARGET: cli-linux
+      artifacts.CODE: "%%steps.CHECKOUT.outputs.artifacts.CODE%%"
+  CLI-DARWIN:
+    template: make
+    arguments:
+      parameters.TARGET: cli-darwin
+      artifacts.CODE: "%%steps.CHECKOUT.outputs.artifacts.CODE%%"
+  UI-IMAGE:
+    resources:
+      mem_mib: 512
+      cpu_cores: 0.1
+    image: argoproj/argo-ci-builder:1.0
+    command: ["sh", "-c"]
+    args: [
+      "cd /go/src/github.com/argoproj/argo && make ui-image"
+    ]
+    inputs:
+      artifacts:
+        CODE:
+          from: "%%steps.CHECKOUT.outputs.artifacts.CODE%%"
+          path: /go/src/github.com/argoproj/argo
+    annotations:
+      ax_ea_docker_enable: '{ "graph-storage-name": "argobuildstorage", "graph-storage-size": "25Gi", "cpu_cores":0.5, "mem_mib":3072}'
+
+
+---
+type: container
+version: 1
+name: make
+resources:
+  mem_mib: 512
+  cpu_cores: 0.1
+image: argoproj/argo-ci-builder:1.0
+command: ["sh", "-c"]
+args: [
+  "cd /go/src/github.com/argoproj/argo && make %%inputs.parameters.TARGET%%"
+]
+inputs:
+  parameters:
+    TARGET:
+  artifacts:
+    CODE:
+      path: /go/src/github.com/argoproj/argo
+annotations:
+  ax_ea_docker_enable: '{ "graph-storage-name": "argobuildstorage", "graph-storage-size": "25Gi", "cpu_cores":0.3, "mem_mib":600}'
+
+---
+type: policy
+name: build-policy
+version: 1
+template: build
+notifications:
+  -
+    when:
+      - on_change
+    whom:
+      - committer
+      - submitter
+      - author
+when:
+  -
+    event: on_pull_request
+  -
+    event: on_push

--- a/.argo/checkout.yaml
+++ b/.argo/checkout.yaml
@@ -1,0 +1,21 @@
+---
+type: container
+version: 1
+name: checkout
+description: Checks out a source repository to /src
+resources:
+  mem_mib: 500
+  cpu_cores: 0.1
+image: indiehosters/git
+command: ["bash", "-c"]
+args: ["git clone %%inputs.parameters.REPO%% /src && cd /src && git checkout %%inputs.parameters.COMMIT%%"]
+inputs:
+  parameters:
+    COMMIT:
+      default: "%%session.commit%%"
+    REPO:
+      default: "%%session.repo%%"
+outputs:
+  artifacts:
+    CODE:
+      path: /src

--- a/Dockerfile-ci-builder
+++ b/Dockerfile-ci-builder
@@ -1,0 +1,8 @@
+FROM golang:1.9.2
+
+WORKDIR /tmp
+
+RUN curl -O https://get.docker.com/builds/Linux/x86_64/docker-1.13.1.tgz && \
+  tar -xzf docker-1.13.1.tgz && \
+  mv docker/docker /usr/local/bin/docker && \
+  rm -rf ./docker

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,13 @@ clean:
 	-rm -rf ${BUILD_DIR}/dist
 
 ui-image:
+	docker build -t argo-ui-builder -f ui/Dockerfile.builder ui && \
+	docker create --name argo-ui-builder argo-ui-builder && \
+	mkdir -p ui/tmp && rm -rf ui/tmp/dist ui/tmp/api-dist ui/tmp/node_modules && \
+	docker cp argo-ui-builder:/src/dist ./ui/tmp && \
+	docker cp argo-ui-builder:/src/api-dist ./ui/tmp && \
+	docker cp argo-ui-builder:/src/node_modules ./ui/tmp
+	docker rm argo-ui-builder
 	docker build -t $(IMAGE_PREFIX)argoui:$(IMAGE_TAG) -f ui/Dockerfile ui
 	if [ "$(DOCKER_PUSH)" = "true" ] ; then docker push $(IMAGE_PREFIX)argoui:$(IMAGE_TAG) ; fi
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,27 +1,9 @@
-FROM node:6.9.5
-
-RUN apt-get update && apt-get install -y apt-transport-https && \
-  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-  apt-get update && apt-get install yarn
-
-
-WORKDIR /src
-ADD ["package.json", "yarn.lock", "./"]
-
-RUN yarn install
-
-ADD [".", "."]
-
-RUN yarn build && yarn run api:build && yarn install --production
-
 FROM node:6.9.5-alpine
 
+COPY ./tmp/api-dist /app/api
+COPY ./tmp/dist /app/ui
+COPY ./tmp/node_modules /app/node_modules
 WORKDIR /app
-
-COPY --from=0 /src/api-dist ./api
-COPY --from=0 /src/dist ./ui
-COPY --from=0 /src/node_modules ./node_modules
 
 EXPOSE 8001
 CMD ["sh", "-c", "node api/api/main.js --uiDist /app/ui --inCluster ${IN_CLUSTER} --namespace ${ARGO_NAMESPACE}"]

--- a/ui/Dockerfile.builder
+++ b/ui/Dockerfile.builder
@@ -1,0 +1,16 @@
+FROM node:6.9.5
+
+RUN apt-get update && apt-get install -y apt-transport-https && \
+  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+  apt-get update && apt-get install yarn
+
+
+WORKDIR /src
+ADD ["package.json", "yarn.lock", "./"]
+
+RUN yarn install
+
+ADD [".", "."]
+
+RUN yarn build && yarn run api:build && yarn install --production


### PR DESCRIPTION
PR contains argo v1 build template. Argo v1 dind uses docker version which does not support multi-stage builds. Due to this limitation, I had to stop using multi-stage builds it 'ui-image' make step and updated make file accordingly. 

Successfully build example: https://argo-v1.applatix.net/app/timeline/jobs/e64b164c-dd7d-11e7-af7b-0a58c0a88113