### PR TITLE
Create the argo-ui service with type ClusterIP as part of installation (resolves #582)

### DIFF
--- a/cmd/argo/commands/const.go
+++ b/cmd/argo/commands/const.go
@@ -4,4 +4,5 @@ package commands
 const (
 	ArgoServiceAccount = "argo"
 	ArgoClusterRole    = "argo-cluster-role"
+	ArgoServiceName    = "argo-ui"
 )


### PR DESCRIPTION
This updates the installer and uninstaller to create & delete the UI service as part of install/uninstall.