### PR TITLE
Address all issues in code caught by golang linting tools (resolves #584)

### DIFF
--- a/.argo/build.yaml
+++ b/.argo/build.yaml
@@ -47,7 +47,11 @@ steps:
           path: /go/src/github.com/argoproj/argo
     annotations:
       ax_ea_docker_enable: '{ "graph-storage-name": "argobuildstorage", "graph-storage-size": "25Gi", "cpu_cores":0.5, "mem_mib":4096}'
-
+  #LINT:
+  #  template: make
+  #  arguments:
+  #    parameters.TARGET: lint
+  #    artifacts.CODE: "%%steps.CHECKOUT.outputs.artifacts.CODE%%"
 
 ---
 type: container

--- a/api/workflow/v1alpha1/workflow.go
+++ b/api/workflow/v1alpha1/workflow.go
@@ -49,7 +49,7 @@ func (wf *Workflow) NodeID(name string) string {
 		return wf.ObjectMeta.Name
 	}
 	h := fnv.New32a()
-	h.Write([]byte(name))
+	_, _ = h.Write([]byte(name))
 	return fmt.Sprintf("%s-%v", wf.ObjectMeta.Name, h.Sum32())
 }
 

--- a/cmd/argo/commands/common.go
+++ b/cmd/argo/commands/common.go
@@ -61,6 +61,9 @@ func initKubeClient() *kubernetes.Clientset {
 	}
 	var err error
 	restConfig, err = clientConfig.ClientConfig()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// create the clientset
 	clientset, err = kubernetes.NewForConfig(restConfig)

--- a/cmd/argo/commands/get.go
+++ b/cmd/argo/commands/get.go
@@ -110,7 +110,7 @@ func printWorkflow(wf *wfv1.Workflow) {
 				fmt.Fprintf(w, "%s\tPODNAME\tMESSAGE\n", ansiFormat("STEP", FgDefault))
 			}
 			printNodeTree(w, wf, node, 0, " ", " ")
-			w.Flush()
+			_ = w.Flush()
 		}
 	}
 }
@@ -184,7 +184,6 @@ func printNodeTree(w *tabwriter.Writer, wf *wfv1.Workflow, node wfv1.NodeStatus,
 			// Remove stepgroup name from being displayed
 			childNode.Name = strings.TrimPrefix(childNode.Name, stepGroupNode.Name+".")
 			printNodeTree(w, wf, childNode, depth+1, childNodePrefix, childChldPrefix)
-			j = j + 1
 		}
 	}
 }

--- a/cmd/argo/commands/install.go
+++ b/cmd/argo/commands/install.go
@@ -242,7 +242,7 @@ func installController(clientset *kubernetes.Clientset, args InstallFlags) {
 							Command: []string{"workflow-controller"},
 							Args:    []string{"--configmap", args.ConfigMap},
 							Env: []apiv1.EnvVar{
-								apiv1.EnvVar{
+								{
 									Name: common.EnvVarNamespace,
 									ValueFrom: &apiv1.EnvVarSource{
 										FieldRef: &apiv1.ObjectFieldSelector{
@@ -302,7 +302,7 @@ func installUI(clientset *kubernetes.Clientset, args InstallFlags) {
 							Name:  args.UIName,
 							Image: args.UIImage,
 							Env: []apiv1.EnvVar{
-								apiv1.EnvVar{
+								{
 									Name: common.EnvVarNamespace,
 									ValueFrom: &apiv1.EnvVarSource{
 										FieldRef: &apiv1.ObjectFieldSelector{
@@ -311,7 +311,7 @@ func installUI(clientset *kubernetes.Clientset, args InstallFlags) {
 										},
 									},
 								},
-								apiv1.EnvVar{
+								{
 									Name:  "IN_CLUSTER",
 									Value: "true",
 								},
@@ -350,7 +350,7 @@ func installUIService(clientset *kubernetes.Clientset, args InstallFlags) {
 		},
 		Spec: apiv1.ServiceSpec{
 			Ports: []apiv1.ServicePort{
-				apiv1.ServicePort{
+				{
 					Port:       80,
 					TargetPort: intstr.FromInt(8001),
 				},

--- a/cmd/argo/commands/list.go
+++ b/cmd/argo/commands/list.go
@@ -33,14 +33,14 @@ var listCmd = &cobra.Command{
 }
 
 var timeMagnitudes = []humanize.RelTimeMagnitude{
-	{time.Second, "0s", time.Second},
-	{2 * time.Second, "1s %s", 1},
-	{time.Minute, "%ds %s", time.Second},
-	{2 * time.Minute, "1m %s", 1},
-	{time.Hour, "%dm %s", time.Minute},
-	{2 * time.Hour, "1h %s", 1},
-	{humanize.Day, "%dh %s", time.Hour},
-	{2 * humanize.Day, "1d %s", 1},
+	{D: time.Second, Format: "0s", DivBy: time.Second},
+	{D: 2 * time.Second, Format: "1s %s", DivBy: 1},
+	{D: time.Minute, Format: "%ds %s", DivBy: time.Second},
+	{D: 2 * time.Minute, Format: "1m %s", DivBy: 1},
+	{D: time.Hour, Format: "%dm %s", DivBy: time.Minute},
+	{D: 2 * time.Hour, Format: "1h %s", DivBy: 1},
+	{D: humanize.Day, Format: "%dh %s", DivBy: time.Hour},
+	{D: 2 * humanize.Day, Format: "1d %s", DivBy: 1},
 }
 
 func listWorkflows(cmd *cobra.Command, args []string) {
@@ -71,7 +71,7 @@ func listWorkflows(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", wf.ObjectMeta.Name, worklowStatus(&wf), ageStr, durationStr)
 		}
 	}
-	w.Flush()
+	_ = w.Flush()
 }
 
 func worklowStatus(wf *wfv1.Workflow) wfv1.NodePhase {

--- a/cmd/argo/commands/logs.go
+++ b/cmd/argo/commands/logs.go
@@ -73,5 +73,8 @@ func getLogs(cmd *cobra.Command, args []string) {
 	execCmd := exec.Command("kubectl", argList...)
 	execCmd.Stdout = os.Stdout
 	execCmd.Stderr = os.Stderr
-	execCmd.Run()
+	err = execCmd.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/cmd/argo/commands/submit.go
+++ b/cmd/argo/commands/submit.go
@@ -52,7 +52,7 @@ func SubmitWorkflows(cmd *cobra.Command, args []string) {
 				log.Fatal(err)
 			}
 			body, err = ioutil.ReadAll(response.Body)
-			response.Body.Close()
+			_ = response.Body.Close()
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/cmd/argoexec/commands/root.go
+++ b/cmd/argoexec/commands/root.go
@@ -113,7 +113,9 @@ func getTemplateFromPodAnnotations(annotationsPath string, template *wfv1.Templa
 		return errors.InternalWrapError(err)
 	}
 
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 	reader := bufio.NewReader(file)
 
 	// Prefix of template property in the annotation file

--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -85,7 +85,8 @@ func Run(cmd *cobra.Command, args []string) {
 		log.Fatalf("%+v", err)
 	}
 
-	ctx, _ := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	go wfController.Run(ctx)
 
 	// Wait forever

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -136,16 +136,15 @@ func (e argoerr) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':
 		if s.Flag('+') {
-			io.WriteString(s, e.Error())
+			_, _ = io.WriteString(s, e.Error())
 			for _, pc := range e.StackTrace() {
-				f := errors.Frame(pc)
-				fmt.Fprintf(s, "\n%+v", f)
+				fmt.Fprintf(s, "\n%+v", pc)
 			}
 			return
 		}
 		fallthrough
 	case 's':
-		io.WriteString(s, e.Error())
+		_, _ = io.WriteString(s, e.Error())
 	case 'q':
 		fmt.Fprintf(s, "%q", e.Error())
 	}

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -3,6 +3,7 @@
     "DisableAll": true,
     "Enable": [
         "vet",
+        "gofmt",
         "deadcode",
         "errcheck",
         "varcheck",

--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -70,7 +70,7 @@ func KillPodContainer(restConfig *rest.Config, namespace string, pod string, con
 func ExecPodContainer(restConfig *rest.Config, namespace string, pod string, container string, stdout bool, stderr bool, command ...string) (remotecommand.Executor, error) {
 	clientset, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
-		errors.InternalWrapError(err)
+		return nil, errors.InternalWrapError(err)
 	}
 
 	execRequest := clientset.CoreV1().RESTClient().Post().

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -94,7 +94,7 @@ func NewWorkflowController(config *rest.Config, configMap string) *WorkflowContr
 }
 
 // Run starts an Workflow resource controller
-func (wfc *WorkflowController) Run(ctx context.Context) error {
+func (wfc *WorkflowController) Run(ctx context.Context) {
 	defer wfc.wfQueue.ShutDown()
 	defer wfc.podQueue.ShutDown()
 
@@ -102,7 +102,7 @@ func (wfc *WorkflowController) Run(ctx context.Context) error {
 	_, err := wfc.watchControllerConfigMap(ctx)
 	if err != nil {
 		log.Errorf("Failed to register watch for controller config map: %v", err)
-		return err
+		return
 	}
 
 	wfc.wfInformer = wfc.newWorkflowInformer()
@@ -113,7 +113,8 @@ func (wfc *WorkflowController) Run(ctx context.Context) error {
 	// Wait for all involved caches to be synced, before processing items from the queue is started
 	for _, informer := range []cache.SharedIndexInformer{wfc.wfInformer, wfc.podInformer} {
 		if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
-			return errors.InternalError("Timed out waiting for caches to sync")
+			log.Error("Timed out waiting for caches to sync")
+			return
 		}
 	}
 
@@ -125,7 +126,6 @@ func (wfc *WorkflowController) Run(ctx context.Context) error {
 		go wait.Until(wfc.podWorker, time.Second, ctx.Done())
 	}
 	<-ctx.Done()
-	return ctx.Err()
 }
 
 func (wfc *WorkflowController) runWorker() {

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -516,7 +516,7 @@ func (woc *wfOperationCtx) createPVCs() error {
 		woc.log.Infof("Creating pvc %s", pvcName)
 		pvcTmpl.ObjectMeta.Name = pvcName
 		pvcTmpl.OwnerReferences = []metav1.OwnerReference{
-			metav1.OwnerReference{
+			{
 				APIVersion:         wfv1.CRDFullName,
 				Kind:               wfv1.CRDKind,
 				Name:               woc.wf.ObjectMeta.Name,
@@ -611,7 +611,9 @@ func (woc *wfOperationCtx) executeTemplate(templateName string, args wfv1.Argume
 		}
 		err = woc.executeSteps(nodeName, tmpl)
 		if woc.wf.Status.Nodes[nodeID].Completed() {
-			woc.killDeamonedChildren(nodeID)
+			// TODO: this implementation should be handled via annotating the pod
+			// and signaling the executor to kill the pod instead.
+			_ = woc.killDeamonedChildren(nodeID)
 		}
 	} else if tmpl.Script != nil {
 		err = woc.executeScript(nodeName, tmpl)

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -27,7 +27,7 @@ var (
 		VolumeSource: apiv1.VolumeSource{
 			DownwardAPI: &apiv1.DownwardAPIVolumeSource{
 				Items: []apiv1.DownwardAPIVolumeFile{
-					apiv1.DownwardAPIVolumeFile{
+					{
 						Path: common.PodMetadataAnnotationsVolumePath,
 						FieldRef: &apiv1.ObjectFieldSelector{
 							APIVersion: "v1",
@@ -139,7 +139,7 @@ func (woc *wfOperationCtx) createWorkflowPod(nodeName string, tmpl *wfv1.Templat
 				common.AnnotationKeyNodeName: nodeName,
 			},
 			OwnerReferences: []metav1.OwnerReference{
-				metav1.OwnerReference{
+				{
 					APIVersion:         wfv1.CRDFullName,
 					Kind:               wfv1.CRDKind,
 					Name:               woc.wf.ObjectMeta.Name,

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -474,7 +474,7 @@ func (we *WorkflowExecutor) killSidecars() error {
 	}
 	timer := time.AfterFunc(killGracePeriod*time.Second, func() {
 		log.Infof("Timed out (%ds) for sidecars to terminate gracefully. Killing forcefully", killGracePeriod)
-		cmd.Process.Kill()
+		_ = cmd.Process.Kill()
 		killArgs[len(waitArgs)-1] = "KILL"
 		cmd = exec.Command("docker", killArgs...)
 		log.Info(cmd.Args)


### PR DESCRIPTION
Running:
```
$ make lint
```
Now produces zero errors. This should give us an A+ on the golang report card so we can add a badge to our README.md.

The following linters are enabled:
        "vet",
        "gofmt",
        "deadcode",
        "errcheck",
        "varcheck",
        "structcheck",
        "ineffassign",
        "unconvert"
