### PR TITLE
Fix some wrong GOPATH assumptions in Makefile. Add `make test` target. Fix unit tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 *
 !dist
+dist/pkg
 !Gopkg.*

--- a/workflow/common/validate_test.go
+++ b/workflow/common/validate_test.go
@@ -103,7 +103,7 @@ func TestDuplicateOrEmptyNames(t *testing.T) {
 	}
 	err = validate(emptyName)
 	if assert.NotNil(t, err) {
-		assert.Contains(t, err.Error(), "name is required")
+		assert.Contains(t, err.Error(), "has invalid name")
 	}
 }
 


### PR DESCRIPTION
The Makefile no longer assumes that the project root is in a valid GOPATH _**when performing builds in a docker container**_. It must still be in a valid GOPATH when running native golang build targets (non-docker) like `make cli`, `make controller`, `make executor`.

Also added a `make test` target, which will be added to CI.