### PR TITLE
Comply with semantic versioning. Include build metadata in `argo version` (resolves #594)

### DIFF
--- a/cmd/argo/commands/install.go
+++ b/cmd/argo/commands/install.go
@@ -24,15 +24,27 @@ import (
 
 const clusterAdmin = "cluster-admin"
 
+var (
+	// These values may be overridden by the link flags during build
+	// (e.g. imageTag will use the official release tag on tagged builds)
+	imageNamespace = "argoproj"
+	imageTag       = "latest"
+
+	// These are the default image names which `argo install` uses during install
+	DefaultControllerImage = imageNamespace + "/workflow-controller:" + imageTag
+	DefaultExecutorImage   = imageNamespace + "/argoexec:" + imageTag
+	DefaultUiImage         = imageNamespace + "/argoui:" + imageTag
+)
+
 func init() {
 	RootCmd.AddCommand(installCmd)
 	installCmd.Flags().StringVar(&installArgs.ControllerName, "controller-name", common.DefaultControllerDeploymentName, "name of controller deployment")
 	installCmd.Flags().StringVar(&installArgs.UIName, "ui-name", common.DefaultUiDeploymentName, "name of ui deployment")
 	installCmd.Flags().StringVar(&installArgs.Namespace, "install-namespace", common.DefaultControllerNamespace, "install into a specific Namespace")
 	installCmd.Flags().StringVar(&installArgs.ConfigMap, "configmap", common.DefaultConfigMapName(common.DefaultControllerDeploymentName), "install controller using preconfigured configmap")
-	installCmd.Flags().StringVar(&installArgs.ControllerImage, "controller-image", common.DefaultControllerImage, "use a specified controller image")
-	installCmd.Flags().StringVar(&installArgs.UIImage, "ui-image", common.DefaultUiImage, "use a specified ui image")
-	installCmd.Flags().StringVar(&installArgs.ExecutorImage, "executor-image", common.DefaultExecutorImage, "use a specified executor image")
+	installCmd.Flags().StringVar(&installArgs.ControllerImage, "controller-image", DefaultControllerImage, "use a specified controller image")
+	installCmd.Flags().StringVar(&installArgs.UIImage, "ui-image", DefaultUiImage, "use a specified ui image")
+	installCmd.Flags().StringVar(&installArgs.ExecutorImage, "executor-image", DefaultExecutorImage, "use a specified executor image")
 	installCmd.Flags().StringVar(&installArgs.ServiceAccount, "service-account", "", "use a specified service account for the workflow-controller deployment")
 }
 

--- a/cmd/argoexec/commands/root.go
+++ b/cmd/argoexec/commands/root.go
@@ -98,7 +98,7 @@ func initExecutor() *executor.WorkflowExecutor {
 		Namespace: namespace,
 	}
 	yamlBytes, _ := yaml.Marshal(&wfExecutor.Template)
-	log.Infof("Executor (version: %s) initialized with template:\n%s", argo.FullVersion, string(yamlBytes))
+	log.Infof("Executor (version: %s) initialized with template:\n%s", argo.GetVersion(), string(yamlBytes))
 	return &wfExecutor
 }
 

--- a/util/cmd/cmd.go
+++ b/util/cmd/cmd.go
@@ -15,13 +15,29 @@ import (
 
 // NewVersionCmd returns a new `version` command to be used as a sub-command to root
 func NewVersionCmd(cliName string) *cobra.Command {
-	return &cobra.Command{
+	var short bool
+	versionCmd := cobra.Command{
 		Use:   "version",
 		Short: fmt.Sprintf("Print version information"),
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("%s version %s\n", cliName, argo.FullVersion)
+			version := argo.GetVersion()
+			fmt.Printf("%s: %s\n", cliName, version)
+			if short {
+				return
+			}
+			fmt.Printf("  BuildDate: %s\n", version.BuildDate)
+			fmt.Printf("  GitCommit: %s\n", version.GitCommit)
+			fmt.Printf("  GitTreeState: %s\n", version.GitTreeState)
+			if version.GitTag != "" {
+				fmt.Printf("  GitTag: %s\n", version.GitTag)
+			}
+			fmt.Printf("  GoVersion: %s\n", version.GoVersion)
+			fmt.Printf("  Compiler: %s\n", version.Compiler)
+			fmt.Printf("  Platform: %s\n", version.Platform)
 		},
 	}
+	versionCmd.Flags().BoolVar(&short, "short", false, "print just the version number")
+	return &versionCmd
 }
 
 // MustIsDir returns whether or not the given filePath is a directory. Exits if path does not exist

--- a/version.go
+++ b/version.go
@@ -1,28 +1,64 @@
 package argo
 
-import "fmt"
-
-// Version information set by link flags during build
-var (
-	Version        = "unknown"
-	Revision       = "unknown"
-	Branch         = "unknown"
-	Tag            = ""
-	BuildDate      = "unknown"
-	FullVersion    = "unknown"
-	ImageNamespace = ""
-	ImageTag       = Version
+import (
+	"fmt"
+	"runtime"
 )
 
-func init() {
-	if ImageNamespace == "" {
-		ImageNamespace = "argoproj"
-	}
-	if Tag != "" {
-		// if a git tag was set, use that as our version
-		FullVersion = Tag
-		ImageTag = Tag
+// Version information set by link flags during build. We fall back to these sane
+// default values when we build outside the Makefile context (e.g. go build or go test).
+var (
+	version      = "0.0.0"                // value from VERSION file
+	buildDate    = "1970-01-01T00:00:00Z" // output from `date -u +'%Y-%m-%dT%H:%M:%SZ'`
+	gitCommit    = ""                     // output from `git rev-parse HEAD`
+	gitTag       = ""                     // output from `git describe --exact-match --tags HEAD` (if clean tree state)
+	gitTreeState = ""                     // determined from `git status --porcelain`. either 'clean' or 'dirty'
+)
+
+// Version contains Argo version information
+type Version struct {
+	Version      string
+	BuildDate    string
+	GitCommit    string
+	GitTag       string
+	GitTreeState string
+	GoVersion    string
+	Compiler     string
+	Platform     string
+}
+
+func (v Version) String() string {
+	return v.Version
+}
+
+// GetVersion returns the version information
+func GetVersion() Version {
+	var versionStr string
+	if gitCommit != "" && gitTag != "" && gitTreeState == "clean" {
+		// if we have a clean tree state and the current commit is tagged,
+		// this is an official release.
+		versionStr = gitTag
 	} else {
-		FullVersion = fmt.Sprintf("v%s-%s", Version, Revision[0:7])
+		// otherwise formulate a version string based on as much metadata
+		// information we have available.
+		versionStr = "v" + version
+		if len(gitCommit) >= 7 {
+			versionStr += "+" + gitCommit[0:7]
+			if gitTreeState != "clean" {
+				versionStr += ".dirty"
+			}
+		} else {
+			versionStr += "+unknown"
+		}
+	}
+	return Version{
+		Version:      versionStr,
+		BuildDate:    buildDate,
+		GitCommit:    gitCommit,
+		GitTag:       gitTag,
+		GitTreeState: gitTreeState,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
 }

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -1,14 +1,7 @@
 package common
 
 import (
-	"github.com/argoproj/argo"
 	wfv1 "github.com/argoproj/argo/api/workflow/v1alpha1"
-)
-
-var (
-	DefaultControllerImage = argo.ImageNamespace + "/workflow-controller:" + argo.ImageTag
-	DefaultExecutorImage   = argo.ImageNamespace + "/argoexec:" + argo.ImageTag
-	DefaultUiImage         = argo.ImageNamespace + "/argoui:" + argo.ImageTag
 )
 
 const (

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -7,6 +7,7 @@ import (
 	goruntime "runtime"
 	"time"
 
+	"github.com/argoproj/argo"
 	wfv1 "github.com/argoproj/argo/api/workflow/v1alpha1"
 	"github.com/argoproj/argo/errors"
 	workflowclient "github.com/argoproj/argo/workflow/client"
@@ -98,6 +99,7 @@ func (wfc *WorkflowController) Run(ctx context.Context) {
 	defer wfc.wfQueue.ShutDown()
 	defer wfc.podQueue.ShutDown()
 
+	log.Infof("Workflow Controller (version: %s) starting", argo.GetVersion())
 	log.Info("Watch Workflow controller config map updates")
 	_, err := wfc.watchControllerConfigMap(ctx)
 	if err != nil {


### PR DESCRIPTION
The `argo version` will now produce the following output:

Version output at a git tag (with the tag being v2.0.0-alpha3):
```
$ argo version
argo: v2.0.0-alpha3
  BuildDate: 2017-12-14T22:52:36Z
  GitCommit: f955deacc638b67b9be10fdac0c371ca705cd218
  GitTreeState: clean
  GitTag: v2.0.0-alpha3
  GoVersion: go1.9.2
  Compiler: gc
  Platform: darwin/amd64
```

Version output at a commit with a clean git tree state:
```
$ argo version
argo: v2.0.0+f955dea
  BuildDate: 2017-12-14T22:51:13Z
  GitCommit: f955deacc638b67b9be10fdac0c371ca705cd218
  GitTreeState: clean
  GoVersion: go1.9.2
  Compiler: gc
  Platform: darwin/amd64
```

Version output at a commit with a dirty git tree state:
```
$ argo version
argo: v2.0.0+f955dea.dirty
  BuildDate: 2017-12-14T22:56:16Z
  GitCommit: f955deacc638b67b9be10fdac0c371ca705cd218
  GitTreeState: dirty
  GoVersion: go1.9.2
  Compiler: gc
  Platform: darwin/amd64
```

There is also a `--short` option:
```
$ argo version --short
argo: v2.0.0+73b3c6f
```