### PR TITLE
Add option to print output of submit in json.

### DIFF
--- a/cmd/argo/commands/get.go
+++ b/cmd/argo/commands/get.go
@@ -47,8 +47,13 @@ func GetWorkflow(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	outFmt := getArgs.output
+	printWorkflow(getArgs.output, wf)
+}
+
+func printWorkflow(outFmt string, wf *wfv1.Workflow) {
 	switch outFmt {
+	case "name":
+		fmt.Println(wf.ObjectMeta.Name)
 	case "json":
 		outBytes, _ := json.MarshalIndent(wf, "", "    ")
 		fmt.Println(string(outBytes))
@@ -56,14 +61,13 @@ func GetWorkflow(cmd *cobra.Command, args []string) {
 		outBytes, _ := yaml.Marshal(wf)
 		fmt.Print(string(outBytes))
 	case "wide", "":
-		printWorkflow(wf)
+		printWorkflowHelper(wf)
 	default:
 		log.Fatalf("Unknown output format: %s", outFmt)
 	}
-
 }
 
-func printWorkflow(wf *wfv1.Workflow) {
+func printWorkflowHelper(wf *wfv1.Workflow) {
 	const fmtStr = "%-17s %v\n"
 	fmt.Printf(fmtStr, "Name:", wf.ObjectMeta.Name)
 	fmt.Printf(fmtStr, "Namespace:", wf.ObjectMeta.Namespace)

--- a/cmd/argo/commands/submit.go
+++ b/cmd/argo/commands/submit.go
@@ -17,11 +17,13 @@ func init() {
 	RootCmd.AddCommand(submitCmd)
 	submitCmd.Flags().StringVar(&submitArgs.entrypoint, "entrypoint", "", "override entrypoint")
 	submitCmd.Flags().StringSliceVarP(&submitArgs.parameters, "parameter", "p", []string{}, "pass an input parameter")
+	submitCmd.Flags().StringVarP(&submitArgs.output, "output", "o", "", "Output format. One of: name|json|yaml|wide")
 }
 
 type submitFlags struct {
 	entrypoint string   // --entrypoint
 	parameters []string // --parameter
+	output     string   // --output
 }
 
 var submitArgs submitFlags
@@ -108,6 +110,6 @@ func submitWorkflow(wf *wfv1.Workflow) error {
 	if err != nil {
 		return err
 	}
-	printWorkflow(created)
+	printWorkflow(submitArgs.output, created)
 	return nil
 }


### PR DESCRIPTION
```
$ ./dist/argo submit examples/hello-world.yaml --output json
{
    "metadata": {
        "name": "hello-world-jgnhz",
        "generateName": "hello-world-",
        "namespace": "default",
        "selfLink": "/apis/argoproj.io/v1alpha1/namespaces/default/workflows/hello-world-jgnhz",
        "uid": "aaf4e8f2-e1f8-11e7-8dd9-42010a8a00c4",
        "resourceVersion": "320353",
        "creationTimestamp": "2017-12-16T00:32:59Z"
    },
    "spec": {
        "templates": [
            {
                "name": "whalesay",
                "inputs": {},
                "outputs": {},
                "container": {
                    "name": "",
                    "image": "docker/whalesay:latest",
                    "command": [
                        "cowsay"
                    ],
                    "args": [
                        "hello world"
                    ],
                    "resources": {}
                }
            }
        ],
        "entrypoint": "whalesay",
        "arguments": {}
    },
    "status": {
        "phase": "",
        "startedAt": null,
        "finishedAt": null,
        "nodes": null
    }
}
$ ./dist/argo submit examples/hello-world.yaml
Name:             hello-world-rrn5s
Namespace:        default
Status:           Pending
Created:          Fri Dec 15 16:33:02 -0800 (now)
$ ./dist/argo submit examples/hello-world.yaml --output json | jq .metadata.name
"hello-world-rsljt"
```

Closes #604.