### PR TITLE
Support for workflow exit handlers

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -340,6 +340,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5d6e9ab2201ce2778a2797c7d2c2049ae16373d7ceb34042cf6f3ee560145f2d"
+  inputs-digest = "c5f87ad56dc3ba62314dcfe92271681e1768e10d7f30fb0f2a524d0ace225f6e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/api/workflow/v1alpha1/types.go
+++ b/api/workflow/v1alpha1/types.go
@@ -48,16 +48,36 @@ type WorkflowList struct {
 	Items           []Workflow `json:"items"`
 }
 
+// WorkflowSpec is the specification of a Workflow.
 type WorkflowSpec struct {
-	Templates            []Template                    `json:"templates"`
-	Entrypoint           string                        `json:"entrypoint"`
-	Arguments            Arguments                     `json:"arguments,omitempty"`
-	Volumes              []apiv1.Volume                `json:"volumes,omitempty"`
+	// Templates is a list of workflow templates used in a workflow
+	Templates []Template `json:"templates"`
+
+	// Entrypoint is a template reference to the starting point of the workflow
+	Entrypoint string `json:"entrypoint"`
+
+	// Arguments contain the parameters and artifacts sent to the workflow entrypoint
+	// Parameters are referencable globally using the 'workflow' variable prefix.
+	// e.g. {{workflow.parameters.myparam}}
+	Arguments Arguments `json:"arguments,omitempty"`
+
+	// Volumes is a list of volumes that can be mounted by containers in a workflow.
+	Volumes []apiv1.Volume `json:"volumes,omitempty"`
+
+	// VolumeClaimTemplates is a list of claims that containers are allowed to reference.
+	// The Workflow controller will create the claims at the beginning of the workflow
+	// and delete the claims upon completion of the workflow
 	VolumeClaimTemplates []apiv1.PersistentVolumeClaim `json:"volumeClaimTemplates,omitempty"`
 
-	// NodeSelector is a selector which will cause all pods of the workflow
-	// to be scheduled on the selected node(s)
+	// NodeSelector is a selector which will result in all pods of the workflow
+	// to be scheduled on the selected node(s). This is able to be overridden by
+	// a nodeSelector specified in the template.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
+	// OnExit is a template reference which is invoked at the end of the
+	// workflow, irrespective of the success, failure, or error of the
+	// primary workflow.
+	OnExit string `json:"onExit,omitempty"`
 }
 
 type Template struct {

--- a/examples/exit-handlers.yaml
+++ b/examples/exit-handlers.yaml
@@ -1,0 +1,52 @@
+# An exit handler is a template reference that executes at the end of the workflow
+# irrespective of the success, failure, or error of the primary workflow. To specify
+# an exit handler, reference the name of a template in 'spec.onExit'.
+# Some common use cases of exit handlers are:
+# - sending notifications of workflow status (e.g. e-mail/slack)
+# - posting the pass/fail status to a webhook result (e.g. github build result)
+# - cleaning up workflow artifacts
+# - resubmitting or submitting another workflow
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: exit-handlers-
+spec:
+  entrypoint: intentional-fail
+  onExit: exit-handler
+  templates:
+  # primary workflow template
+  - name: intentional-fail
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["echo intentional failure; exit 1"]
+
+  # exit handler related templates
+  # After the completion of the entrypoint template, the status of the
+  # workflow is made available in the global variable {{workflow.status}}.
+  # {{workflow.status}} will be one of: Succeeded, Failed, Error
+  - name: exit-handler
+    steps:
+    - - name: notify
+        template: send-email
+      - name: celebrate
+        template: celebrate
+        when: "{{workflow.status}} == Succeeded"
+      - name: cry
+        template: cry
+        when: "{{workflow.status}} != Succeeded"
+  - name: send-email
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["echo send e-mail: {{workflow.name}} {{workflow.status}}"]
+  - name: celebrate
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["echo hooray!"]
+  - name: cry
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["echo boohoo!"]

--- a/test/e2e/expectedfailures/exit-handler-failed.yaml
+++ b/test/e2e/expectedfailures/exit-handler-failed.yaml
@@ -1,0 +1,21 @@
+# Test to make sure when exit handler fails it overrides the workflow status as failed
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: exit-handlers-
+spec:
+  entrypoint: pass
+  onExit: fail
+  templates:
+  # primary workflow template
+  - name: pass
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["exit 0"]
+
+  - name: fail
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["exit 1"]

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -15,9 +15,6 @@ const (
 	// Content encoding is expected to be YAML.
 	WorkflowControllerConfigMapKey = "config"
 
-	// Workflow Global Parameter Reference Prefix string in yaml
-	WorkflowGlobalParameterPrefixString = "workflow.parameters."
-
 	// Container names used in the workflow pod
 	MainContainerName = "main"
 	InitContainerName = "init"

--- a/workflow/common/validate.go
+++ b/workflow/common/validate.go
@@ -15,21 +15,44 @@ import (
 // wfValidationCtx is the context for validating a workflow spec
 type wfValidationCtx struct {
 	wf *wfv1.Workflow
+	// globalParams keeps track of variables which are available the global
+	// scope and can be referenced from anywhere.
+	globalParams map[string]string
 	// results tracks if validation has already been run on a template
 	results map[string]bool
 }
 
+const (
+	// placeholderValue is an arbitrary string to perform mock substitution of variables
+	placeholderValue = "placeholder"
+
+	// anyItemMagicValue is a magic value set in addItemsToScope() and checked in
+	// resolveAllVariables() to determine if any {{item.name}} can be accepted during
+	// variable resolution (to support withParam)
+	anyItemMagicValue = "item.*"
+)
+
 // ValidateWorkflow accepts a workflow and performs validation against it
 func ValidateWorkflow(wf *wfv1.Workflow) error {
-	err := VerifyUniqueNonEmptyNames(wf.Spec.Templates)
-	if err != nil {
-		return errors.Errorf(errors.CodeBadRequest, "templates%s", err.Error())
+	ctx := wfValidationCtx{
+		wf:           wf,
+		globalParams: make(map[string]string),
+		results:      make(map[string]bool),
 	}
 
-	ctx := wfValidationCtx{
-		wf:      wf,
-		results: make(map[string]bool),
+	err := validateWorkflowFieldNames(wf.Spec.Templates)
+	if err != nil {
+		return errors.Errorf(errors.CodeBadRequest, "spec.templates%s", err.Error())
 	}
+	err = validateArguments("spec.arguments.", wf.Spec.Arguments)
+	if err != nil {
+		return err
+	}
+	ctx.globalParams["workflow.name"] = placeholderValue
+	for _, param := range ctx.wf.Spec.Arguments.Parameters {
+		ctx.globalParams["workflow.parameters."+param.Name] = placeholderValue
+	}
+
 	if ctx.wf.Spec.Entrypoint == "" {
 		return errors.New(errors.CodeBadRequest, "spec.entrypoint is required")
 	}
@@ -38,83 +61,33 @@ func ValidateWorkflow(wf *wfv1.Workflow) error {
 		return errors.Errorf(errors.CodeBadRequest, "spec.entrypoint template '%s' undefined", ctx.wf.Spec.Entrypoint)
 	}
 
-	return ctx.validateTemplate(entryTmpl, ctx.wf.Spec.Arguments, ctx.wf.Spec.Arguments.Parameters)
-}
-
-func validateFieldName(name string, errFormatStr string) error {
-	if errs := IsValidWorkflowFieldName(name); len(errs) != 0 {
-		return errors.Errorf(errors.CodeBadRequest, errFormatStr, name, strings.Join(errs, ";"))
-	}
-	return nil
-}
-
-func validateTemplateFieldNames(tmpl *wfv1.Template, args wfv1.Arguments, wfGlobalParameters []wfv1.Parameter) error {
-	// Validate Template Name
-	if err := validateFieldName(tmpl.Name, "workflow.spec.templates.%s has invalid name: %s"); err != nil {
-		return err
-	}
-	// Validate globalParameter names
-	for _, globalParam := range wfGlobalParameters {
-		if err := validateFieldName(globalParam.Name, "workflow.spec.arguments.parameters.%s has invalid name: %s"); err != nil {
-			return err
-		}
-	}
-	// Validate Argument Names
-	for _, argParam := range args.Parameters {
-		if err := validateFieldName(argParam.Name, "arguments.parameters.%s has invalid name: %s"); err != nil {
-			return err
-		}
-	}
-	for _, argArt := range args.Artifacts {
-		if err := validateFieldName(argArt.Name, "arguments.artifacts.%s has invalid name: %s"); err != nil {
-			return err
-		}
-	}
-	// Validate Input Names
-	for _, inParam := range tmpl.Inputs.Parameters {
-		if err := validateFieldName(inParam.Name, "inputs.parameters.%s has invalid name: %s"); err != nil {
-			return err
-		}
-	}
-	for _, inArt := range tmpl.Inputs.Artifacts {
-		if err := validateFieldName(inArt.Name, "inputs.artifacts.%s has invalid name: %s"); err != nil {
-			return err
-		}
-	}
-	// Validate Output Names
-	for _, outParam := range tmpl.Outputs.Parameters {
-		if err := validateFieldName(outParam.Name, "outputs.parameters.%s has invalid name: %s"); err != nil {
-			return err
-		}
-	}
-	for _, outArt := range tmpl.Outputs.Artifacts {
-		if err := validateFieldName(outArt.Name, "outputs.artifacts.%s has invalid name: %s"); err != nil {
-			return err
-		}
-	}
-	// Validate step names
-	for _, stepList := range tmpl.Steps {
-		for _, step := range stepList {
-			if err := validateFieldName(step.Name, "steps.%s has invalid name: %s"); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-func (ctx *wfValidationCtx) validateTemplate(tmpl *wfv1.Template, args wfv1.Arguments, wfGlobalParameters []wfv1.Parameter) error {
-	err := validateTemplateFieldNames(tmpl, args, wfGlobalParameters)
+	err = ctx.validateTemplate(entryTmpl, ctx.wf.Spec.Arguments)
 	if err != nil {
 		return err
 	}
+	if ctx.wf.Spec.OnExit != "" {
+		exitTmpl := ctx.wf.GetTemplate(ctx.wf.Spec.OnExit)
+		if exitTmpl == nil {
+			return errors.Errorf(errors.CodeBadRequest, "spec.onExit template '%s' undefined", ctx.wf.Spec.OnExit)
+		}
+		// now when validating onExit, {{workflow.status}} is now available as a global
+		ctx.globalParams["workflow.status"] = placeholderValue
+		err = ctx.validateTemplate(exitTmpl, ctx.wf.Spec.Arguments)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (ctx *wfValidationCtx) validateTemplate(tmpl *wfv1.Template, args wfv1.Arguments) error {
 	_, ok := ctx.results[tmpl.Name]
 	if ok {
 		// we already processed this template
 		return nil
 	}
 	ctx.results[tmpl.Name] = true
-	_, err = ProcessArgs(tmpl, args, wfGlobalParameters, true)
+	_, err := ProcessArgs(tmpl, args, ctx.globalParams, true)
 	if err != nil {
 		return err
 	}
@@ -122,9 +95,26 @@ func (ctx *wfValidationCtx) validateTemplate(tmpl *wfv1.Template, args wfv1.Argu
 	if err != nil {
 		return err
 	}
-	err = validateWFGlobalParams(tmpl, wfGlobalParameters, scope)
-	if err != nil {
-		return err
+	for globalVar, val := range ctx.globalParams {
+		scope[globalVar] = val
+	}
+	// the following validates that only one template type is defined
+	tmplTypes := 0
+	if tmpl.Container != nil {
+		tmplTypes++
+	}
+	if tmpl.Steps != nil {
+		tmplTypes++
+	}
+	if tmpl.Script != nil {
+		tmplTypes++
+	}
+	switch tmplTypes {
+	case 0:
+		return errors.New(errors.CodeBadRequest, "template type unspecified. choose one of: container, steps, script")
+	case 1:
+	default:
+		return errors.New(errors.CodeBadRequest, "multiple template types specified. choose one of: container, steps, script")
 	}
 	if tmpl.Steps == nil {
 		err = validateLeaf(scope, tmpl)
@@ -134,7 +124,6 @@ func (ctx *wfValidationCtx) validateTemplate(tmpl *wfv1.Template, args wfv1.Argu
 	if err != nil {
 		return err
 	}
-
 	err = validateOutputs(tmpl)
 	if err != nil {
 		return err
@@ -143,11 +132,11 @@ func (ctx *wfValidationCtx) validateTemplate(tmpl *wfv1.Template, args wfv1.Argu
 }
 
 func validateInputs(tmpl *wfv1.Template) (map[string]interface{}, error) {
-	err := VerifyUniqueNonEmptyNames(tmpl.Inputs.Parameters)
+	err := validateWorkflowFieldNames(tmpl.Inputs.Parameters)
 	if err != nil {
 		return nil, errors.Errorf(errors.CodeBadRequest, "template '%s' inputs.parameters%s", tmpl.Name, err.Error())
 	}
-	err = VerifyUniqueNonEmptyNames(tmpl.Inputs.Artifacts)
+	err = validateWorkflowFieldNames(tmpl.Inputs.Artifacts)
 	if err != nil {
 		return nil, errors.Errorf(errors.CodeBadRequest, "template '%s' inputs.artifacts%s", tmpl.Name, err.Error())
 	}
@@ -180,17 +169,6 @@ func validateInputs(tmpl *wfv1.Template) (map[string]interface{}, error) {
 	return scope, nil
 }
 
-func validateWFGlobalParams(tmpl *wfv1.Template, wfGlobalParams []wfv1.Parameter, scope map[string]interface{}) error {
-	err := VerifyUniqueNonEmptyNames(wfGlobalParams)
-	if err != nil {
-		return errors.Errorf(errors.CodeBadRequest, "Workflow spec.arguments.parameters%s", err.Error())
-	}
-	for _, param := range wfGlobalParams {
-		scope[WorkflowGlobalParameterPrefixString+param.Name] = true
-	}
-	return nil
-}
-
 func validateArtifactLocation(errPrefix string, art wfv1.Artifact) error {
 	if art.Git != nil {
 		if art.Git.Repo == "" {
@@ -204,7 +182,7 @@ func validateArtifactLocation(errPrefix string, art wfv1.Artifact) error {
 // resolveAllVariables is a helper to ensure all {{variables}} are resolveable from current scope
 func resolveAllVariables(scope map[string]interface{}, tmplStr string) error {
 	var unresolvedErr error
-	_, allowAllItemRefs := scope["item.*"] // 'item.*' is a magic placeholder value set by addItemsToScope
+	_, allowAllItemRefs := scope[anyItemMagicValue] // 'item.*' is a magic placeholder value set by addItemsToScope
 	fstTmpl := fasttemplate.New(tmplStr, "{{", "}}")
 
 	fstTmpl.ExecuteFuncString(func(w io.Writer, tag string) (int, error) {
@@ -234,6 +212,20 @@ func validateLeaf(scope map[string]interface{}, tmpl *wfv1.Template) error {
 	return nil
 }
 
+func validateArguments(prefix string, arguments wfv1.Arguments) error {
+	fieldToSlices := map[string]interface{}{
+		"parameters": arguments.Parameters,
+		"artifacts":  arguments.Artifacts,
+	}
+	for fieldName, lst := range fieldToSlices {
+		err := validateWorkflowFieldNames(lst)
+		if err != nil {
+			return errors.Errorf(errors.CodeBadRequest, "%s%s%s", prefix, fieldName, err.Error())
+		}
+	}
+	return nil
+}
+
 func (ctx *wfValidationCtx) validateSteps(scope map[string]interface{}, tmpl *wfv1.Template) error {
 	stepNames := make(map[string]bool)
 	for i, stepGroup := range tmpl.Steps {
@@ -243,7 +235,10 @@ func (ctx *wfValidationCtx) validateSteps(scope map[string]interface{}, tmpl *wf
 			}
 			_, ok := stepNames[step.Name]
 			if ok {
-				return errors.Errorf(errors.CodeBadRequest, "template '%s' steps[%d].%s name is not unique", tmpl.Name, i, step.Name)
+				return errors.Errorf(errors.CodeBadRequest, "template '%s' steps[%d].name '%s' is not unique", tmpl.Name, i, step.Name)
+			}
+			if errs := IsValidWorkflowFieldName(step.Name); len(errs) != 0 {
+				return errors.Errorf(errors.CodeBadRequest, "template '%s' steps[%d].name '%s' is invalid: %s", tmpl.Name, i, step.Name, strings.Join(errs, ";"))
 			}
 			stepNames[step.Name] = true
 			err := addItemsToScope(&step, scope)
@@ -262,7 +257,11 @@ func (ctx *wfValidationCtx) validateSteps(scope map[string]interface{}, tmpl *wf
 			if childTmpl == nil {
 				return errors.Errorf(errors.CodeBadRequest, "template '%s' steps[%d].%s.template '%s' undefined", tmpl.Name, i, step.Name, step.Template)
 			}
-			err = ctx.validateTemplate(childTmpl, step.Arguments, ctx.wf.Spec.Arguments.Parameters)
+			err = validateArguments(fmt.Sprintf("template '%s' steps[%d].%s.arguments.", tmpl.Name, i, step.Name), step.Arguments)
+			if err != nil {
+				return err
+			}
+			err = ctx.validateTemplate(childTmpl, step.Arguments)
 			if err != nil {
 				return err
 			}
@@ -291,7 +290,7 @@ func addItemsToScope(step *wfv1.WorkflowStep, scope map[string]interface{}) erro
 		scope["item"] = true
 		// 'item.*' is magic placeholder value which resolveAllVariables() will look for
 		// when considering if all variables are resolveable.
-		scope["item.*"] = true
+		scope[anyItemMagicValue] = true
 	}
 	return nil
 }
@@ -313,11 +312,11 @@ func (ctx *wfValidationCtx) addOutputsToScope(templateName string, stepName stri
 }
 
 func validateOutputs(tmpl *wfv1.Template) error {
-	err := VerifyUniqueNonEmptyNames(tmpl.Outputs.Parameters)
+	err := validateWorkflowFieldNames(tmpl.Outputs.Parameters)
 	if err != nil {
 		return errors.Errorf(errors.CodeBadRequest, "template '%s' outputs.parameters%s", tmpl.Name, err.Error())
 	}
-	err = VerifyUniqueNonEmptyNames(tmpl.Outputs.Artifacts)
+	err = validateWorkflowFieldNames(tmpl.Outputs.Artifacts)
 	if err != nil {
 		return errors.Errorf(errors.CodeBadRequest, "template '%s' outputs.artifacts%s", tmpl.Name, err.Error())
 	}
@@ -341,12 +340,15 @@ func validateOutputs(tmpl *wfv1.Template) error {
 	return nil
 }
 
-// VerifyUniqueNonEmptyNames accepts a slice of structs and
-// verifies that the Name field of the structs are unique and non-empty
-func VerifyUniqueNonEmptyNames(slice interface{}) error {
+// validateWorkflowFieldNames accepts a slice of structs and
+// verifies that the Name field of the structs are:
+// * unique
+// * non-empty
+// * matches matches our regex requirements
+func validateWorkflowFieldNames(slice interface{}) error {
 	s := reflect.ValueOf(slice)
 	if s.Kind() != reflect.Slice {
-		return errors.InternalErrorf("VerifyNoDuplicateOrEmptyNames given a non-slice type")
+		return errors.InternalErrorf("validateWorkflowFieldNames given a non-slice type")
 	}
 	items := make([]interface{}, s.Len())
 	for i := 0; i < s.Len(); i++ {
@@ -370,11 +372,14 @@ func VerifyUniqueNonEmptyNames(slice interface{}) error {
 			return err
 		}
 		if name == "" {
-			return fmt.Errorf("[%d].name is required", i)
+			return errors.Errorf(errors.CodeBadRequest, "[%d].name is required", i)
+		}
+		if errs := IsValidWorkflowFieldName(name); len(errs) != 0 {
+			return errors.Errorf(errors.CodeBadRequest, "[%d].name: '%s' is invalid: %s", i, name, strings.Join(errs, ";"))
 		}
 		_, ok := names[name]
 		if ok {
-			return fmt.Errorf("[%d].name '%s' is not unique", i, name)
+			return errors.Errorf(errors.CodeBadRequest, "[%d].name '%s' is not unique", i, name)
 		}
 		names[name] = true
 	}

--- a/workflow/common/validate_test.go
+++ b/workflow/common/validate_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// validate is a test helper to accept YAML as a string and return
+// its validation result.
 func validate(yamlStr string) error {
 	var wf wfv1.Workflow
 	err := yaml.Unmarshal([]byte(yamlStr), &wf)
@@ -16,6 +18,8 @@ func validate(yamlStr string) error {
 	}
 	return ValidateWorkflow(&wf)
 }
+
+const invalidErr = "is invalid"
 
 var unknownField = `
 apiVersion: argoproj.io/v1alpha1
@@ -103,7 +107,7 @@ func TestDuplicateOrEmptyNames(t *testing.T) {
 	}
 	err = validate(emptyName)
 	if assert.NotNil(t, err) {
-		assert.Contains(t, err.Error(), "has invalid name")
+		assert.Contains(t, err.Error(), "name is required")
 	}
 }
 
@@ -258,7 +262,7 @@ spec:
 func TestInvalidTemplateName(t *testing.T) {
 	err := validate(invalidTemplateNames)
 	if assert.NotNil(t, err) {
-		assert.Contains(t, err.Error(), "has invalid name")
+		assert.Contains(t, err.Error(), invalidErr)
 	}
 }
 
@@ -285,7 +289,7 @@ spec:
 func TestInvalidArgParamName(t *testing.T) {
 	err := validate(invalidArgParamNames)
 	if assert.NotNil(t, err) {
-		assert.Contains(t, err.Error(), "has invalid name")
+		assert.Contains(t, err.Error(), invalidErr)
 	}
 }
 
@@ -318,7 +322,7 @@ spec:
 func TestInvalidArgArtName(t *testing.T) {
 	err := validate(invalidArgArtNames)
 	if assert.NotNil(t, err) {
-		assert.Contains(t, err.Error(), "has invalid name")
+		assert.Contains(t, err.Error(), invalidErr)
 	}
 }
 
@@ -365,7 +369,7 @@ spec:
 func TestInvalidStepName(t *testing.T) {
 	err := validate(invalidStepNames)
 	if assert.NotNil(t, err) {
-		assert.Contains(t, err.Error(), "has invalid name")
+		assert.Contains(t, err.Error(), invalidErr)
 	}
 }
 
@@ -375,34 +379,13 @@ kind: Workflow
 metadata:
   generateName: steps-
 spec:
-  entrypoint: hello-hello-hello
-
+  entrypoint: whalesay
   templates:
-  - name: hello-hello-hello
-    steps:
-    - - name: hello1
-        template: whalesay
-        arguments:
-          parameters:
-          - name: message
-            value: "hello1"
-    - - name: hello2a
-        template: whalesay
-        arguments:
-          parameters:
-          - name: message
-            value: "hello2a"
-      - name: hello2b
-        template: whalesay
-        arguments:
-          parameters:
-          - name: message
-            value: "hello2b"
-
   - name: whalesay
     inputs:
       parameters:
       - name: message+123
+        default: "abc"
     container:
       image: docker/whalesay
       command: [cowsay]
@@ -412,7 +395,7 @@ spec:
 func TestInvalidInputParamName(t *testing.T) {
 	err := validate(invalidInputParamNames)
 	if assert.NotNil(t, err) {
-		assert.Contains(t, err.Error(), "has invalid name")
+		assert.Contains(t, err.Error(), invalidErr)
 	}
 }
 
@@ -464,7 +447,7 @@ spec:
 func TestInvalidInputArtName(t *testing.T) {
 	err := validate(invalidInputArtNames)
 	if assert.NotNil(t, err) {
-		assert.Contains(t, err.Error(), "has invalid name")
+		assert.Contains(t, err.Error(), invalidErr)
 	}
 }
 
@@ -490,7 +473,7 @@ spec:
 func TestInvalidOutputArtName(t *testing.T) {
 	err := validate(invalidOutputArtNames)
 	if assert.NotNil(t, err) {
-		assert.Contains(t, err.Error(), "has invalid name")
+		assert.Contains(t, err.Error(), invalidErr)
 	}
 }
 
@@ -516,6 +499,81 @@ spec:
 func TestInvalidOutputParamName(t *testing.T) {
 	err := validate(invalidOutputParamNames)
 	if assert.NotNil(t, err) {
-		assert.Contains(t, err.Error(), "has invalid name")
+		assert.Contains(t, err.Error(), invalidErr)
 	}
+}
+
+var multipleTemplateTypes = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: multiple-template-types-
+spec:
+  entrypoint: whalesay
+  templates:
+  - name: whalesay
+    container:
+      image: docker/whalesay:latest
+      command: [sh, -c]
+      args: ["cowsay hello world | tee /tmp/hello_world.txt"]
+    script:
+      image: python:3.6
+      command: [python]
+      source: |
+        import random
+        i = random.randint(1, 100)
+        print(i)
+`
+
+func TestMultipleTemplateTypes(t *testing.T) {
+	err := validate(multipleTemplateTypes)
+	if assert.NotNil(t, err) {
+		assert.Contains(t, err.Error(), "multiple template types specified")
+	}
+}
+
+var exitHandlerWorkflowStatusOnExit = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: exit-handlers-
+spec:
+  entrypoint: pass
+  onExit: fail
+  templates:
+  - name: pass
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["exit 0"]
+  - name: fail
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["echo {{workflow.status}}"]
+`
+
+var workflowStatusNotOnExit = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: exit-handlers-
+spec:
+  entrypoint: pass
+  templates:
+  - name: pass
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["echo {{workflow.status}}"]
+`
+
+func TestExitHandler(t *testing.T) {
+	// ensure {{workflow.status}} is not available when not in exit handler
+	err := validate(workflowStatusNotOnExit)
+	assert.NotNil(t, err)
+
+	// ensure {{workflow.status}} is available in exit handler
+	err = validate(exitHandlerWorkflowStatusOnExit)
+	assert.Nil(t, err)
 }

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -35,6 +35,9 @@ type wfOperationCtx struct {
 	log *log.Entry
 	// controller reference to workflow controller
 	controller *WorkflowController
+	// globalParms holds any parameters that are available to be referenced
+	// in the global scope (e.g. workflow.parameters.XXX).
+	globalParams map[string]string
 	// map of pods which need to be labeled with completed=true
 	completedPods map[string]bool
 	// deadline is the dealine time in which this operation should relinquish
@@ -78,12 +81,12 @@ func (wfc *WorkflowController) operateWorkflow(wf *wfv1.Workflow) {
 			"namespace": wf.ObjectMeta.Namespace,
 		}),
 		controller:    wfc,
+		globalParams:  make(map[string]string),
 		completedPods: make(map[string]bool),
 		deadline:      time.Now().UTC().Add(maxOperationTime),
 	}
 	defer woc.persistUpdates()
 	woc.log.Infof("Processing workflow")
-
 	// Perform one-time workflow validation
 	if woc.wf.Status.Phase == "" {
 		woc.markWorkflowRunning()
@@ -99,6 +102,10 @@ func (wfc *WorkflowController) operateWorkflow(wf *wfv1.Workflow) {
 			// TODO: we need to re-add to the workqueue, but should happen in caller
 			return
 		}
+	}
+	woc.globalParams["workflow.name"] = wf.ObjectMeta.Name
+	for _, param := range wf.Spec.Arguments.Parameters {
+		woc.globalParams["workflow.parameters."+param.Name] = *param.Value
 	}
 
 	err = woc.createPVCs()
@@ -126,6 +133,34 @@ func (wfc *WorkflowController) operateWorkflow(wf *wfv1.Workflow) {
 		return
 	}
 
+	var onExitNode *wfv1.NodeStatus
+	if wf.Spec.OnExit != "" {
+		if node.Phase == wfv1.NodeSkipped {
+			// treat skipped the same as Succeeded for workflow.status
+			woc.globalParams["workflow.status"] = string(wfv1.NodeSucceeded)
+		} else {
+			woc.globalParams["workflow.status"] = string(node.Phase)
+		}
+		woc.log.Infof("Running OnExit handler: %s", wf.Spec.OnExit)
+		onExitNodeName := wf.ObjectMeta.Name + ".onExit"
+		err = woc.executeTemplate(wf.Spec.OnExit, wf.Spec.Arguments, onExitNodeName)
+		if err != nil {
+			if errors.IsCode(errors.CodeTimeout, err) {
+				key, err := cache.MetaNamespaceKeyFunc(woc.wf)
+				if err == nil {
+					wfc.wfQueue.Add(key)
+				}
+				return
+			}
+			woc.log.Errorf("%s error: %+v", onExitNodeName, err)
+		}
+		xitNode := woc.wf.Status.Nodes[woc.wf.NodeID(onExitNodeName)]
+		onExitNode = &xitNode
+		if !onExitNode.Completed() {
+			return
+		}
+	}
+
 	err = woc.deletePVCs()
 	if err != nil {
 		woc.log.Errorf("%s error: %+v", wf.ObjectMeta.Name, err)
@@ -136,14 +171,18 @@ func (wfc *WorkflowController) operateWorkflow(wf *wfv1.Workflow) {
 		return
 	}
 
-	// TODO: workflow finalizer logic goes here
-
-	// If we get here, the workflow completed, all PVCs were deleted successfully,
-	// and finalizers were executed (finalizer feature yet to be implemented).
-	// We now need to infer the workflow phase from the node phase.
+	// If we get here, the workflow completed, all PVCs were deleted successfully, and
+	// exit handlers were executed. We now need to infer the workflow phase from the
+	// node phase.
 	switch node.Phase {
 	case wfv1.NodeSucceeded, wfv1.NodeSkipped:
-		woc.markWorkflowSuccess()
+		if onExitNode != nil && !onExitNode.Successful() {
+			// if main workflow succeeded, but the exit node was unsuccessful
+			// the workflow is now considered unsuccessful.
+			woc.markWorkflowPhase(onExitNode.Phase, true, onExitNode.Message)
+		} else {
+			woc.markWorkflowSuccess()
+		}
 	case wfv1.NodeFailed:
 		woc.markWorkflowFailed(node.Message)
 	case wfv1.NodeError:
@@ -590,7 +629,7 @@ func (woc *wfOperationCtx) executeTemplate(templateName string, args wfv1.Argume
 		return err
 	}
 
-	tmpl, err := common.ProcessArgs(tmpl, args, woc.wf.Spec.Arguments.Parameters, false)
+	tmpl, err := common.ProcessArgs(tmpl, args, woc.globalParams, false)
 	if err != nil {
 		woc.markNodeError(nodeName, err)
 		return err
@@ -610,11 +649,6 @@ func (woc *wfOperationCtx) executeTemplate(templateName string, args wfv1.Argume
 			woc.log.Infof("Initialized workflow node %v", node)
 		}
 		err = woc.executeSteps(nodeName, tmpl)
-		if woc.wf.Status.Nodes[nodeID].Completed() {
-			// TODO: this implementation should be handled via annotating the pod
-			// and signaling the executor to kill the pod instead.
-			_ = woc.killDeamonedChildren(nodeID)
-		}
 	} else if tmpl.Script != nil {
 		err = woc.executeScript(nodeName, tmpl)
 	} else {
@@ -730,6 +764,14 @@ func (woc *wfOperationCtx) executeContainer(nodeName string, tmpl *wfv1.Template
 }
 
 func (woc *wfOperationCtx) executeSteps(nodeName string, tmpl *wfv1.Template) error {
+	defer func() {
+		nodeID := woc.wf.NodeID(nodeName)
+		if woc.wf.Status.Nodes[nodeID].Completed() {
+			// TODO: this implementation should be handled via annotating the pod
+			// and signaling the executor to kill the pod instead.
+			_ = woc.killDeamonedChildren(nodeID)
+		}
+	}()
 	scope := wfScope{
 		tmpl:  tmpl,
 		scope: make(map[string]interface{}),


### PR DESCRIPTION
This resolves issue #495.

* Introduce spec.onExit field for specifying a template to run upon workflow completion
* Make {{workflow.name}} available as a global variable
* Make {{workflow.status}} available in the scope for exit handlers
* Simplify some of the workflow spec validation

Output from `argo get` with a workflow using exit handlers:
```
$ argo get exit-handlers-fpkb4
Name:             exit-handlers-fpkb4
Namespace:        default
Status:           Failed
Message:          failed with exit code 1
Created:          Sat Dec 16 05:59:41 -0800 (14 hours ago)
Started:          Sat Dec 16 20:33:31 -0800 (20 minutes ago)
Finished:         Sat Dec 16 20:33:43 -0800 (20 minutes ago)
Duration:         12 seconds

STEP                    PODNAME                         MESSAGE
 ✖ exit-handlers-fpkb4  exit-handlers-fpkb4             failed with exit code 1

 ✔ onExit
 └-·-✔ notify           exit-handlers-fpkb4-3469848261
   ├-○ celebrate
   └-✔ cry              exit-handlers-fpkb4-3938594380
```