### PR TITLE
Add ability to timeout a container/script using activeDeadlineSeconds

### DIFF
--- a/api/workflow/v1alpha1/types.go
+++ b/api/workflow/v1alpha1/types.go
@@ -89,6 +89,11 @@ type Template struct {
 	// artifact repository location configured in the controller, appended with the
 	// <workflowname>/<nodename> in the key.
 	ArchiveLocation *ArtifactLocation `json:"archiveLocation,omitempty"`
+
+	// Optional duration in seconds relative to the StartTime that the pod may be active on a node
+	// before the system actively tries to terminate the pod; value must be positive integer
+	// This field is only applicable to container and script templates.
+	ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,omitempty"`
 }
 
 // Inputs are the mechanism for passing parameters, artifacts, volumes from one template to another

--- a/examples/timeouts.yaml
+++ b/examples/timeouts.yaml
@@ -1,0 +1,17 @@
+# To enforce a timeout to a template, specify a value for activeDeadlineSeconds.
+# This value represents the duration in seconds relative to the pod StartTime
+# that the pod may be active on a node before the system actively tries to
+# terminate it. This field is only applicable to container and script templates.
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: timeouts-
+spec:
+  entrypoint: sleep
+  templates:
+  - name: sleep
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["echo sleeping for 1m; sleep 60; echo done"]
+    activeDeadlineSeconds: 10

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -159,6 +159,7 @@ func (woc *wfOperationCtx) createWorkflowPod(nodeName string, tmpl *wfv1.Templat
 				volumeDockerLib,
 				volumeDockerSock,
 			},
+			ActiveDeadlineSeconds: tmpl.ActiveDeadlineSeconds,
 		},
 	}
 


### PR DESCRIPTION
This adds the field `activeDeadlineSeconds` to the template spec which gets carried forward to the pod spec. This gives us kubernetes pod timeout for free. Below is an example of a 10s timeout enforced on a container which sleeps for 1 minute:

```
$ argo get timeouts-d4qhf
Name:             timeouts-d4qhf
Namespace:        default
Status:           Failed
Message:          Pod was active on the node longer than the specified deadline
Created:          Sat Dec 16 07:16:49 -0800 (17 hours ago)
Started:          Sat Dec 16 21:54:37 -0800 (2 hours ago)
Finished:         Sat Dec 16 21:54:47 -0800 (2 hours ago)
Duration:         10 seconds

STEP               PODNAME         MESSAGE
 ✖ timeouts-d4qhf  timeouts-d4qhf  Pod was active on the node longer than the specified deadline
```