### PR TITLE
Resolve controller panic with script template and input artifact

### DIFF
--- a/test/e2e/functional/script-with-input-art.yaml
+++ b/test/e2e/functional/script-with-input-art.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: script-with-input-artifact-
+spec:
+  entrypoint: script-with-input-artifact
+  templates:
+  - name: script-with-input-artifact
+    inputs:
+      artifacts:
+      - name: kubectl
+        path: /bin/kubectl
+        http:
+          url: https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl
+    script:
+      image: alpine:latest
+      command: [sh]
+      source: |
+        ls /bin/kubectl

--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -32,6 +32,9 @@ import (
 // user specified volumeMounts in the template, and returns the deepest volumeMount
 // (if any).
 func FindOverlappingVolume(tmpl *wfv1.Template, path string) *apiv1.VolumeMount {
+	if tmpl.Container == nil {
+		return nil
+	}
 	var volMnt *apiv1.VolumeMount
 	deepestLen := 0
 	for _, mnt := range tmpl.Container.VolumeMounts {
@@ -258,16 +261,16 @@ func RunCommand(name string, arg ...string) error {
 
 const patchRetries = 5
 
-func AddPodAnnotation(c *kubernetes.Clientset, podName, namespace, key, value string) error {
+func AddPodAnnotation(c kubernetes.Interface, podName, namespace, key, value string) error {
 	return addPodMetadata(c, "annotations", podName, namespace, key, value)
 }
 
-func AddPodLabel(c *kubernetes.Clientset, podName, namespace, key, value string) error {
+func AddPodLabel(c kubernetes.Interface, podName, namespace, key, value string) error {
 	return addPodMetadata(c, "labels", podName, namespace, key, value)
 }
 
 // addPodMetadata is helper to either add a pod label or annotation to the pod
-func addPodMetadata(c *kubernetes.Clientset, field, podName, namespace, key, value string) error {
+func addPodMetadata(c kubernetes.Interface, field, podName, namespace, key, value string) error {
 	metadata := map[string]interface{}{
 		"metadata": map[string]interface{}{
 			field: map[string]string{

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -36,7 +36,7 @@ type WorkflowController struct {
 	restConfig *rest.Config
 	restClient *rest.RESTClient
 	scheme     *runtime.Scheme
-	clientset  *kubernetes.Clientset
+	clientset  kubernetes.Interface
 
 	// datastructures to support the processing of workflows and workflow pods
 	wfInformer  cache.SharedIndexInformer

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -355,11 +355,12 @@ func (woc *wfOperationCtx) addInputArtifactsVolumes(pod *apiv1.Pod, tmpl *wfv1.T
 			// We also add the user supplied mount paths to the init container,
 			// in case the executor needs to load artifacts to this volume
 			// instead of the artifacts volume
-			for _, mnt := range tmpl.Container.VolumeMounts {
-				mnt.MountPath = path.Join(common.InitContainerMainFilesystemDir, mnt.MountPath)
-				initCtr.VolumeMounts = append(initCtr.VolumeMounts, mnt)
+			if tmpl.Container != nil {
+				for _, mnt := range tmpl.Container.VolumeMounts {
+					mnt.MountPath = path.Join(common.InitContainerMainFilesystemDir, mnt.MountPath)
+					initCtr.VolumeMounts = append(initCtr.VolumeMounts, mnt)
+				}
 			}
-
 			pod.Spec.InitContainers[i] = initCtr
 			break
 		}

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -1,0 +1,70 @@
+package controller
+
+import (
+	"testing"
+
+	wfv1 "github.com/argoproj/argo/api/workflow/v1alpha1"
+	"github.com/ghodss/yaml"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func unmarshalTemplate(yamlStr string) *wfv1.Template {
+	var tmpl wfv1.Template
+	err := yaml.Unmarshal([]byte(yamlStr), &tmpl)
+	if err != nil {
+		panic(err)
+	}
+	return &tmpl
+}
+
+// newWoc a new operation context suitable for testing
+func newWoc() *wfOperationCtx {
+	wf := &wfv1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-wf",
+			Namespace: "default",
+		},
+	}
+	woc := wfOperationCtx{
+		wf:      wf,
+		orig:    wf.DeepCopyObject().(*wfv1.Workflow),
+		updated: false,
+		log: log.WithFields(log.Fields{
+			"workflow":  wf.ObjectMeta.Name,
+			"namespace": wf.ObjectMeta.Namespace,
+		}),
+		controller: &WorkflowController{
+			Config: WorkflowControllerConfig{
+				ExecutorImage: "executor:latest",
+			},
+			clientset: fake.NewSimpleClientset(),
+		},
+		completedPods: make(map[string]bool),
+	}
+	return &woc
+}
+
+var scriptTemplateWithInputArtifact = `
+name: script-with-input-artifact
+inputs:
+  artifacts:
+  - name: kubectl
+    path: /bin/kubectl
+    http:
+      url: https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl
+script:
+  image: alpine:latest
+  command: [sh]
+  source: |
+    ls /bin/kubectl
+`
+
+func TestScriptTemplateWithVolume(t *testing.T) {
+	// ensure we can a script pod with input artifacts
+	tmpl := unmarshalTemplate(scriptTemplateWithInputArtifact)
+	_, err := newWoc().createWorkflowPod(tmpl.Name, tmpl)
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
This resolves issue #617.

Resolve controller panic when a script template with an input artifact was submitted.
Utilize the kubernetes.Interface and fake.Clientset to support unit test mocking.
Added a unit test to reproduce the panic. Add an e2e test to verify functionality works.