### PR TITLE
Implementation for resource templates and resource wait/fail conditions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -248,6 +248,18 @@
   version = "v1.1.4"
 
 [[projects]]
+  name = "github.com/tidwall/gjson"
+  packages = ["."]
+  revision = "080cd2281672e2db949148e6f07cc2e9630fb480"
+  version = "v1.0.4"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/tidwall/match"
+  packages = ["."]
+  revision = "1731857f09b1f38450e2c12409748407822dc6be"
+
+[[projects]]
   branch = "master"
   name = "github.com/valyala/bytebufferpool"
   packages = ["."]
@@ -328,7 +340,7 @@
 [[projects]]
   branch = "release-5.0"
   name = "k8s.io/client-go"
-  packages = ["discovery","kubernetes","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/apps/v1beta1","kubernetes/typed/apps/v1beta2","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1beta1","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v2beta1","kubernetes/typed/batch/v1","kubernetes/typed/batch/v1beta1","kubernetes/typed/batch/v2alpha1","kubernetes/typed/certificates/v1beta1","kubernetes/typed/core/v1","kubernetes/typed/extensions/v1beta1","kubernetes/typed/networking/v1","kubernetes/typed/policy/v1beta1","kubernetes/typed/rbac/v1","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1beta1","kubernetes/typed/scheduling/v1alpha1","kubernetes/typed/settings/v1alpha1","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1beta1","pkg/version","plugin/pkg/client/auth/gcp","rest","rest/watch","third_party/forked/golang/template","tools/auth","tools/cache","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/metrics","tools/pager","tools/reference","tools/remotecommand","transport","transport/spdy","util/cert","util/exec","util/flowcontrol","util/homedir","util/integer","util/jsonpath","util/workqueue"]
+  packages = ["discovery","discovery/fake","kubernetes","kubernetes/fake","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/admissionregistration/v1alpha1/fake","kubernetes/typed/apps/v1beta1","kubernetes/typed/apps/v1beta1/fake","kubernetes/typed/apps/v1beta2","kubernetes/typed/apps/v1beta2/fake","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1/fake","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authentication/v1beta1/fake","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1/fake","kubernetes/typed/authorization/v1beta1","kubernetes/typed/authorization/v1beta1/fake","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v1/fake","kubernetes/typed/autoscaling/v2beta1","kubernetes/typed/autoscaling/v2beta1/fake","kubernetes/typed/batch/v1","kubernetes/typed/batch/v1/fake","kubernetes/typed/batch/v1beta1","kubernetes/typed/batch/v1beta1/fake","kubernetes/typed/batch/v2alpha1","kubernetes/typed/batch/v2alpha1/fake","kubernetes/typed/certificates/v1beta1","kubernetes/typed/certificates/v1beta1/fake","kubernetes/typed/core/v1","kubernetes/typed/core/v1/fake","kubernetes/typed/extensions/v1beta1","kubernetes/typed/extensions/v1beta1/fake","kubernetes/typed/networking/v1","kubernetes/typed/networking/v1/fake","kubernetes/typed/policy/v1beta1","kubernetes/typed/policy/v1beta1/fake","kubernetes/typed/rbac/v1","kubernetes/typed/rbac/v1/fake","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1alpha1/fake","kubernetes/typed/rbac/v1beta1","kubernetes/typed/rbac/v1beta1/fake","kubernetes/typed/scheduling/v1alpha1","kubernetes/typed/scheduling/v1alpha1/fake","kubernetes/typed/settings/v1alpha1","kubernetes/typed/settings/v1alpha1/fake","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1/fake","kubernetes/typed/storage/v1beta1","kubernetes/typed/storage/v1beta1/fake","pkg/version","plugin/pkg/client/auth/gcp","rest","rest/watch","testing","third_party/forked/golang/template","tools/auth","tools/cache","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/metrics","tools/pager","tools/reference","tools/remotecommand","transport","transport/spdy","util/cert","util/exec","util/flowcontrol","util/homedir","util/integer","util/jsonpath","util/workqueue"]
   revision = "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
 
 [[projects]]
@@ -340,6 +352,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c5f87ad56dc3ba62314dcfe92271681e1768e10d7f30fb0f2a524d0ace225f6e"
+  inputs-digest = "f6b324efb92d07252d3ef206eb12829d050561a5075214365503c1298ee48b5b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,11 @@ cli:
 	go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argo ./cmd/argo
 
 cli-linux: builder
-	${BUILDER_CMD} make cli IMAGE_TAG=$(IMAGE_TAG)
+	${BUILDER_CMD} make cli IMAGE_TAG=$(IMAGE_TAG) IMAGE_NAMESPACE=$(IMAGE_NAMESPACE)
 	mv ${DIST_DIR}/argo ${DIST_DIR}/argo-linux-amd64
 
 cli-darwin: builder
-	${BUILDER_CMD} make cli GOOS=darwin IMAGE_TAG=$(IMAGE_TAG)
+	${BUILDER_CMD} make cli GOOS=darwin IMAGE_TAG=$(IMAGE_TAG) IMAGE_NAMESPACE=$(IMAGE_NAMESPACE)
 	mv ${DIST_DIR}/argo ${DIST_DIR}/argo-darwin-amd64
 
 controller:
@@ -73,7 +73,7 @@ controller-linux: builder
 
 controller-image: controller-linux
 	docker build -t $(IMAGE_PREFIX)workflow-controller:$(IMAGE_TAG) -f Dockerfile-workflow-controller .
-	if [ "$(DOCKER_PUSH)" = "true" ] ; then docker push $(IMAGE_PREFIX)workflow-controller:$(IMAGE_TAG) ; fi
+	@if [ "$(DOCKER_PUSH)" = "true" ] ; then docker push $(IMAGE_PREFIX)workflow-controller:$(IMAGE_TAG) ; fi
 
 executor:
 	go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argoexec ./cmd/argoexec
@@ -83,7 +83,7 @@ executor-linux: builder
 
 executor-image: executor-linux
 	docker build -t $(IMAGE_PREFIX)argoexec:$(IMAGE_TAG) -f Dockerfile-argoexec .
-	if [ "$(DOCKER_PUSH)" = "true" ] ; then docker push $(IMAGE_PREFIX)argoexec:$(IMAGE_TAG) ; fi
+	@if [ "$(DOCKER_PUSH)" = "true" ] ; then docker push $(IMAGE_PREFIX)argoexec:$(IMAGE_TAG) ; fi
 
 lint:
 	gometalinter --deadline 2m --config gometalinter.json --vendor ./...
@@ -103,11 +103,11 @@ ui-image:
 	docker cp argo-ui-builder:/src/node_modules ./ui/tmp
 	docker rm argo-ui-builder
 	docker build -t $(IMAGE_PREFIX)argoui:$(IMAGE_TAG) -f ui/Dockerfile ui
-	if [ "$(DOCKER_PUSH)" = "true" ] ; then docker push $(IMAGE_PREFIX)argoui:$(IMAGE_TAG) ; fi
+	@if [ "$(DOCKER_PUSH)" = "true" ] ; then docker push $(IMAGE_PREFIX)argoui:$(IMAGE_TAG) ; fi
 
 release-precheck:
-	@if [ "$(TREE_STATE)" != "clean" ]; then echo 'git tree state is $(TREE_STATE)' ; exit 1; fi
-	@if [ -z "$(TAG)" ]; then echo 'commit must be tagged to perform release' ; exit 1; fi
+	@if [ "$(GIT_TREE_STATE)" != "clean" ]; then echo 'git tree state is $(GIT_TREE_STATE)' ; exit 1; fi
+	@if [ -z "$(GIT_TAG)" ]; then echo 'commit must be tagged to perform release' ; exit 1; fi
 
 release: release-precheck controller-image cli-darwin cli-linux executor-image ui-image
 

--- a/cmd/argoexec/commands/init.go
+++ b/cmd/argoexec/commands/init.go
@@ -19,10 +19,10 @@ var initCmd = &cobra.Command{
 func loadArtifacts(cmd *cobra.Command, args []string) {
 	wfExecutor := initExecutor()
 	// Download input artifacts
-	err := wfExecutor.LoadScriptSource()
+	err := wfExecutor.StageFiles()
 	if err != nil {
 		_ = wfExecutor.AddAnnotation(common.AnnotationKeyNodeMessage, err.Error())
-		log.Fatalf("Error loading script: %+v", err)
+		log.Fatalf("Error loading staging files: %+v", err)
 	}
 	err = wfExecutor.LoadArtifacts()
 	if err != nil {

--- a/cmd/argoexec/commands/resource.go
+++ b/cmd/argoexec/commands/resource.go
@@ -1,0 +1,43 @@
+package commands
+
+import (
+	"os"
+
+	"github.com/argoproj/argo/workflow/common"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(resourceCmd)
+}
+
+var resourceCmd = &cobra.Command{
+	Use:   "resource (get|create|apply|delete) MANIFEST",
+	Short: "update a resource and wait for resource conditions",
+	Run:   execResource,
+}
+
+func execResource(cmd *cobra.Command, args []string) {
+	if len(args) != 1 {
+		cmd.HelpFunc()(cmd, args)
+		os.Exit(1)
+	}
+
+	wfExecutor := initExecutor()
+	err := wfExecutor.StageFiles()
+	if err != nil {
+		_ = wfExecutor.AddAnnotation(common.AnnotationKeyNodeMessage, err.Error())
+		log.Fatalf("Error staing resource: %+v", err)
+	}
+	resourceName, err := wfExecutor.ExecResource(args[0], common.ExecutorResourceManifestPath)
+	if err != nil {
+		_ = wfExecutor.AddAnnotation(common.AnnotationKeyNodeMessage, err.Error())
+		log.Fatalf("Error running %s resource: %+v", args[0], err)
+	}
+	err = wfExecutor.WaitResource(resourceName)
+	if err != nil {
+		_ = wfExecutor.AddAnnotation(common.AnnotationKeyNodeMessage, err.Error())
+		log.Fatalf("Error waiting for resource %s: %+v", resourceName, err)
+	}
+}

--- a/examples/k8s-jobs.yaml
+++ b/examples/k8s-jobs.yaml
@@ -1,0 +1,41 @@
+# This example demonstrates the 'resource' template type, which provides a
+# convenient way to create/update/delete any type of kubernetes resources
+# in a workflow. The resource template type accepts any k8s manifest
+# (including CRDs) and can perform any kubectl action against it (e.g. create,
+# apply, delete, patch).
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: k8s-jobs-
+spec:
+  entrypoint: pi-tmpl
+  templates:
+  - name: pi-tmpl
+    resource:
+      action: create
+      # successCondition and failureCondition are optional expressions which are
+      # evaluated upon every update of the resource. If failureCondition is ever
+      # evaluated to true, the step is considered failed. Likewise, if successCondition
+      # is ever evaluated to true the step is considered successful. It uses kubernetes
+      # label selection syntax and can be applied against any field of the resource
+      # (not just labels). Multiple AND conditions can be represented by comma
+      # delimited expressions. For more details, see:
+      # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+      successCondition: status.succeeded > 0
+      failureCondition: status.failed > 3
+      manifest: |
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          generateName: pi-job-
+        spec:
+          template:
+            metadata:
+              name: pi
+            spec:
+              containers:
+              - name: pi
+                image: perl
+                command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+              restartPolicy: Never
+          backoffLimit: 4

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -67,21 +67,28 @@ const (
 	// (when there is overlapping paths between artifacts and volume mounts)
 	InitContainerMainFilesystemDir = "/mainctrfs"
 
-	// ScriptTemplateEmptyDir is the path of the emptydir which will be shared between init/main container for script templates
-	ScriptTemplateEmptyDir = "/argo/script"
-	// ScriptTemplateSourcePath is the path which init will write the source file to and the main container will execute
-	ScriptTemplateSourcePath = "/argo/script/source"
+	// ExecutorStagingEmptyDir is the path of the emptydir which is used as a staging area to transfer a file between init/main container for script/resource templates
+	ExecutorStagingEmptyDir = "/argo/staging"
+	// ExecutorScriptSourcePath is the path which init will write the script source file to for script templates
+	ExecutorScriptSourcePath = "/argo/staging/script"
+	// ExecutorResourceManifestPath is the path which init will write the a manifest file to for resource templates
+	ExecutorResourceManifestPath = "/tmp/manifest.yaml"
 
 	// Various environment variables containing pod information exposed to the executor container(s)
 
-	// EnvVarHostIP contains the host IP which the container is executing on.
-	// Used to communicate with kubelet directly. Kubelet enables the wait sidecar
-	// to query pod state without burdening the k8s apiserver.
-	EnvVarHostIP = "ARGO_HOST_IP"
 	// EnvVarPodIP contains the IP of the pod (currently unused)
 	EnvVarPodIP = "ARGO_POD_IP"
 	// EnvVarPodName contains the name of the pod (currently unused)
 	EnvVarPodName = "ARGO_POD_NAME"
 	// EnvVarNamespace contains the namespace of the pod (currently unused)
 	EnvVarNamespace = "ARGO_NAMESPACE"
+
+	// These are global variables that are added to the scope during template execution and can be referenced using {{}} syntax
+
+	// GlobalVarWorkflowName is a global workflow variable referencing the workflow's metadata.name field
+	GlobalVarWorkflowName = "workflow.name"
+	// GlobalVarWorkflowUUID is a global workflow variable referencing the workflow's metadata.uuid field
+	GlobalVarWorkflowUUID = "workflow.uuid"
+	// GlobalVarWorkflowStatus is a global workflow variable referencing the workflow's status.phase field
+	GlobalVarWorkflowStatus = "workflow.status"
 )

--- a/workflow/common/validate_test.go
+++ b/workflow/common/validate_test.go
@@ -550,7 +550,7 @@ spec:
     container:
       image: alpine:latest
       command: [sh, -c]
-      args: ["echo {{workflow.status}}"]
+      args: ["echo {{workflow.status}} {{workflow.uuid}}"]
 `
 
 var workflowStatusNotOnExit = `

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -85,7 +85,6 @@ var (
 
 	// execEnvVars exposes various pod information as environment variables to the exec container
 	execEnvVars = []apiv1.EnvVar{
-		envFromField(common.EnvVarHostIP, "status.hostIP"),
 		envFromField(common.EnvVarPodIP, "status.podIP"),
 		envFromField(common.EnvVarPodName, "metadata.name"),
 		envFromField(common.EnvVarNamespace, "metadata.namespace"),
@@ -105,29 +104,11 @@ func envFromField(envVarName, fieldPath string) apiv1.EnvVar {
 	}
 }
 
-func (woc *wfOperationCtx) createWorkflowPod(nodeName string, tmpl *wfv1.Template) (*apiv1.Pod, error) {
+func (woc *wfOperationCtx) createWorkflowPod(nodeName string, mainCtr apiv1.Container, tmpl *wfv1.Template) (*apiv1.Pod, error) {
 	woc.log.Debugf("Creating Pod: %s", nodeName)
 	tmpl = tmpl.DeepCopy()
-	waitCtr, err := woc.newWaitContainer(tmpl)
-	if err != nil {
-		return nil, err
-	}
-	var mainCtr apiv1.Container
-	if tmpl.Container != nil {
-		mainCtr = *tmpl.Container
-	} else if tmpl.Script != nil {
-		// script case
-		mainCtr = apiv1.Container{
-			Image:   tmpl.Script.Image,
-			Command: tmpl.Script.Command,
-			Args:    []string{common.ScriptTemplateSourcePath},
-		}
-	} else {
-		return nil, errors.InternalError("Cannot create container from non-container/script template")
-	}
 	mainCtr.Name = common.MainContainerName
 	t := true
-
 	pod := apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: woc.wf.NodeID(nodeName),
@@ -151,7 +132,6 @@ func (woc *wfOperationCtx) createWorkflowPod(nodeName string, tmpl *wfv1.Templat
 		Spec: apiv1.PodSpec{
 			RestartPolicy: apiv1.RestartPolicyNever,
 			Containers: []apiv1.Container{
-				*waitCtr,
 				mainCtr,
 			},
 			Volumes: []apiv1.Volume{
@@ -165,16 +145,28 @@ func (woc *wfOperationCtx) createWorkflowPod(nodeName string, tmpl *wfv1.Templat
 	if woc.controller.Config.InstanceID != "" {
 		pod.ObjectMeta.Labels[common.LabelKeyControllerInstanceID] = woc.controller.Config.InstanceID
 	}
-	// Add init container only if it needs input artifacts
-	// or if it is a script template (which needs to populate the script)
-	if len(tmpl.Inputs.Artifacts) > 0 || tmpl.Script != nil {
+
+	if tmpl.GetType() != wfv1.TemplateTypeResource {
+		// we do not need the wait container for resource templates because
+		// argoexec runs as the main container and will perform the job of
+		// annotating the outputs or errors, making the wait container redundant.
+		waitCtr, err := woc.newWaitContainer(tmpl)
+		if err != nil {
+			return nil, err
+		}
+		pod.Spec.Containers = append(pod.Spec.Containers, *waitCtr)
+	}
+
+	// Add init container only if it needs input artifacts. This is also true for
+	// script templates (which needs to populate the script)
+	if len(tmpl.Inputs.Artifacts) > 0 || tmpl.GetType() == wfv1.TemplateTypeScript {
 		initCtr := woc.newInitContainer(tmpl)
 		pod.Spec.InitContainers = []apiv1.Container{initCtr}
 	}
 
 	woc.addNodeSelectors(&pod, tmpl)
 
-	err = woc.addVolumeReferences(&pod, tmpl)
+	err := woc.addVolumeReferences(&pod, tmpl)
 	if err != nil {
 		return nil, err
 	}
@@ -183,13 +175,14 @@ func (woc *wfOperationCtx) createWorkflowPod(nodeName string, tmpl *wfv1.Templat
 	if err != nil {
 		return nil, err
 	}
+
 	err = woc.addArchiveLocation(&pod, tmpl)
 	if err != nil {
 		return nil, err
 	}
 
-	if tmpl.Script != nil {
-		addScriptVolume(&pod)
+	if tmpl.GetType() == wfv1.TemplateTypeScript {
+		addExecutorStagingVolume(&pod)
 	}
 
 	// addSidecars should be called after all volumes have been manipulated
@@ -216,8 +209,8 @@ func (woc *wfOperationCtx) createWorkflowPod(nodeName string, tmpl *wfv1.Templat
 	created, err := woc.controller.clientset.CoreV1().Pods(woc.wf.ObjectMeta.Namespace).Create(&pod)
 	if err != nil {
 		if apierr.IsAlreadyExists(err) {
-			// workflow pod names are deterministic. We can get here if
-			// the controller fails to persist the workflow after creating the pod.
+			// workflow pod names are deterministic. We can get here if the
+			// controller fails to persist the workflow after creating the pod.
 			woc.log.Infof("Skipped pod %s creation: already exists", nodeName)
 			return created, nil
 		}
@@ -231,8 +224,7 @@ func (woc *wfOperationCtx) createWorkflowPod(nodeName string, tmpl *wfv1.Templat
 func (woc *wfOperationCtx) newInitContainer(tmpl *wfv1.Template) apiv1.Container {
 	ctr := woc.newExecContainer(common.InitContainerName, false)
 	ctr.Command = []string{"argoexec"}
-	argoExecCmd := fmt.Sprintf("init")
-	ctr.Args = []string{argoExecCmd}
+	ctr.Args = []string{"init"}
 	ctr.VolumeMounts = []apiv1.VolumeMount{
 		volumeMountPodMetadata,
 	}
@@ -242,8 +234,7 @@ func (woc *wfOperationCtx) newInitContainer(tmpl *wfv1.Template) apiv1.Container
 func (woc *wfOperationCtx) newWaitContainer(tmpl *wfv1.Template) (*apiv1.Container, error) {
 	ctr := woc.newExecContainer(common.WaitContainerName, false)
 	ctr.Command = []string{"argoexec"}
-	argoExecCmd := fmt.Sprintf("wait")
-	ctr.Args = []string{argoExecCmd}
+	ctr.Args = []string{"wait"}
 	ctr.VolumeMounts = []apiv1.VolumeMount{
 		volumeMountPodMetadata,
 		volumeMountDockerLib,
@@ -374,7 +365,7 @@ func (woc *wfOperationCtx) addInputArtifactsVolumes(pod *apiv1.Pod, tmpl *wfv1.T
 	for i, ctr := range pod.Spec.Containers {
 		if ctr.Name == common.MainContainerName {
 			mainCtrIndex = i
-			mainCtr = &ctr
+			mainCtr = &pod.Spec.Containers[i]
 		}
 	}
 	if mainCtr == nil {
@@ -442,23 +433,23 @@ func (woc *wfOperationCtx) addArchiveLocation(pod *apiv1.Pod, tmpl *wfv1.Templat
 	return nil
 }
 
-// addScriptVolume sets up the shared volume between init container and main container
-// containing the template script source code
-func addScriptVolume(pod *apiv1.Pod) {
-	volName := "script"
-	scriptVol := apiv1.Volume{
+// addExecutorStagingVolume sets up a shared staging volume between the init container
+// and main container for the purpose of holding the script source code for script templates
+func addExecutorStagingVolume(pod *apiv1.Pod) {
+	volName := "argo-staging"
+	stagingVol := apiv1.Volume{
 		Name: volName,
 		VolumeSource: apiv1.VolumeSource{
 			EmptyDir: &apiv1.EmptyDirVolumeSource{},
 		},
 	}
-	pod.Spec.Volumes = append(pod.Spec.Volumes, scriptVol)
+	pod.Spec.Volumes = append(pod.Spec.Volumes, stagingVol)
 
 	for i, initCtr := range pod.Spec.InitContainers {
 		if initCtr.Name == common.InitContainerName {
 			volMount := apiv1.VolumeMount{
 				Name:      volName,
-				MountPath: common.ScriptTemplateEmptyDir,
+				MountPath: common.ExecutorStagingEmptyDir,
 			}
 			initCtr.VolumeMounts = append(initCtr.VolumeMounts, volMount)
 			pod.Spec.InitContainers[i] = initCtr
@@ -470,7 +461,7 @@ func addScriptVolume(pod *apiv1.Pod) {
 		if ctr.Name == common.MainContainerName {
 			volMount := apiv1.VolumeMount{
 				Name:      volName,
-				MountPath: common.ScriptTemplateEmptyDir,
+				MountPath: common.ExecutorStagingEmptyDir,
 			}
 			if ctr.VolumeMounts == nil {
 				ctr.VolumeMounts = []apiv1.VolumeMount{volMount}

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -65,6 +65,6 @@ script:
 func TestScriptTemplateWithVolume(t *testing.T) {
 	// ensure we can a script pod with input artifacts
 	tmpl := unmarshalTemplate(scriptTemplateWithInputArtifact)
-	_, err := newWoc().createWorkflowPod(tmpl.Name, tmpl)
+	err := newWoc().executeScript(tmpl.Name, tmpl)
 	assert.Nil(t, err)
 }

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -1,6 +1,8 @@
 package executor
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -18,8 +20,10 @@ import (
 	"github.com/argoproj/argo/workflow/artifacts/s3"
 	"github.com/argoproj/argo/workflow/common"
 	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -105,14 +109,23 @@ func (we *WorkflowExecutor) LoadArtifacts() error {
 	return nil
 }
 
-// LoadScriptSource will create the script source file used in script containers
-func (we *WorkflowExecutor) LoadScriptSource() error {
-	if we.Template.Script == nil {
+// StageFiles will create any files required by script/resource templates
+func (we *WorkflowExecutor) StageFiles() error {
+	var filePath string
+	var body []byte
+	switch we.Template.GetType() {
+	case wfv1.TemplateTypeScript:
+		log.Infof("Loading script source to %s", common.ExecutorScriptSourcePath)
+		filePath = common.ExecutorScriptSourcePath
+		body = []byte(we.Template.Script.Source)
+	case wfv1.TemplateTypeResource:
+		log.Infof("Loading manifest to %s", common.ExecutorResourceManifestPath)
+		filePath = common.ExecutorResourceManifestPath
+		body = []byte(we.Template.Resource.Manifest)
+	default:
 		return nil
 	}
-	log.Infof("Loading script source to %s", common.ScriptTemplateSourcePath)
-	source := []byte(we.Template.Script.Source)
-	err := ioutil.WriteFile(common.ScriptTemplateSourcePath, source, 0644)
+	err := ioutil.WriteFile(filePath, body, 0644)
 	if err != nil {
 		return errors.InternalWrapError(err)
 	}
@@ -500,4 +513,139 @@ func (we *WorkflowExecutor) killSidecars() error {
 		return errors.InternalWrapError(err)
 	}
 	return err
+}
+
+// ExecResource will run kubectl action against a manifest
+func (we *WorkflowExecutor) ExecResource(action string, manifestPath string) (string, error) {
+	args := []string{
+		action,
+	}
+	if action == "delete" {
+		args = append(args, "--ignore-not-found")
+	}
+	args = append(args, "-f")
+	args = append(args, manifestPath)
+	args = append(args, "-o")
+	args = append(args, "name")
+	cmd := exec.Command("kubectl", args...)
+	log.Info(strings.Join(cmd.Args, " "))
+	out, err := cmd.Output()
+	if err != nil {
+		exErr := err.(*exec.ExitError)
+		errMsg := strings.TrimSpace(string(exErr.Stderr))
+		return "", errors.New(errors.CodeBadRequest, errMsg)
+	}
+	resourceName := strings.TrimSpace(string(out))
+	log.Infof(resourceName)
+	return resourceName, nil
+}
+
+// gjsonLabels is an implementation of labels.Labels interface
+// which allows us to take advantage of k8s labels library
+// for the purposes of evaluating fail and success conditions
+type gjsonLabels struct {
+	json []byte
+}
+
+// Has returns whether the provided label exists.
+func (g gjsonLabels) Has(label string) bool {
+	return gjson.GetBytes(g.json, label).Exists()
+}
+
+// Get returns the value for the provided label.
+func (g gjsonLabels) Get(label string) string {
+	return gjson.GetBytes(g.json, label).String()
+}
+
+// WaitResource waits for a specific resource to satisfy either the success or failure condition
+func (we *WorkflowExecutor) WaitResource(resourceName string) error {
+	if we.Template.Resource.SuccessCondition == "" && we.Template.Resource.FailureCondition == "" {
+		return nil
+	}
+	var successReqs labels.Requirements
+	if we.Template.Resource.SuccessCondition != "" {
+		successSelector, err := labels.Parse(we.Template.Resource.SuccessCondition)
+		if err != nil {
+			return errors.Errorf(errors.CodeBadRequest, "success condition '%s' failed to parse: %v", we.Template.Resource.SuccessCondition, err)
+		}
+		log.Infof("Waiting for conditions: %s", successSelector)
+		successReqs, _ = successSelector.Requirements()
+	}
+
+	var failReqs labels.Requirements
+	if we.Template.Resource.FailureCondition != "" {
+		failSelector, err := labels.Parse(we.Template.Resource.FailureCondition)
+		if err != nil {
+			return errors.Errorf(errors.CodeBadRequest, "fail condition '%s' failed to parse: %v", we.Template.Resource.FailureCondition, err)
+		}
+		log.Infof("Failing for conditions: %s", failSelector)
+		failReqs, _ = failSelector.Requirements()
+	}
+
+	cmd := exec.Command("kubectl", "get", resourceName, "-w", "-o", "json")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return errors.InternalWrapError(err)
+	}
+	reader := bufio.NewReader(stdout)
+	log.Info(strings.Join(cmd.Args, " "))
+	if err := cmd.Start(); err != nil {
+		return errors.InternalWrapError(err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+	}()
+	for {
+		jsonBytes, err := readJSON(reader)
+		if err != nil {
+			// TODO: it's possible that kubectl might EOF upon an API disconnect.
+			// In this case, we would want to refork kubectl again.
+			return errors.InternalWrapError(err)
+		}
+		log.Info(string(jsonBytes))
+		ls := gjsonLabels{json: jsonBytes}
+		for _, req := range failReqs {
+			failed := req.Matches(ls)
+			msg := fmt.Sprintf("failure condition '%s' evaluated %v", req, failed)
+			log.Infof(msg)
+			if failed {
+				// TODO: need a better error code instead of BadRequest
+				return errors.Errorf(errors.CodeBadRequest, msg)
+			}
+		}
+		numMatched := 0
+		for _, req := range successReqs {
+			matched := req.Matches(ls)
+			log.Infof("success condition '%s' evaluated %v", req, matched)
+			if matched {
+				numMatched++
+			}
+		}
+		log.Infof("%d/%d success conditions matched", numMatched, len(successReqs))
+		if numMatched >= len(successReqs) {
+			break
+		}
+	}
+	return nil
+}
+
+// readJSON reads from a reader line-by-line until it reaches "}\n" indicating end of json
+func readJSON(reader *bufio.Reader) ([]byte, error) {
+	var buffer bytes.Buffer
+	for {
+		line, err := reader.ReadBytes('\n')
+		if err != nil {
+			return nil, err
+		}
+		isDelimiter := len(line) == 2 && line[0] == byte('}')
+		line = bytes.TrimSpace(line)
+		_, err = buffer.Write(line)
+		if err != nil {
+			return nil, err
+		}
+		if isDelimiter {
+			break
+		}
+	}
+	return buffer.Bytes(), nil
 }


### PR DESCRIPTION
This implements issue #606.

It introduces a new template type, resource, which has the following fields:
```
// ResourceTemplate is a template subtype to manipulate kubernetes resources
type ResourceTemplate struct {
	// Action is the action to perform to the resource.
	// Must be one of: create, apply, delete
	Action string `json:"action"`

	// Manifest contains the kubernetes manifest
	Manifest string `json:"manifest"`

	// WaitCondition is a label selector expression which describes the conditions
	// of the k8s resource in which it is acceptable to proceed to the following step
	WaitCondition string `json:"waitCondition,omitempty"`

	// FailCondition is a label selector expression which describes the conditions
	// of the k8s resource in which the step was considered failed
	FailCondition string `json:"failCondition,omitempty"`
}
```
It has support for "wait conditions" which block the step from proceeding until the expression evaluates true, as well as "fail conditions", which fail the step immediately if evaluated true.