### PR TITLE
[Preview] Implementation of retries.

### DIFF
--- a/api/workflow/v1alpha1/types.go
+++ b/api/workflow/v1alpha1/types.go
@@ -127,6 +127,10 @@ type Template struct {
 	// before the system actively tries to terminate the pod; value must be positive integer
 	// This field is only applicable to container and script templates.
 	ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,omitempty"`
+
+	// Optional number of retries to perform before declaring the container as failed. Only
+	// applicable to `container` type.
+	BackoffLimit *int32 `json:"backoffLimit,omitempty"`
 }
 
 // Inputs are the mechanism for passing parameters, artifacts, volumes from one template to another
@@ -246,6 +250,17 @@ type WorkflowStatus struct {
 	PersistentVolumeClaims []apiv1.Volume `json:"persistentVolumeClaims,omitempty"`
 }
 
+// GetNodesWithRetries returns a list of nodes that have maxRetries > 0.
+func (wfs *WorkflowStatus) GetNodesWithRetries() []NodeStatus {
+	var nodesWithRetries []NodeStatus
+	for _, node := range wfs.Nodes {
+		if node.MaxRetries > 0 {
+			nodesWithRetries = append(nodesWithRetries, node)
+		}
+	}
+	return nodesWithRetries
+}
+
 type NodeStatus struct {
 	// ID is a unique identifier of a node within the worklow
 	// It is implemented as a hash of the node name, which makes the ID deterministic
@@ -273,6 +288,10 @@ type NodeStatus struct {
 
 	// Daemoned tracks whether or not this node was daemoned and need to be terminated
 	Daemoned *bool `json:"daemoned,omitempty"`
+
+	// MaxRetries indicates how many retries should be executed before marking the node
+	// as Failed. MaxRetries is the same as BackoffLimit from the template.
+	MaxRetries int32 `json:"maxRetries,omitempty"`
 
 	// Outputs captures output parameter values and artifact locations
 	Outputs *Outputs `json:"outputs,omitempty"`
@@ -304,6 +323,11 @@ func (n NodeStatus) IsDaemoned() bool {
 // Successful returns whether or not this node completed successfully
 func (n NodeStatus) Successful() bool {
 	return n.Phase == NodeSucceeded || n.Phase == NodeSkipped
+}
+
+// Failed returns whether the node failed during execution.
+func (n NodeStatus) Failed() bool {
+	return n.Phase == NodeFailed
 }
 
 type S3Bucket struct {

--- a/examples/backoff-with-steps.yaml
+++ b/examples/backoff-with-steps.yaml
@@ -1,0 +1,36 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: backoff-with-steps-
+spec:
+  entrypoint: hello-hello-hello
+  templates:
+  - name: hello-hello-hello
+    steps:
+    - - name: hello1
+        template: random-fail
+        arguments:
+          parameters:
+          - name: failPct
+            value: "80"
+    - - name: hello2a
+        template: random-fail
+        arguments:
+          parameters:
+          - name: failPct
+            value: "90"
+      - name: hello2b
+        template: random-fail
+        arguments:
+          parameters:
+          - name: failPct
+            value: "90"
+  - name: random-fail
+    inputs:
+      parameters:
+      - name: failPct
+    backoffLimit: 3
+    container:
+      image: shrinand/random-fail
+      command: ["python"]
+      args: ["/run.py", "{{inputs.parameters.failPct}}"]

--- a/examples/backoff.yaml
+++ b/examples/backoff.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: backoff-
+spec:
+  entrypoint: backoff
+  templates:
+  - name: backoff
+    backoffLimit: 4
+    container:
+      image: shrinand/random-fail
+      command: ["python"]
+      args: ["/run.py", "80"]
+

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -57,6 +57,29 @@ type wfScope struct {
 	scope map[string]interface{}
 }
 
+// newWorkflowOperationCtx creates and initializes a new wfOperationCtx object.
+func newWorkflowOperationCtx(wf *wfv1.Workflow, wfc *WorkflowController) *wfOperationCtx {
+	woc := wfOperationCtx{
+		wf:      wf.DeepCopyObject().(*wfv1.Workflow),
+		orig:    wf,
+		updated: false,
+		log: log.WithFields(log.Fields{
+			"workflow":  wf.ObjectMeta.Name,
+			"namespace": wf.ObjectMeta.Namespace,
+		}),
+		controller:    wfc,
+		globalParams:  make(map[string]string),
+		completedPods: make(map[string]bool),
+		deadline:      time.Now().UTC().Add(maxOperationTime),
+	}
+
+	if woc.wf.Status.Nodes == nil {
+		woc.wf.Status.Nodes = make(map[string]wfv1.NodeStatus)
+	}
+
+	return &woc
+}
+
 // operateWorkflow is the main operator logic of a workflow.
 // It evaluates the current state of the workflow, and its pods
 // and decides how to proceed down the execution path.
@@ -72,19 +95,7 @@ func (wfc *WorkflowController) operateWorkflow(wf *wfv1.Workflow) {
 	// NEVER modify objects from the store. It's a read-only, local cache.
 	// You can use DeepCopy() to make a deep copy of original object and modify this copy
 	// Or create a copy manually for better performance
-	woc := wfOperationCtx{
-		wf:      wf.DeepCopyObject().(*wfv1.Workflow),
-		orig:    wf,
-		updated: false,
-		log: log.WithFields(log.Fields{
-			"workflow":  wf.ObjectMeta.Name,
-			"namespace": wf.ObjectMeta.Namespace,
-		}),
-		controller:    wfc,
-		globalParams:  make(map[string]string),
-		completedPods: make(map[string]bool),
-		deadline:      time.Now().UTC().Add(maxOperationTime),
-	}
+	woc := newWorkflowOperationCtx(wf, wfc)
 	defer woc.persistUpdates()
 	woc.log.Infof("Processing workflow")
 	// Perform one-time workflow validation
@@ -237,6 +248,70 @@ func (woc *wfOperationCtx) persistUpdates() {
 	}
 }
 
+// checkAndRetryPods checks whether any of the failed nodes had retries left and if so,
+// starts a new pod. It returns whether a new pod was created or not.
+func (woc *wfOperationCtx) checkAndRetryPods(failedPods map[string]*apiv1.Pod) (bool, error) {
+	// TODO(shri): This should be fixed by moving the container execution logic into a
+	// separate layer. Steps, Retries, etc. will be higher layers that call into the
+	// container execution layer.
+	for _, node := range woc.wf.Status.GetNodesWithRetries() {
+		if node.Completed() {
+			continue
+		}
+		// Check the last child node
+		lastChildNodeName := node.Children[len(node.Children)-1]
+		lastChildNode, ok := woc.wf.Status.Nodes[lastChildNodeName]
+		if !ok {
+			return false, fmt.Errorf("Failed to find node " + lastChildNodeName)
+		}
+
+		if lastChildNode.Successful() {
+			woc.markNodePhase(node.Name, wfv1.NodeSucceeded)
+			return false, nil
+		}
+
+		// Bail out if the last child has not failed (could be pending, running, etc.)
+		if !lastChildNode.Failed() {
+			return false, nil
+		}
+
+		// This means that the last child node has failed. Check for retries.
+		if int32(len(node.Children)) > node.MaxRetries {
+			woc.log.Infoln("No more retries left. Failing...")
+			woc.markNodePhase(node.Name, wfv1.NodeFailed)
+			return false, nil
+		}
+		woc.log.Infof("%d child nodes failed. Trying again\n", len(node.Children))
+		pod, ok := failedPods[lastChildNodeName]
+		if !ok {
+			return false, fmt.Errorf("Failed to find pod " + lastChildNodeName)
+		}
+		tmplStr, ok := pod.Annotations[common.AnnotationKeyTemplate]
+		if !ok {
+			err := fmt.Errorf(pod.ObjectMeta.Name + " missing template annotation")
+			woc.markNodePhase(node.Name, wfv1.NodeFailed, err.Error())
+			return false, err
+		}
+		var tmpl wfv1.Template
+		err := json.Unmarshal([]byte(tmplStr), &tmpl)
+		if err != nil {
+			woc.markNodePhase(node.Name, wfv1.NodeFailed, err.Error())
+			return false, err
+		}
+		newContainerName := fmt.Sprintf("%s-%d", node.Name, time.Now().Unix())
+		woc.addChildNode(node.Name, newContainerName)
+		woc.markNodePhase(newContainerName, wfv1.NodeRunning)
+		err = woc.executeContainer(newContainerName, &tmpl)
+		if err != nil {
+			woc.markNodePhase(node.Name, wfv1.NodeFailed, err.Error())
+			return false, err
+		}
+		return true, nil
+	}
+
+	return false, nil
+}
+
 // podReconciliation is the process by which a workflow will examine all its related
 // pods and update the node state before continuing the evaluation of the workflow.
 // Records all pods which were observed completed, which will be labeled completed=true
@@ -246,20 +321,33 @@ func (woc *wfOperationCtx) podReconciliation() error {
 	if err != nil {
 		return err
 	}
+	failedPods := make(map[string]*apiv1.Pod)
 	seenPods := make(map[string]bool)
 	for _, pod := range podList.Items {
-		seenPods[pod.ObjectMeta.Name] = true
-		if node, ok := woc.wf.Status.Nodes[pod.ObjectMeta.Name]; ok {
+		nodeNameForPod := pod.Annotations[common.AnnotationKeyNodeName]
+		nodeID := woc.wf.NodeID(nodeNameForPod)
+		seenPods[nodeID] = true
+		if node, ok := woc.wf.Status.Nodes[nodeID]; ok {
 			if newState := assessNodeStatus(&pod, &node); newState != nil {
-				woc.wf.Status.Nodes[pod.ObjectMeta.Name] = *newState
+				woc.wf.Status.Nodes[nodeID] = *newState
 				woc.updated = true
+
+				if newState.Phase == wfv1.NodeFailed {
+					failedPods[pod.ObjectMeta.Name] = &pod
+				}
 			}
 			if woc.wf.Status.Nodes[pod.ObjectMeta.Name].Completed() {
 				woc.completedPods[pod.ObjectMeta.Name] = true
 			}
 		}
 	}
-	if len(podList.Items) > 0 {
+
+	newPodCreated, err := woc.checkAndRetryPods(failedPods)
+	if err != nil {
+		return err
+	}
+
+	if newPodCreated || len(podList.Items) > 0 {
 		return nil
 	}
 	// If we get here, our initial query for pods related to this workflow returned nothing.
@@ -278,10 +366,12 @@ func (woc *wfOperationCtx) podReconciliation() error {
 		return err
 	}
 	for _, pod := range podList.Items {
-		seenPods[pod.ObjectMeta.Name] = true
-		if node, ok := woc.wf.Status.Nodes[pod.ObjectMeta.Name]; ok {
+		nodeNameForPod := pod.Annotations[common.AnnotationKeyNodeName]
+		nodeID := woc.wf.NodeID(nodeNameForPod)
+		seenPods[nodeID] = true
+		if node, ok := woc.wf.Status.Nodes[nodeID]; ok {
 			if newState := assessNodeStatus(&pod, &node); newState != nil {
-				woc.wf.Status.Nodes[pod.ObjectMeta.Name] = *newState
+				woc.wf.Status.Nodes[nodeID] = *newState
 				woc.updated = true
 			}
 			if woc.wf.Status.Nodes[pod.ObjectMeta.Name].Completed() {
@@ -289,6 +379,7 @@ func (woc *wfOperationCtx) podReconciliation() error {
 			}
 		}
 	}
+
 	// Now iterate the workflow pod nodes which we still believe to be incomplete.
 	// If the pod was not seen in the pod list, it means the pod was deleted and it
 	// is now impossible to infer status. The only thing we can do at this point is
@@ -298,6 +389,7 @@ func (woc *wfOperationCtx) podReconciliation() error {
 			// node is not a pod, or it is already complete
 			continue
 		}
+
 		if _, ok := seenPods[nodeID]; !ok {
 			node.Message = "pod deleted"
 			node.Phase = wfv1.NodeError
@@ -628,7 +720,7 @@ func (woc *wfOperationCtx) executeTemplate(templateName string, args wfv1.Argume
 	nodeID := woc.wf.NodeID(nodeName)
 	node, ok := woc.wf.Status.Nodes[nodeID]
 	if ok && node.Completed() {
-		woc.log.Debugf("Node %s already completed", nodeName)
+		woc.log.Infof("Node %s already completed", nodeName)
 		return nil
 	}
 	tmpl := woc.wf.GetTemplate(templateName)
@@ -651,8 +743,30 @@ func (woc *wfOperationCtx) executeTemplate(templateName string, args wfv1.Argume
 			// scheduled (or had a create pod error). Nothing to more to do with this node.
 			return nil
 		}
+
+		// If the user has specified retries, a special "retries" non-leaf node
+		// is created. This node acts as the parent of all retries that will be
+		// done for the container. The status of this node should be "Success"
+		// if any of the retries succeed. Otherwise, it is "Failed".
+
+		// TODO(shri): Mark the current node as a "retry" node
+		// Create a new child node as the first attempt node and
+		// run the template in that node.
+		nodeToExecute := nodeName
+		if tmpl.BackoffLimit != nil && *tmpl.BackoffLimit > 0 {
+			node := woc.markNodePhase(nodeName, wfv1.NodeRunning)
+			node.MaxRetries = *tmpl.BackoffLimit
+			woc.wf.Status.Nodes[nodeID] = *node
+
+			// Create new node as child of 'node'
+			newContainerName := fmt.Sprintf("%s-%d", nodeName, time.Now().Unix())
+			woc.markNodePhase(newContainerName, wfv1.NodeRunning)
+			woc.addChildNode(nodeName, newContainerName)
+			nodeToExecute = newContainerName
+		}
+
 		// We have not yet created the pod
-		err = woc.executeContainer(nodeName, tmpl)
+		err = woc.executeContainer(nodeToExecute, tmpl)
 	case wfv1.TemplateTypeSteps:
 		if !ok {
 			node = *woc.markNodePhase(nodeName, wfv1.NodeRunning)
@@ -731,9 +845,6 @@ func (woc *wfOperationCtx) markWorkflowError(err error, markCompleted bool) {
 
 // markNodePhase marks a node with the given phase, creating the node if necessary and handles timestamps
 func (woc *wfOperationCtx) markNodePhase(nodeName string, phase wfv1.NodePhase, message ...string) *wfv1.NodeStatus {
-	if woc.wf.Status.Nodes == nil {
-		woc.wf.Status.Nodes = make(map[string]wfv1.NodeStatus)
-	}
 	nodeID := woc.wf.NodeID(nodeName)
 	node, ok := woc.wf.Status.Nodes[nodeID]
 	if !ok {
@@ -754,6 +865,7 @@ func (woc *wfOperationCtx) markNodePhase(nodeName string, phase wfv1.NodePhase, 
 	}
 	woc.wf.Status.Nodes[nodeID] = node
 	woc.updated = true
+	woc.log.Debugf("Marked node %s %s\n", nodeName, phase)
 	return &node
 }
 
@@ -763,6 +875,7 @@ func (woc *wfOperationCtx) markNodeError(nodeName string, err error) *wfv1.NodeS
 }
 
 func (woc *wfOperationCtx) executeContainer(nodeName string, tmpl *wfv1.Template) error {
+	woc.log.Debugf("Executing node %s with container template: %v\n", nodeName, tmpl)
 	pod, err := woc.createWorkflowPod(nodeName, *tmpl.Container, tmpl)
 	if err != nil {
 		woc.markNodeError(nodeName, err)


### PR DESCRIPTION
This PR is mainly to give a preview of the implementation of adding "retries" to containers. I'm not done testing this fully.

So far, I've tested:
* Retries where eventually the container succeeds.
* Retries where the containers fails.
* Steps with containers that have retries in them (see example yaml).
* NodeStatus' is correctly populated.
* Workflows that don't have retries are unaffected.

The implementation basically creates a new non-leaf node that keeps tracks of the retries.

`argo get` doesn't yet show the nodes correctly. Nor does the web UI.