### PR TITLE
Prevent a potential k8s scheduler panic from incomplete setting of pod ownership reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.0-alpha4 (Unreleased)
+- Prevent a potential k8s scheduler panic from incomplete setting of pod ownership reference
+
 ## 2.0.0-alpha3 (2018-01-02)
 + Introduce the "resource" template type for performing CRUD operations on k8s resources
 + Support for workflow exit handlers

--- a/cmd/argo/commands/common.go
+++ b/cmd/argo/commands/common.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/argoproj/argo/errors"
+	"github.com/argoproj/argo/pkg/apis/workflow"
 	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	wfclientset "github.com/argoproj/argo/pkg/client/clientset/versioned"
 	"github.com/argoproj/argo/pkg/client/clientset/versioned/typed/workflow/v1alpha1"
@@ -129,7 +130,7 @@ func splitYAMLFile(body []byte) ([]wfv1.Workflow, error) {
 		}
 		var wf wfv1.Workflow
 		err := yaml.Unmarshal([]byte(manifestStr), &wf)
-		if wf.Kind != "" && wf.Kind != wfv1.CRDKind {
+		if wf.Kind != "" && wf.Kind != workflow.Kind {
 			// If we get here, it was a k8s manifest which was not of type 'Workflow'
 			// We ignore these since we only care about validating Workflow manifests.
 			continue

--- a/cmd/argo/commands/install.go
+++ b/cmd/argo/commands/install.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/argoproj/argo"
 	"github.com/argoproj/argo/errors"
-	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo/pkg/apis/workflow"
 	"github.com/argoproj/argo/workflow/common"
 	"github.com/argoproj/argo/workflow/controller"
 	"github.com/ghodss/yaml"
@@ -447,7 +447,7 @@ func installUIService(clientset *kubernetes.Clientset, args InstallFlags) {
 func installCRD(clientset *kubernetes.Clientset) {
 	apiextensionsclientset, err := apiextensionsclient.NewForConfig(restConfig)
 	if err != nil {
-		log.Fatalf("Failed to create CustomResourceDefinition '%s': %v", wfv1.CRDFullName, err)
+		log.Fatalf("Failed to create CustomResourceDefinition '%s': %v", workflow.FullName, err)
 	}
 
 	// initialize custom resource using a CustomResourceDefinition if it does not exist
@@ -456,7 +456,7 @@ func installCRD(clientset *kubernetes.Clientset) {
 		if !apierr.IsAlreadyExists(err) {
 			log.Fatalf("Failed to create CustomResourceDefinition: %v", err)
 		}
-		fmt.Printf("CustomResourceDefinition '%s' already exists\n", wfv1.CRDFullName)
+		fmt.Printf("CustomResourceDefinition '%s' already exists\n", workflow.FullName)
 	} else {
 		fmt.Printf("CustomResourceDefinition '%s' created\n", result.GetObjectMeta().GetName())
 	}

--- a/cmd/argo/commands/uninstall.go
+++ b/cmd/argo/commands/uninstall.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"fmt"
 
-	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo/pkg/apis/workflow"
 	"github.com/argoproj/argo/workflow/common"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -85,11 +85,11 @@ func uninstall(cmd *cobra.Command, args []string) {
 	err = common.DeleteCustomResourceDefinition(apiextensionsclientset)
 	if err != nil {
 		if !apierr.IsNotFound(err) {
-			log.Fatalf("Failed to delete CustomResourceDefinition '%s': %v", wfv1.CRDFullName, err)
+			log.Fatalf("Failed to delete CustomResourceDefinition '%s': %v", workflow.FullName, err)
 		}
-		fmt.Printf("CustomResourceDefinition '%s' not found\n", wfv1.CRDFullName)
+		fmt.Printf("CustomResourceDefinition '%s' not found\n", workflow.FullName)
 	} else {
-		fmt.Printf("CustomResourceDefinition '%s' deleted\n", wfv1.CRDFullName)
+		fmt.Printf("CustomResourceDefinition '%s' deleted\n", workflow.FullName)
 	}
 
 	// Delete role binding

--- a/pkg/apis/workflow/register.go
+++ b/pkg/apis/workflow/register.go
@@ -1,0 +1,11 @@
+package workflow
+
+// Workflow constants
+const (
+	Kind      string = "Workflow"
+	Group     string = "argoproj.io"
+	Singular  string = "workflow"
+	Plural    string = "workflows"
+	ShortName string = "wf"
+	FullName  string = Plural + "." + Group
+)

--- a/pkg/apis/workflow/v1alpha1/register.go
+++ b/pkg/apis/workflow/v1alpha1/register.go
@@ -1,20 +1,28 @@
 package v1alpha1
 
 import (
+	"github.com/argoproj/argo/pkg/apis/workflow"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var (
-	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	AddToScheme   = SchemeBuilder.AddToScheme
+	// SchemeGroupVersion is group version used to register these objects
+	SchemeGroupVersion     = schema.GroupVersion{Group: workflow.Group, Version: "v1alpha1"}
+	SchemaGroupVersionKind = schema.GroupVersionKind{Group: workflow.Group, Version: "v1alpha1", Kind: workflow.Kind}
 )
 
 // Resource takes an unqualified resource and returns a Group-qualified GroupResource.
 func Resource(resource string) schema.GroupResource {
 	return SchemeGroupVersion.WithResource(resource).GroupResource()
 }
+
+var (
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	AddToScheme   = SchemeBuilder.AddToScheme
+)
 
 // addKnownTypes adds the set of types defined in this package to the supplied scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {

--- a/pkg/apis/workflow/v1alpha1/types.go
+++ b/pkg/apis/workflow/v1alpha1/types.go
@@ -7,18 +7,6 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-)
-
-// CRD constants
-const (
-	CRDKind      string = "Workflow"
-	CRDSingular  string = "workflow"
-	CRDPlural    string = "workflows"
-	CRDShortName string = "wf"
-	CRDGroup     string = "argoproj.io"
-	CRDVersion   string = "v1alpha1"
-	CRDFullName  string = CRDPlural + "." + CRDGroup
 )
 
 // TemplateType is the type of a template
@@ -43,9 +31,6 @@ const (
 	NodeFailed    NodePhase = "Failed"
 	NodeError     NodePhase = "Error"
 )
-
-// Create a Rest client with the new CRD Schema
-var SchemeGroupVersion = schema.GroupVersion{Group: CRDGroup, Version: CRDVersion}
 
 // +genclient
 // +genclient:noStatus

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -1,7 +1,7 @@
 package common
 
 import (
-	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo/pkg/apis/workflow"
 )
 
 const (
@@ -38,25 +38,25 @@ const (
 	DockerSockVolumeName = "docker-sock"
 
 	// AnnotationKeyNodeName is the pod metadata annotation key containing the workflow node name
-	AnnotationKeyNodeName = wfv1.CRDFullName + "/node-name"
+	AnnotationKeyNodeName = workflow.FullName + "/node-name"
 	// AnnotationKeyNodeMessage is the pod metadata annotation key the executor will use to
 	// communicate errors encountered by the executor during artifact load/save, etc...
-	AnnotationKeyNodeMessage = wfv1.CRDFullName + "/node-message"
+	AnnotationKeyNodeMessage = workflow.FullName + "/node-message"
 	// AnnotationKeyTemplate is the pod metadata annotation key containing the container template as JSON
-	AnnotationKeyTemplate = wfv1.CRDFullName + "/template"
+	AnnotationKeyTemplate = workflow.FullName + "/template"
 	// AnnotationKeyOutputs is the pod metadata annotation key containing the container outputs
-	AnnotationKeyOutputs = wfv1.CRDFullName + "/outputs"
+	AnnotationKeyOutputs = workflow.FullName + "/outputs"
 
 	// LabelKeyControllerInstanceID is the label the controller will carry forward to pod labels
 	// for the purposes of workflow segregation
-	LabelKeyControllerInstanceID = wfv1.CRDFullName + "/controller-instanceid"
+	LabelKeyControllerInstanceID = workflow.FullName + "/controller-instanceid"
 	// LabelKeyCompleted is the metadata label applied on worfklows and workflow pods to indicates if resource is completed
 	// Workflows and pods with a completed=true label will be ignored by the controller
-	LabelKeyCompleted = wfv1.CRDFullName + "/completed"
+	LabelKeyCompleted = workflow.FullName + "/completed"
 	// LabelKeyWorkflow is the pod metadata label to indicate the associated workflow name
-	LabelKeyWorkflow = wfv1.CRDFullName + "/workflow"
+	LabelKeyWorkflow = workflow.FullName + "/workflow"
 	// LabelKeyPhase is a label applied to workflows to indicate the current phase of the workflow (for filtering purposes)
-	LabelKeyPhase = wfv1.CRDFullName + "/phase"
+	LabelKeyPhase = workflow.FullName + "/phase"
 
 	// ExecutorArtifactBaseDir is the base directory in the init container in which artifacts will be copied to.
 	// Each artifact will be named according to its input name (e.g: /argo/inputs/artifacts/CODE)

--- a/workflow/common/createcrd.go
+++ b/workflow/common/createcrd.go
@@ -3,6 +3,7 @@ package common
 import (
 	"time"
 
+	"github.com/argoproj/argo/pkg/apis/workflow"
 	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	log "github.com/sirupsen/logrus"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -15,16 +16,16 @@ import (
 func CreateCustomResourceDefinition(clientset apiextensionsclient.Interface) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
 	crd := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: wfv1.CRDFullName,
+			Name: workflow.FullName,
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   wfv1.CRDGroup,
+			Group:   workflow.Group,
 			Version: wfv1.SchemeGroupVersion.Version,
 			Scope:   apiextensionsv1beta1.NamespaceScoped,
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Plural:     wfv1.CRDPlural,
-				Kind:       wfv1.CRDKind,
-				ShortNames: []string{wfv1.CRDShortName},
+				Plural:     workflow.Plural,
+				Kind:       workflow.Kind,
+				ShortNames: []string{workflow.ShortName},
 			},
 		},
 	}
@@ -36,7 +37,7 @@ func CreateCustomResourceDefinition(clientset apiextensionsclient.Interface) (*a
 
 	// wait for CRD being established
 	err = wait.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {
-		crd, err = clientset.Apiextensions().CustomResourceDefinitions().Get(wfv1.CRDFullName, metav1.GetOptions{})
+		crd, err = clientset.Apiextensions().CustomResourceDefinitions().Get(workflow.FullName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -55,7 +56,7 @@ func CreateCustomResourceDefinition(clientset apiextensionsclient.Interface) (*a
 		return false, err
 	})
 	if err != nil {
-		deleteErr := clientset.Apiextensions().CustomResourceDefinitions().Delete(wfv1.CRDFullName, nil)
+		deleteErr := clientset.Apiextensions().CustomResourceDefinitions().Delete(workflow.FullName, nil)
 		if deleteErr != nil {
 			return nil, errors.NewAggregate([]error{err, deleteErr})
 		}
@@ -67,5 +68,5 @@ func CreateCustomResourceDefinition(clientset apiextensionsclient.Interface) (*a
 // DeleteCustomResourceDefinition deletes the Workflow CRD
 func DeleteCustomResourceDefinition(clientset apiextensionsclient.Interface) error {
 	crdClient := clientset.Apiextensions().CustomResourceDefinitions()
-	return crdClient.Delete(wfv1.CRDFullName, nil)
+	return crdClient.Delete(workflow.FullName, nil)
 }

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -108,7 +108,6 @@ func (woc *wfOperationCtx) createWorkflowPod(nodeName string, mainCtr apiv1.Cont
 	woc.log.Debugf("Creating Pod: %s", nodeName)
 	tmpl = tmpl.DeepCopy()
 	mainCtr.Name = common.MainContainerName
-	t := true
 	pod := apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: woc.wf.NodeID(nodeName),
@@ -120,13 +119,7 @@ func (woc *wfOperationCtx) createWorkflowPod(nodeName string, mainCtr apiv1.Cont
 				common.AnnotationKeyNodeName: nodeName,
 			},
 			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion:         wfv1.CRDFullName,
-					Kind:               wfv1.CRDKind,
-					Name:               woc.wf.ObjectMeta.Name,
-					UID:                woc.wf.ObjectMeta.UID,
-					BlockOwnerDeletion: &t,
-				},
+				*metav1.NewControllerRef(woc.wf, wfv1.SchemaGroupVersionKind),
 			},
 		},
 		Spec: apiv1.PodSpec{


### PR DESCRIPTION
This resolves issue #656.

When setting the ownership reference of a pod/pvc, we should also set the `controller: true`. Although this field is marked optional in the API, on at least one cluster it panics the k8s scheduler when left unset. I believe this to be a k8s bug. In general, I believe the controller should be set when applying ownership from the creator resource.

Also moved the CRD constants out of the v1alpha1 package, since they are constants that will not change from version to version.