### PR TITLE
Clarify where the Minio secret comes from

### DIFF
--- a/demo.md
+++ b/demo.md
@@ -98,6 +98,8 @@ $ kubectl edit configmap workflow-controller-configmap -n kube-system
           key: secretkey
 ```
 
+The Minio secret is retrived from the namespace you use to run workflows. If Minio is installed in a different namespace then you will need to create a copy of its secret in the namespace you use for workflows.
+
 ## 6. Run a workflow which uses artifacts
 ```
 $ argo submit https://raw.githubusercontent.com/argoproj/argo/master/examples/artifact-passing.yaml


### PR DESCRIPTION
I found this confusing when trying to reuse an existing minio deployment in a separate namespace.  Does this advice seem reasonable?  I think the behaviour is right, as it keeps secret handling simple, it just wasn't obvious to me.

Feel free to close and just take as docs feedback 😀