### PR TITLE
Use minimal ClusterRoles to be used by workflow-controller and argo-ui

### DIFF
--- a/cmd/argo/commands/const.go
+++ b/cmd/argo/commands/const.go
@@ -1,8 +1,61 @@
 package commands
 
-// Constants used by Argo
+import rbacv1 "k8s.io/api/rbac/v1"
+
 const (
-	ArgoServiceAccount = "argo"
-	ArgoClusterRole    = "argo-cluster-role"
-	ArgoServiceName    = "argo-ui"
+	// Argo controller resource constants
+	ArgoControllerServiceAccount     = "argo"
+	ArgoControllerClusterRole        = "argo-cluster-role"
+	ArgoControllerClusterRoleBinding = "argo-binding"
+
+	// Argo UI resource constants
+	ArgoUIServiceAccount     = "argo-ui"
+	ArgoUIClusterRole        = "argo-ui-cluster-role"
+	ArgoUIClusterRoleBinding = "argo-ui-binding"
+	ArgoUIDeploymentName     = "argo-ui"
+	ArgoUIServiceName        = "argo-ui"
+)
+
+var (
+	ArgoControllerPolicyRules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			// TODO(jesse): remove exec privileges when issue #499 is resolved
+			Resources: []string{"pods", "pods/exec"},
+			Verbs:     []string{"create", "get", "list", "watch", "update", "patch"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"configmaps"},
+			Verbs:     []string{"get", "watch", "list"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"persistentvolumeclaims"},
+			Verbs:     []string{"create", "delete"},
+		},
+		{
+			APIGroups: []string{"argoproj.io"},
+			Resources: []string{"workflows"},
+			Verbs:     []string{"get", "list", "watch", "update", "patch"},
+		},
+	}
+
+	ArgoUIPolicyRules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"pods", "pods/exec", "pods/log"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"get"},
+		},
+		{
+			APIGroups: []string{"argoproj.io"},
+			Resources: []string{"workflows"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+	}
 )

--- a/demo.md
+++ b/demo.md
@@ -23,7 +23,12 @@ $ chmod +x /usr/local/bin/argo
 ```
 $ argo install
 ```
-NOTE: the instructions below assume the installation of argo into the `kube-system` namespace (the default behavior). A different namespace can be chosen using the `argo install --install-namespace <name>` flag, in which case you should substitute `kube-system` with your chosen namespace in the examples below.
+NOTE:
+* On GKE with RBAC enabled, you may need to grant your account the ability to create new cluster roles
+```
+$ kubectl create clusterrolebinding YOURNAME-cluster-admin-binding --clusterrole=cluster-admin --user=YOUREMAIL@gmail.com
+```
+* The subsequent instructions below assume the installation of argo into the `kube-system` namespace (the default behavior). A different namespace can be chosen using the `argo install --install-namespace <name>` flag, in which case you should substitute `kube-system` with your chosen namespace in the examples below.
 
 ## 3. Configure the service account to run workflows (required for RBAC clusters)
 For clusters with RBAC enabled, the 'default' service account is too limited to do any kind of meaningful work. Run the following command to grant admin privileges to the 'default' service account in the namespace 'default':
@@ -114,14 +119,23 @@ $ argo submit https://raw.githubusercontent.com/argoproj/argo/master/examples/ar
 
 By default, the Argo UI service is not exposed with an external IP. To access the UI, use one of the following methods:
 
-#### Method 1: kubectl proxy
+#### Method 1: kubectl port-forward
+Run:
+```
+$ kubectl port-forward $(kubectl get pods -n kube-system -l app=argo-ui -o jsonpath='{.items[0].metadata.name}') -n kube-system 8001:8001
+```
+Then visit: http://127.0.0.1:8001/
+
+#### Method 2: kubectl proxy
 Run:
 ```
 $ kubectl proxy
 ```
-Then visit the following URL in your browser: http://127.0.0.1:8001/api/v1/proxy/namespaces/kube-system/services/argo-ui/
+Then visit: http://127.0.0.1:8001/api/v1/proxy/namespaces/kube-system/services/argo-ui/
 
-#### Method 2: Use a LoadBalancer
+NOTE: artifact download and webconsole is not supported using this method
+
+#### Method 3: Use a LoadBalancer
 
 Update the argo-ui service to be of type `LoadBalancer`.
 ```

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -38,7 +38,7 @@ func getKubernetesClient() *kubernetes.Clientset {
 func newInstallArgs(namespace string) commands.InstallFlags {
 	return commands.InstallFlags{
 		ControllerName:  common.DefaultControllerDeploymentName,
-		UIName:          common.DefaultUiDeploymentName,
+		UIName:          commands.ArgoUIDeploymentName,
 		Namespace:       namespace,
 		ConfigMap:       common.DefaultConfigMapName(common.DefaultControllerDeploymentName),
 		ControllerImage: "argoproj/workflow-controller:latest",
@@ -55,7 +55,7 @@ func createNamespaceForTest() string {
 			GenerateName: "argo-e2e-test-",
 		},
 	}
-	cns, err := clientset.Core().Namespaces().Create(ns)
+	cns, err := clientset.CoreV1().Namespaces().Create(ns)
 	if err != nil {
 		panic(err)
 	}
@@ -66,7 +66,7 @@ func createNamespaceForTest() string {
 func deleteTestNamespace(namespace string) error {
 	clientset := getKubernetesClient()
 	deleteOptions := metav1.DeleteOptions{}
-	return clientset.Core().Namespaces().Delete(namespace, &deleteOptions)
+	return clientset.CoreV1().Namespaces().Delete(namespace, &deleteOptions)
 }
 
 func installArgoInNamespace(namespace string) {

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -7,7 +7,6 @@ import (
 const (
 	// DefaultControllerDeploymentName is the default deployment name of the workflow controller
 	DefaultControllerDeploymentName = "workflow-controller"
-	DefaultUiDeploymentName         = "argo-ui"
 	// DefaultControllerNamespace is the default namespace where the workflow controller is installed
 	DefaultControllerNamespace = "kube-system"
 

--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -281,7 +281,7 @@ func addPodMetadata(c kubernetes.Interface, field, podName, namespace, key, valu
 		return errors.InternalWrapError(err)
 	}
 	for attempt := 0; attempt < patchRetries; attempt++ {
-		_, err = c.Core().Pods(namespace).Patch(podName, types.MergePatchType, patch)
+		_, err = c.CoreV1().Pods(namespace).Patch(podName, types.MergePatchType, patch)
 		if err != nil {
 			if !apierr.IsConflict(err) {
 				return err

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -359,7 +359,7 @@ func (wfc *WorkflowController) watchControllerConfigMap(ctx context.Context) (ca
 }
 
 func (wfc *WorkflowController) newControllerConfigMapWatch() *cache.ListWatch {
-	c := wfc.kubeclientset.Core().RESTClient()
+	c := wfc.kubeclientset.CoreV1().RESTClient()
 	resource := "configmaps"
 	name := wfc.ConfigMap
 	namespace := wfc.ConfigMapNS
@@ -386,7 +386,7 @@ func (wfc *WorkflowController) newControllerConfigMapWatch() *cache.ListWatch {
 }
 
 func (wfc *WorkflowController) newWorkflowPodWatch() *cache.ListWatch {
-	c := wfc.kubeclientset.Core().RESTClient()
+	c := wfc.kubeclientset.CoreV1().RESTClient()
 	resource := "pods"
 	namespace := wfc.Config.Namespace
 	fieldSelector := fields.ParseSelectorOrDie("status.phase!=Pending")


### PR DESCRIPTION
This addresses issue #662.

It creates two new service accounts (argo and argo-ui) and ClusterRoles (argo-cluster-role and argo-ui-cluster-role) as part of install, These roles have the bare minimum privileges necessary to run the workflow-controller and argo-ui respectively.

@alexmt please review argo-ui cluster role and let me know if there are additional privileges needed by argo-ui that I am not aware of.