### PR TITLE
Introduce communication channel from workflow-controller to executor through pod annotations

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -40,14 +40,20 @@
 [[projects]]
   name = "github.com/emicklei/go-restful"
   packages = [".","log"]
-  revision = "5741799b275a3c4a5a9623a993576d7545cf7b5c"
-  version = "v2.4.0"
+  revision = "2dd44038f0b95ae693b266c5f87593b5d2fdd78d"
+  version = "v2.5.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/evanphx/json-patch"
   packages = ["."]
   revision = "944e07253867aacae43c04b2e6a239005443f33a"
+
+[[projects]]
+  name = "github.com/fsnotify/fsnotify"
+  packages = ["."]
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  version = "v1.4.7"
 
 [[projects]]
   name = "github.com/ghodss/yaml"
@@ -148,8 +154,8 @@
 [[projects]]
   name = "github.com/imdario/mergo"
   packages = ["."]
-  revision = "7fe0c75c13abdee74b09fcacef5ea1c6bba6a874"
-  version = "0.2.4"
+  revision = "f1ac5984e69fed03e0574a92f70c59f132616ea2"
+  version = "0.3.0"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
@@ -227,7 +233,7 @@
   branch = "master"
   name = "github.com/spf13/cobra"
   packages = ["."]
-  revision = "b95ab734e27d33e0d8fbabf71ca990568d4e2020"
+  revision = "0c34d16c3123764e413b9ed982ada58b1c3d53ea"
 
 [[projects]]
   name = "github.com/spf13/pflag"
@@ -269,25 +275,25 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "0fcca4842a8d74bfddc2c96a073bd2a4d2a7a2e8"
+  revision = "13931e22f9e72ea58bb73048bc752b48c6d4d4ac"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","context/ctxhttp","http2","http2/hpack","idna","lex/httplex"]
-  revision = "d866cfc389cec985d6fda2859936a575a55a3ab6"
+  revision = "5ccada7d0a7ba9aeb5d3aca8d3501b4c2a509fec"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/oauth2"
   packages = [".","google","internal","jws","jwt"]
-  revision = "876b1c6ee618a9f8fa31ded3b27708d44b3153af"
+  revision = "30785a2c434e431ef7c507b54617d6a951d5f2b4"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
-  revision = "28a7276518d399b9634904daad79e18b44d481bc"
+  revision = "fff93fa7cd278d84afc205751523809c464168ab"
 
 [[projects]]
   branch = "master"
@@ -299,7 +305,7 @@
   branch = "master"
   name = "golang.org/x/tools"
   packages = ["go/ast/astutil","imports"]
-  revision = "96b5a5404f303f074e6117d832a9873c439508f0"
+  revision = "8ea45f96742f825c49e900f42a01928554b5a6a0"
 
 [[projects]]
   name = "google.golang.org/appengine"
@@ -317,7 +323,7 @@
   branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "c95af922eae69f190717a0b7148960af8c55a072"
+  revision = "d670f9405373e636a5a2765eea47fac0c9bc91a4"
 
 [[projects]]
   branch = "release-1.9"
@@ -329,7 +335,7 @@
   branch = "release-1.9"
   name = "k8s.io/apiextensions-apiserver"
   packages = ["pkg/apis/apiextensions","pkg/apis/apiextensions/v1beta1","pkg/client/clientset/clientset","pkg/client/clientset/clientset/scheme","pkg/client/clientset/clientset/typed/apiextensions/v1beta1"]
-  revision = "097c49c1906b3527571b6876c7bf47c4487f6c61"
+  revision = "6f29dd12234812844d29f52bd520bb01374619ce"
 
 [[projects]]
   branch = "release-1.9"
@@ -359,11 +365,11 @@
   branch = "master"
   name = "k8s.io/kube-openapi"
   packages = ["pkg/common"]
-  revision = "b16ebc07f5cad97831f961e4b5a9cc1caed33b7e"
+  revision = "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6eda994cb9f9aa22b81e1d421255810c4e5af1ff4741166de5aaf725c98d4023"
+  inputs-digest = "37a8421fecc4292a16b7a657cdc862fcc8e4471472309d1aaaf1b8444fa415be"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/argoexec/commands/root.go
+++ b/cmd/argoexec/commands/root.go
@@ -1,17 +1,9 @@
 package commands
 
 import (
-	"bufio"
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io"
 	"os"
-	"strings"
 
 	"github.com/argoproj/argo"
-	"github.com/argoproj/argo/errors"
-	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo/util/cmd"
 	"github.com/argoproj/argo/workflow/common"
 	"github.com/argoproj/argo/workflow/executor"
@@ -69,14 +61,6 @@ func initExecutor() *executor.WorkflowExecutor {
 		podAnnotationsPath = GlobalArgs.podAnnotationsPath
 	}
 
-	var wfTemplate wfv1.Template
-
-	// Read template
-	err := getTemplateFromPodAnnotations(podAnnotationsPath, &wfTemplate)
-	if err != nil {
-		log.Fatalf("Error getting template %v", err)
-	}
-
 	config, err := getClientConfig(GlobalArgs.kubeConfig)
 	if err != nil {
 		panic(err.Error())
@@ -97,95 +81,16 @@ func initExecutor() *executor.WorkflowExecutor {
 
 	// Initialize workflow executor
 	wfExecutor := executor.WorkflowExecutor{
-		PodName:   podName,
-		Template:  wfTemplate,
-		ClientSet: clientset,
-		Namespace: namespace,
+		PodName:            podName,
+		ClientSet:          clientset,
+		Namespace:          namespace,
+		PodAnnotationsPath: podAnnotationsPath,
+	}
+	err = wfExecutor.LoadTemplate()
+	if err != nil {
+		panic(err.Error())
 	}
 	yamlBytes, _ := yaml.Marshal(&wfExecutor.Template)
 	log.Infof("Executor (version: %s) initialized with template:\n%s", argo.GetVersion(), string(yamlBytes))
 	return &wfExecutor
-}
-
-// Open the Kubernetes downward api file and
-// read the pod annotation file that contains template and then
-// unmarshal the template
-func getTemplateFromPodAnnotations(annotationsPath string, template *wfv1.Template) error {
-	// Read the annotation file
-	file, err := os.Open(annotationsPath)
-	if err != nil {
-		fmt.Printf("ERROR opening annotation file from %s\n", annotationsPath)
-		return errors.InternalWrapError(err)
-	}
-
-	defer func() {
-		_ = file.Close()
-	}()
-	reader := bufio.NewReader(file)
-
-	// Prefix of template property in the annotation file
-	prefix := fmt.Sprintf("%s=", common.AnnotationKeyTemplate)
-
-	for {
-		// Read line-by-line
-		var buffer bytes.Buffer
-
-		var l []byte
-		var isPrefix bool
-		for {
-			l, isPrefix, err = reader.ReadLine()
-			buffer.Write(l)
-
-			// If we've reached the end of the line, stop reading.
-			if !isPrefix {
-				break
-			}
-
-			// If we're just at the EOF, break
-			if err != nil {
-				break
-			}
-		}
-
-		// The end of the annotation file
-		if err == io.EOF {
-			break
-		}
-
-		line := buffer.String()
-
-		// Read template property
-		if strings.HasPrefix(line, prefix) {
-			// Trim the prefix
-			templateContent := strings.TrimPrefix(line, prefix)
-
-			// This part is a bit tricky in terms of unmarshalling
-			// The content in the file will be something like,
-			// `"{\"type\":\"container\",\"inputs\":{},\"outputs\":{}}"`
-			// which is required to unmarshal twice
-
-			// First unmarshal to a string without escaping characters
-			var templateString string
-			err = json.Unmarshal([]byte(templateContent), &templateString)
-			if err != nil {
-				fmt.Printf("Error unmarshalling annotation into template string, %s, %v\n", templateContent, err)
-				return errors.InternalWrapError(err)
-			}
-
-			// Second unmarshal to a template
-			err = json.Unmarshal([]byte(templateString), template)
-			if err != nil {
-				fmt.Printf("Error unmarshalling annotation into template, %s, %v\n", templateString, err)
-				return errors.InternalWrapError(err)
-			}
-			return nil
-		}
-	}
-
-	if err != io.EOF {
-		return errors.InternalWrapError(err)
-	}
-
-	// If reaching here, then no template prefix in the file
-	return errors.InternalErrorf("No template property found from annotation file: %s", annotationsPath)
 }

--- a/examples/daemon-nginx.yaml
+++ b/examples/daemon-nginx.yaml
@@ -28,8 +28,6 @@ spec:
           port: 80
         initialDelaySeconds: 2
         timeoutSeconds: 1
-      command: ["/bin/sh", "-c"]
-      args: ["nginx"]
 
   - name: nginx-client
     inputs:
@@ -38,5 +36,5 @@ spec:
     container:
       image: appropriate/curl:latest
       command: ["/bin/sh", "-c"]
-      args: ["echo curl --silent -G http://{{inputs.parameters.server-ip}}:80/ && curl --silent -G http://{{inputs.parameters.server-ip}}:80/ && sleep 3600"]
+      args: ["echo curl --silent -G http://{{inputs.parameters.server-ip}}:80/ && curl --silent -G http://{{inputs.parameters.server-ip}}:80/"]
 

--- a/pkg/apis/workflow/v1alpha1/types.go
+++ b/pkg/apis/workflow/v1alpha1/types.go
@@ -103,7 +103,7 @@ type Template struct {
 	// Deamon will allow a workflow to proceed to the next step so long as the container reaches readiness
 	Daemon *bool `json:"daemon,omitempty"`
 
-	// Steps define a series of sequential/parallal workflow steps
+	// Steps define a series of sequential/parallel workflow steps
 	Steps [][]WorkflowStep `json:"steps,omitempty"`
 
 	// Container
@@ -250,7 +250,7 @@ type SidecarOptions struct {
 
 	// Other sidecar options to consider:
 	// * Lifespan - allow a sidecar to live longer than the main container and run to completion.
-	// * PropogateFailure - if a sidecar fails, also fail the step
+	// * PropagateFailure - if a sidecar fails, also fail the step
 }
 
 type WorkflowStatus struct {

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"time"
+
 	"github.com/argoproj/argo/pkg/apis/workflow"
 )
 
@@ -45,6 +47,10 @@ const (
 	AnnotationKeyTemplate = workflow.FullName + "/template"
 	// AnnotationKeyOutputs is the pod metadata annotation key containing the container outputs
 	AnnotationKeyOutputs = workflow.FullName + "/outputs"
+	// AnnotationKeyExecutionControl is the pod metadata annotation key containing execution control parameters
+	// set by the controller and obeyed by the executor. For example, the controller will use this annotation to
+	// signal the executors of daemoned containers that it should terminate.
+	AnnotationKeyExecutionControl = workflow.FullName + "/execution"
 
 	// LabelKeyControllerInstanceID is the label the controller will carry forward to pod labels
 	// for the purposes of workflow segregation
@@ -91,3 +97,11 @@ const (
 	// GlobalVarWorkflowStatus is a global workflow variable referencing the workflow's status.phase field
 	GlobalVarWorkflowStatus = "workflow.status"
 )
+
+// ExecutionControl contains execution control parameters for executor to decide how to execute the container
+type ExecutionControl struct {
+	// Deadline is a max timestamp in which an executor can run the container before terminating it
+	// It is used to signal the executor to terminate a daemoned container. In the future it will be
+	// used to support workflow or steps/dag level timeouts.
+	Deadline *time.Time `json:"deadline,omitempty"`
+}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3,9 +3,7 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"runtime/debug"
-	"sort"
 	"strings"
 	"time"
 
@@ -14,7 +12,6 @@ import (
 	"github.com/argoproj/argo/workflow/common"
 	jsonpatch "github.com/evanphx/json-patch"
 	log "github.com/sirupsen/logrus"
-	"github.com/valyala/fasttemplate"
 	apiv1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -716,7 +713,7 @@ func (woc *wfOperationCtx) getNode(nodeName string) wfv1.NodeStatus {
 }
 
 func (woc *wfOperationCtx) executeTemplate(templateName string, args wfv1.Arguments, nodeName string) error {
-	woc.log.Infof("Evaluating node %s: template: %s", nodeName, templateName)
+	woc.log.Debugf("Evaluating node %s: template: %s", nodeName, templateName)
 	nodeID := woc.wf.NodeID(nodeName)
 	node, ok := woc.wf.Status.Nodes[nodeID]
 	if ok && node.Completed() {
@@ -746,7 +743,7 @@ func (woc *wfOperationCtx) executeTemplate(templateName string, args wfv1.Argume
 
 				// The updated node status could've changed. Get the latest copy of the node.
 				node = woc.getNode(node.Name)
-				fmt.Printf("Node %s: Status: %s\n", node.Name, node.Phase)
+				log.Infof("Node %s: Status: %s", node.Name, node.Phase)
 				if node.Completed() {
 					return nil
 				}
@@ -912,327 +909,6 @@ func (woc *wfOperationCtx) executeContainer(nodeName string, tmpl *wfv1.Template
 	return nil
 }
 
-func (woc *wfOperationCtx) executeSteps(nodeName string, tmpl *wfv1.Template) error {
-	nodeID := woc.wf.NodeID(nodeName)
-	defer func() {
-		if woc.wf.Status.Nodes[nodeID].Completed() {
-			// TODO: this implementation should be handled via annotating the pod
-			// and signaling the executor to kill the pod instead.
-			_ = woc.killDeamonedChildren(nodeID)
-		}
-	}()
-	scope := wfScope{
-		tmpl:  tmpl,
-		scope: make(map[string]interface{}),
-	}
-	for i, stepGroup := range tmpl.Steps {
-		sgNodeName := fmt.Sprintf("%s[%d]", nodeName, i)
-		woc.addChildNode(nodeName, sgNodeName)
-		err := woc.executeStepGroup(stepGroup, sgNodeName, &scope)
-		if err != nil {
-			if errors.IsCode(errors.CodeTimeout, err) {
-				return err
-			}
-			woc.markNodeError(nodeName, err)
-			return err
-		}
-		sgNodeID := woc.wf.NodeID(sgNodeName)
-		if !woc.wf.Status.Nodes[sgNodeID].Completed() {
-			woc.log.Infof("Workflow step group node %v not yet completed", woc.wf.Status.Nodes[sgNodeID])
-			return nil
-		}
-
-		if !woc.wf.Status.Nodes[sgNodeID].Successful() {
-			failMessage := fmt.Sprintf("step group %s was unsuccessful", sgNodeName)
-			woc.log.Info(failMessage)
-			woc.markNodePhase(nodeName, wfv1.NodeFailed, failMessage)
-			return nil
-		}
-
-		// HACK: need better way to add children to scope
-		for _, step := range stepGroup {
-			childNodeName := fmt.Sprintf("%s.%s", sgNodeName, step.Name)
-			childNodeID := woc.wf.NodeID(childNodeName)
-			childNode, ok := woc.wf.Status.Nodes[childNodeID]
-			if !ok {
-				// This can happen if there was `withItem` expansion
-				// it is okay to ignore this because these expanded steps
-				// are not easily referenceable by user.
-				continue
-			}
-			if childNode.PodIP != "" {
-				key := fmt.Sprintf("steps.%s.ip", step.Name)
-				scope.addParamToScope(key, childNode.PodIP)
-			}
-			if childNode.Outputs != nil {
-				if childNode.Outputs.Result != nil {
-					key := fmt.Sprintf("steps.%s.outputs.result", step.Name)
-					scope.addParamToScope(key, *childNode.Outputs.Result)
-				}
-				for _, outParam := range childNode.Outputs.Parameters {
-					key := fmt.Sprintf("steps.%s.outputs.parameters.%s", step.Name, outParam.Name)
-					scope.addParamToScope(key, *outParam.Value)
-				}
-				for _, outArt := range childNode.Outputs.Artifacts {
-					key := fmt.Sprintf("steps.%s.outputs.artifacts.%s", step.Name, outArt.Name)
-					scope.addArtifactToScope(key, outArt)
-				}
-			}
-		}
-	}
-	outputs, err := getTemplateOutputsFromScope(tmpl, &scope)
-	if err != nil {
-		woc.markNodeError(nodeName, err)
-		return err
-	}
-	if outputs != nil {
-		node := woc.wf.Status.Nodes[nodeID]
-		node.Outputs = outputs
-		woc.wf.Status.Nodes[nodeID] = node
-	}
-	woc.markNodePhase(nodeName, wfv1.NodeSucceeded)
-	return nil
-}
-
-// executeStepGroup examines a map of parallel steps and executes them in parallel.
-// Handles referencing of variables in scope, expands `withItem` clauses, and evaluates `when` expressions
-func (woc *wfOperationCtx) executeStepGroup(stepGroup []wfv1.WorkflowStep, sgNodeName string, scope *wfScope) error {
-	nodeID := woc.wf.NodeID(sgNodeName)
-	node, ok := woc.wf.Status.Nodes[nodeID]
-	if ok && node.Completed() {
-		woc.log.Debugf("Step group node %v already marked completed", node)
-		return nil
-	}
-	if !ok {
-		node = *woc.markNodePhase(sgNodeName, wfv1.NodeRunning)
-		woc.log.Infof("Initializing step group node %v", node)
-	}
-
-	// First, resolve any references to outputs from previous steps, and perform substitution
-	stepGroup, err := woc.resolveReferences(stepGroup, scope)
-	if err != nil {
-		woc.markNodeError(sgNodeName, err)
-		return err
-	}
-
-	// Next, expand the step's withItems (if any)
-	stepGroup, err = woc.expandStepGroup(stepGroup)
-	if err != nil {
-		woc.markNodeError(sgNodeName, err)
-		return err
-	}
-
-	// Kick off all parallel steps in the group
-	for _, step := range stepGroup {
-		childNodeName := fmt.Sprintf("%s.%s", sgNodeName, step.Name)
-		woc.addChildNode(sgNodeName, childNodeName)
-
-		// Check the step's when clause to decide if it should execute
-		proceed, err := shouldExecute(step.When)
-		if err != nil {
-			woc.markNodeError(childNodeName, err)
-			woc.markNodeError(sgNodeName, err)
-			return err
-		}
-		if !proceed {
-			skipReason := fmt.Sprintf("when '%s' evaluated false", step.When)
-			woc.log.Infof("Skipping %s: %s", childNodeName, skipReason)
-			woc.markNodePhase(childNodeName, wfv1.NodeSkipped, skipReason)
-			continue
-		}
-		err = woc.executeTemplate(step.Template, step.Arguments, childNodeName)
-		if err != nil {
-			if !errors.IsCode(errors.CodeTimeout, err) {
-				woc.markNodeError(childNodeName, err)
-				woc.markNodeError(sgNodeName, err)
-			}
-			return err
-		}
-	}
-
-	node = woc.wf.Status.Nodes[nodeID]
-	// Return if not all children completed
-	for _, childNodeID := range node.Children {
-		if !woc.wf.Status.Nodes[childNodeID].Completed() {
-			return nil
-		}
-	}
-	// All children completed. Determine step group status as a whole
-	for _, childNodeID := range node.Children {
-		childNode := woc.wf.Status.Nodes[childNodeID]
-		if !childNode.Successful() {
-			failMessage := fmt.Sprintf("child '%s' failed", childNodeID)
-			woc.markNodePhase(sgNodeName, wfv1.NodeFailed, failMessage)
-			woc.log.Infof("Step group node %s deemed failed: %s", childNode, failMessage)
-			return nil
-		}
-	}
-	woc.markNodePhase(node.Name, wfv1.NodeSucceeded)
-	woc.log.Infof("Step group node %v successful", woc.wf.Status.Nodes[nodeID])
-	return nil
-}
-
-var whenExpression = regexp.MustCompile("^(.*)(==|!=)(.*)$")
-
-// shouldExecute evaluates a already substituted when expression to decide whether or not a step should execute
-func shouldExecute(when string) (bool, error) {
-	if when == "" {
-		return true, nil
-	}
-	parts := whenExpression.FindStringSubmatch(when)
-	if len(parts) == 0 {
-		return false, errors.Errorf(errors.CodeBadRequest, "Invalid 'when' expression: %s", when)
-	}
-	var1 := strings.TrimSpace(parts[1])
-	operator := parts[2]
-	var2 := strings.TrimSpace(parts[3])
-	switch operator {
-	case "==":
-		return var1 == var2, nil
-	case "!=":
-		return var1 != var2, nil
-	default:
-		return false, errors.Errorf(errors.CodeBadRequest, "Unknown operator: %s", operator)
-	}
-}
-
-// resolveReferences replaces any references to outputs of previous steps, or artifacts in the inputs
-// NOTE: by now, input parameters should have been substituted throughout the template, so we only
-// are concerned with:
-// 1) dereferencing output.parameters from previous steps
-// 2) dereferencing output.result from previous steps
-// 2) dereferencing artifacts from previous steps
-// 3) dereferencing artifacts from inputs
-func (woc *wfOperationCtx) resolveReferences(stepGroup []wfv1.WorkflowStep, scope *wfScope) ([]wfv1.WorkflowStep, error) {
-	newStepGroup := make([]wfv1.WorkflowStep, len(stepGroup))
-
-	for i, step := range stepGroup {
-		// Step 1: replace all parameter scope references in the step
-		// TODO: improve this
-		stepBytes, err := json.Marshal(step)
-		if err != nil {
-			return nil, errors.InternalWrapError(err)
-		}
-		replaceMap := make(map[string]string)
-		for key, val := range scope.scope {
-			valStr, ok := val.(string)
-			if ok {
-				replaceMap[key] = valStr
-			}
-		}
-		fstTmpl := fasttemplate.New(string(stepBytes), "{{", "}}")
-		newStepStr, err := common.Replace(fstTmpl, replaceMap, true, "")
-		if err != nil {
-			return nil, err
-		}
-		var newStep wfv1.WorkflowStep
-		err = json.Unmarshal([]byte(newStepStr), &newStep)
-		if err != nil {
-			return nil, errors.InternalWrapError(err)
-		}
-
-		// Step 2: replace all artifact references
-		for j, art := range newStep.Arguments.Artifacts {
-			if art.From == "" {
-				continue
-			}
-			resolvedArt, err := scope.resolveArtifact(art.From)
-			if err != nil {
-				return nil, err
-			}
-			resolvedArt.Name = art.Name
-			newStep.Arguments.Artifacts[j] = *resolvedArt
-		}
-
-		newStepGroup[i] = newStep
-	}
-	return newStepGroup, nil
-}
-
-// expandStepGroup looks at each step in a collection of parallel steps, and expands all steps using withItems/withParam
-func (woc *wfOperationCtx) expandStepGroup(stepGroup []wfv1.WorkflowStep) ([]wfv1.WorkflowStep, error) {
-	newStepGroup := make([]wfv1.WorkflowStep, 0)
-	for _, step := range stepGroup {
-		if len(step.WithItems) == 0 && step.WithParam == "" {
-			newStepGroup = append(newStepGroup, step)
-			continue
-		}
-		expandedStep, err := woc.expandStep(step)
-		if err != nil {
-			return nil, err
-		}
-		for _, newStep := range expandedStep {
-			newStepGroup = append(newStepGroup, newStep)
-		}
-	}
-	return newStepGroup, nil
-}
-
-// expandStep expands a step containing withItems or withParams into multiple parallel steps
-func (woc *wfOperationCtx) expandStep(step wfv1.WorkflowStep) ([]wfv1.WorkflowStep, error) {
-	stepBytes, err := json.Marshal(step)
-	if err != nil {
-		return nil, errors.InternalWrapError(err)
-	}
-	fstTmpl := fasttemplate.New(string(stepBytes), "{{", "}}")
-	expandedStep := make([]wfv1.WorkflowStep, 0)
-	var items []wfv1.Item
-	if len(step.WithItems) > 0 {
-		items = step.WithItems
-	} else if step.WithParam != "" {
-		err = json.Unmarshal([]byte(step.WithParam), &items)
-		if err != nil {
-			return nil, errors.Errorf(errors.CodeBadRequest, "withParam value not be parsed as a JSON list: %s", step.WithParam)
-		}
-	} else {
-		// this should have been prevented in expandStepGroup()
-		return nil, errors.InternalError("expandStep() was called with withItems and withParam empty")
-	}
-
-	for i, item := range items {
-		replaceMap := make(map[string]string)
-		var newStepName string
-		switch val := item.(type) {
-		case string, int32, int64, float32, float64:
-			replaceMap["item"] = fmt.Sprintf("%v", val)
-			newStepName = fmt.Sprintf("%s(%v)", step.Name, val)
-		case map[string]interface{}:
-			// Handle the case when withItems is a list of maps.
-			// vals holds stringified versions of the map items which are incorporated as part of the step name.
-			// For example if the item is: {"name": "jesse","group":"developer"}
-			// the vals would be: ["name:jesse", "group:developer"]
-			// This would eventually be part of the step name (group:developer,name:jesse)
-			vals := make([]string, 0)
-			for itemKey, itemValIf := range val {
-				switch itemVal := itemValIf.(type) {
-				case string, int32, int64, float32, float64:
-					replaceMap[fmt.Sprintf("item.%s", itemKey)] = fmt.Sprintf("%v", itemVal)
-					vals = append(vals, fmt.Sprintf("%s:%s", itemKey, itemVal))
-				default:
-					return nil, errors.Errorf(errors.CodeBadRequest, "withItems[%d][%s] expected string or number. received: %s", i, itemKey, itemVal)
-				}
-			}
-			// sort the values so that the name is deterministic
-			sort.Strings(vals)
-			newStepName = fmt.Sprintf("%s(%v)", step.Name, strings.Join(vals, ","))
-		default:
-			return nil, errors.Errorf(errors.CodeBadRequest, "withItems[%d] expected string, number, or map. received: %s", i, val)
-		}
-		newStepStr, err := common.Replace(fstTmpl, replaceMap, false, "")
-		if err != nil {
-			return nil, err
-		}
-		var newStep wfv1.WorkflowStep
-		err = json.Unmarshal([]byte(newStepStr), &newStep)
-		if err != nil {
-			return nil, errors.InternalWrapError(err)
-		}
-		newStep.Name = newStepName
-		expandedStep = append(expandedStep, newStep)
-	}
-	return expandedStep, nil
-}
-
 // getTemplateOutputsFromScope resolves a template's outputs from the scope of the template
 func getTemplateOutputsFromScope(tmpl *wfv1.Template, scope *wfScope) (*wfv1.Outputs, error) {
 	if !tmpl.Outputs.HasOutputs() {
@@ -1354,31 +1030,6 @@ func (woc *wfOperationCtx) addChildNode(parent string, child string) {
 	node.Children = append(node.Children, childID)
 	woc.wf.Status.Nodes[parentID] = node
 	woc.updated = true
-}
-
-// killDeamonedChildren kill any granchildren of a step template node, which have been daemoned.
-// We only need to check grandchildren instead of children because the direct children of a step
-// template are actually stepGroups, which are nodes that cannot represent actual containers.
-// Returns the first error that occurs (if any)
-func (woc *wfOperationCtx) killDeamonedChildren(nodeID string) error {
-	woc.log.Infof("Checking deamon children of %s", nodeID)
-	var firstErr error
-	for _, childNodeID := range woc.wf.Status.Nodes[nodeID].Children {
-		for _, grandChildID := range woc.wf.Status.Nodes[childNodeID].Children {
-			gcNode := woc.wf.Status.Nodes[grandChildID]
-			if gcNode.Daemoned == nil || !*gcNode.Daemoned {
-				continue
-			}
-			err := common.KillPodContainer(woc.controller.restConfig, woc.wf.ObjectMeta.Namespace, gcNode.ID, common.MainContainerName)
-			if err != nil {
-				woc.log.Errorf("Failed to kill %s: %+v", gcNode, err)
-				if firstErr == nil {
-					firstErr = err
-				}
-			}
-		}
-	}
-	return firstErr
 }
 
 // executeResource is runs a kubectl command against a manifest

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -1,0 +1,410 @@
+package controller
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/argoproj/argo/errors"
+	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo/workflow/common"
+	log "github.com/sirupsen/logrus"
+	"github.com/valyala/fasttemplate"
+)
+
+func (woc *wfOperationCtx) executeSteps(nodeName string, tmpl *wfv1.Template) error {
+	nodeID := woc.wf.NodeID(nodeName)
+	defer func() {
+		if woc.wf.Status.Nodes[nodeID].Completed() {
+			_ = woc.killDeamonedChildren(nodeID)
+		}
+	}()
+	scope := wfScope{
+		tmpl:  tmpl,
+		scope: make(map[string]interface{}),
+	}
+	for i, stepGroup := range tmpl.Steps {
+		sgNodeName := fmt.Sprintf("%s[%d]", nodeName, i)
+		woc.addChildNode(nodeName, sgNodeName)
+		err := woc.executeStepGroup(stepGroup, sgNodeName, &scope)
+		if err != nil {
+			if errors.IsCode(errors.CodeTimeout, err) {
+				return err
+			}
+			woc.markNodeError(nodeName, err)
+			return err
+		}
+		sgNodeID := woc.wf.NodeID(sgNodeName)
+		if !woc.wf.Status.Nodes[sgNodeID].Completed() {
+			woc.log.Infof("Workflow step group node %v not yet completed", woc.wf.Status.Nodes[sgNodeID])
+			return nil
+		}
+
+		if !woc.wf.Status.Nodes[sgNodeID].Successful() {
+			failMessage := fmt.Sprintf("step group %s was unsuccessful", sgNodeName)
+			woc.log.Info(failMessage)
+			woc.markNodePhase(nodeName, wfv1.NodeFailed, failMessage)
+			return nil
+		}
+
+		// HACK: need better way to add children to scope
+		for _, step := range stepGroup {
+			childNodeName := fmt.Sprintf("%s.%s", sgNodeName, step.Name)
+			childNodeID := woc.wf.NodeID(childNodeName)
+			childNode, ok := woc.wf.Status.Nodes[childNodeID]
+			if !ok {
+				// This can happen if there was `withItem` expansion
+				// it is okay to ignore this because these expanded steps
+				// are not easily referenceable by user.
+				continue
+			}
+			if childNode.PodIP != "" {
+				key := fmt.Sprintf("steps.%s.ip", step.Name)
+				scope.addParamToScope(key, childNode.PodIP)
+			}
+			if childNode.Outputs != nil {
+				if childNode.Outputs.Result != nil {
+					key := fmt.Sprintf("steps.%s.outputs.result", step.Name)
+					scope.addParamToScope(key, *childNode.Outputs.Result)
+				}
+				for _, outParam := range childNode.Outputs.Parameters {
+					key := fmt.Sprintf("steps.%s.outputs.parameters.%s", step.Name, outParam.Name)
+					scope.addParamToScope(key, *outParam.Value)
+				}
+				for _, outArt := range childNode.Outputs.Artifacts {
+					key := fmt.Sprintf("steps.%s.outputs.artifacts.%s", step.Name, outArt.Name)
+					scope.addArtifactToScope(key, outArt)
+				}
+			}
+		}
+	}
+	outputs, err := getTemplateOutputsFromScope(tmpl, &scope)
+	if err != nil {
+		woc.markNodeError(nodeName, err)
+		return err
+	}
+	if outputs != nil {
+		node := woc.wf.Status.Nodes[nodeID]
+		node.Outputs = outputs
+		woc.wf.Status.Nodes[nodeID] = node
+	}
+	woc.markNodePhase(nodeName, wfv1.NodeSucceeded)
+	return nil
+}
+
+// executeStepGroup examines a map of parallel steps and executes them in parallel.
+// Handles referencing of variables in scope, expands `withItem` clauses, and evaluates `when` expressions
+func (woc *wfOperationCtx) executeStepGroup(stepGroup []wfv1.WorkflowStep, sgNodeName string, scope *wfScope) error {
+	nodeID := woc.wf.NodeID(sgNodeName)
+	node, ok := woc.wf.Status.Nodes[nodeID]
+	if ok && node.Completed() {
+		woc.log.Debugf("Step group node %v already marked completed", node)
+		return nil
+	}
+	if !ok {
+		node = *woc.markNodePhase(sgNodeName, wfv1.NodeRunning)
+		woc.log.Infof("Initializing step group node %v", node)
+	}
+
+	// First, resolve any references to outputs from previous steps, and perform substitution
+	stepGroup, err := woc.resolveReferences(stepGroup, scope)
+	if err != nil {
+		woc.markNodeError(sgNodeName, err)
+		return err
+	}
+
+	// Next, expand the step's withItems (if any)
+	stepGroup, err = woc.expandStepGroup(stepGroup)
+	if err != nil {
+		woc.markNodeError(sgNodeName, err)
+		return err
+	}
+
+	// Kick off all parallel steps in the group
+	for _, step := range stepGroup {
+		childNodeName := fmt.Sprintf("%s.%s", sgNodeName, step.Name)
+		woc.addChildNode(sgNodeName, childNodeName)
+
+		// Check the step's when clause to decide if it should execute
+		proceed, err := shouldExecute(step.When)
+		if err != nil {
+			woc.markNodeError(childNodeName, err)
+			woc.markNodeError(sgNodeName, err)
+			return err
+		}
+		if !proceed {
+			skipReason := fmt.Sprintf("when '%s' evaluated false", step.When)
+			woc.log.Infof("Skipping %s: %s", childNodeName, skipReason)
+			woc.markNodePhase(childNodeName, wfv1.NodeSkipped, skipReason)
+			continue
+		}
+		err = woc.executeTemplate(step.Template, step.Arguments, childNodeName)
+		if err != nil {
+			if !errors.IsCode(errors.CodeTimeout, err) {
+				woc.markNodeError(childNodeName, err)
+				woc.markNodeError(sgNodeName, err)
+			}
+			return err
+		}
+	}
+
+	node = woc.wf.Status.Nodes[nodeID]
+	// Return if not all children completed
+	for _, childNodeID := range node.Children {
+		if !woc.wf.Status.Nodes[childNodeID].Completed() {
+			return nil
+		}
+	}
+	// All children completed. Determine step group status as a whole
+	for _, childNodeID := range node.Children {
+		childNode := woc.wf.Status.Nodes[childNodeID]
+		if !childNode.Successful() {
+			failMessage := fmt.Sprintf("child '%s' failed", childNodeID)
+			woc.markNodePhase(sgNodeName, wfv1.NodeFailed, failMessage)
+			woc.log.Infof("Step group node %s deemed failed: %s", childNode, failMessage)
+			return nil
+		}
+	}
+	woc.markNodePhase(node.Name, wfv1.NodeSucceeded)
+	woc.log.Infof("Step group node %v successful", woc.wf.Status.Nodes[nodeID])
+	return nil
+}
+
+var whenExpression = regexp.MustCompile("^(.*)(==|!=)(.*)$")
+
+// shouldExecute evaluates a already substituted when expression to decide whether or not a step should execute
+func shouldExecute(when string) (bool, error) {
+	if when == "" {
+		return true, nil
+	}
+	parts := whenExpression.FindStringSubmatch(when)
+	if len(parts) == 0 {
+		return false, errors.Errorf(errors.CodeBadRequest, "Invalid 'when' expression: %s", when)
+	}
+	var1 := strings.TrimSpace(parts[1])
+	operator := parts[2]
+	var2 := strings.TrimSpace(parts[3])
+	switch operator {
+	case "==":
+		return var1 == var2, nil
+	case "!=":
+		return var1 != var2, nil
+	default:
+		return false, errors.Errorf(errors.CodeBadRequest, "Unknown operator: %s", operator)
+	}
+}
+
+// resolveReferences replaces any references to outputs of previous steps, or artifacts in the inputs
+// NOTE: by now, input parameters should have been substituted throughout the template, so we only
+// are concerned with:
+// 1) dereferencing output.parameters from previous steps
+// 2) dereferencing output.result from previous steps
+// 2) dereferencing artifacts from previous steps
+// 3) dereferencing artifacts from inputs
+func (woc *wfOperationCtx) resolveReferences(stepGroup []wfv1.WorkflowStep, scope *wfScope) ([]wfv1.WorkflowStep, error) {
+	newStepGroup := make([]wfv1.WorkflowStep, len(stepGroup))
+
+	for i, step := range stepGroup {
+		// Step 1: replace all parameter scope references in the step
+		// TODO: improve this
+		stepBytes, err := json.Marshal(step)
+		if err != nil {
+			return nil, errors.InternalWrapError(err)
+		}
+		replaceMap := make(map[string]string)
+		for key, val := range scope.scope {
+			valStr, ok := val.(string)
+			if ok {
+				replaceMap[key] = valStr
+			}
+		}
+		fstTmpl := fasttemplate.New(string(stepBytes), "{{", "}}")
+		newStepStr, err := common.Replace(fstTmpl, replaceMap, true, "")
+		if err != nil {
+			return nil, err
+		}
+		var newStep wfv1.WorkflowStep
+		err = json.Unmarshal([]byte(newStepStr), &newStep)
+		if err != nil {
+			return nil, errors.InternalWrapError(err)
+		}
+
+		// Step 2: replace all artifact references
+		for j, art := range newStep.Arguments.Artifacts {
+			if art.From == "" {
+				continue
+			}
+			resolvedArt, err := scope.resolveArtifact(art.From)
+			if err != nil {
+				return nil, err
+			}
+			resolvedArt.Name = art.Name
+			newStep.Arguments.Artifacts[j] = *resolvedArt
+		}
+
+		newStepGroup[i] = newStep
+	}
+	return newStepGroup, nil
+}
+
+// expandStepGroup looks at each step in a collection of parallel steps, and expands all steps using withItems/withParam
+func (woc *wfOperationCtx) expandStepGroup(stepGroup []wfv1.WorkflowStep) ([]wfv1.WorkflowStep, error) {
+	newStepGroup := make([]wfv1.WorkflowStep, 0)
+	for _, step := range stepGroup {
+		if len(step.WithItems) == 0 && step.WithParam == "" {
+			newStepGroup = append(newStepGroup, step)
+			continue
+		}
+		expandedStep, err := woc.expandStep(step)
+		if err != nil {
+			return nil, err
+		}
+		for _, newStep := range expandedStep {
+			newStepGroup = append(newStepGroup, newStep)
+		}
+	}
+	return newStepGroup, nil
+}
+
+// expandStep expands a step containing withItems or withParams into multiple parallel steps
+func (woc *wfOperationCtx) expandStep(step wfv1.WorkflowStep) ([]wfv1.WorkflowStep, error) {
+	stepBytes, err := json.Marshal(step)
+	if err != nil {
+		return nil, errors.InternalWrapError(err)
+	}
+	fstTmpl := fasttemplate.New(string(stepBytes), "{{", "}}")
+	expandedStep := make([]wfv1.WorkflowStep, 0)
+	var items []wfv1.Item
+	if len(step.WithItems) > 0 {
+		items = step.WithItems
+	} else if step.WithParam != "" {
+		err = json.Unmarshal([]byte(step.WithParam), &items)
+		if err != nil {
+			return nil, errors.Errorf(errors.CodeBadRequest, "withParam value not be parsed as a JSON list: %s", step.WithParam)
+		}
+	} else {
+		// this should have been prevented in expandStepGroup()
+		return nil, errors.InternalError("expandStep() was called with withItems and withParam empty")
+	}
+
+	for i, item := range items {
+		replaceMap := make(map[string]string)
+		var newStepName string
+		switch val := item.(type) {
+		case string, int32, int64, float32, float64:
+			replaceMap["item"] = fmt.Sprintf("%v", val)
+			newStepName = fmt.Sprintf("%s(%v)", step.Name, val)
+		case map[string]interface{}:
+			// Handle the case when withItems is a list of maps.
+			// vals holds stringified versions of the map items which are incorporated as part of the step name.
+			// For example if the item is: {"name": "jesse","group":"developer"}
+			// the vals would be: ["name:jesse", "group:developer"]
+			// This would eventually be part of the step name (group:developer,name:jesse)
+			vals := make([]string, 0)
+			for itemKey, itemValIf := range val {
+				switch itemVal := itemValIf.(type) {
+				case string, int32, int64, float32, float64:
+					replaceMap[fmt.Sprintf("item.%s", itemKey)] = fmt.Sprintf("%v", itemVal)
+					vals = append(vals, fmt.Sprintf("%s:%s", itemKey, itemVal))
+				default:
+					return nil, errors.Errorf(errors.CodeBadRequest, "withItems[%d][%s] expected string or number. received: %s", i, itemKey, itemVal)
+				}
+			}
+			// sort the values so that the name is deterministic
+			sort.Strings(vals)
+			newStepName = fmt.Sprintf("%s(%v)", step.Name, strings.Join(vals, ","))
+		default:
+			return nil, errors.Errorf(errors.CodeBadRequest, "withItems[%d] expected string, number, or map. received: %s", i, val)
+		}
+		newStepStr, err := common.Replace(fstTmpl, replaceMap, false, "")
+		if err != nil {
+			return nil, err
+		}
+		var newStep wfv1.WorkflowStep
+		err = json.Unmarshal([]byte(newStepStr), &newStep)
+		if err != nil {
+			return nil, errors.InternalWrapError(err)
+		}
+		newStep.Name = newStepName
+		expandedStep = append(expandedStep, newStep)
+	}
+	return expandedStep, nil
+}
+
+// killDeamonedChildren kill any granchildren of a step template node, which have been daemoned.
+// We only need to check grandchildren instead of children because the direct children of a step
+// template are actually stepGroups, which are nodes that cannot represent actual containers.
+// Returns the first error that occurs (if any)
+// TODO(jessesuen): this logic will need to change with DAGs
+func (woc *wfOperationCtx) killDeamonedChildren(nodeID string) error {
+	woc.log.Infof("Checking deamon children of %s", nodeID)
+	var firstErr error
+	execCtl := common.ExecutionControl{
+		Deadline: &time.Time{},
+	}
+	for _, childNodeID := range woc.wf.Status.Nodes[nodeID].Children {
+		for _, grandChildID := range woc.wf.Status.Nodes[childNodeID].Children {
+			gcNode := woc.wf.Status.Nodes[grandChildID]
+			if gcNode.Daemoned == nil || !*gcNode.Daemoned {
+				continue
+			}
+			err := woc.updateExecutionControl(gcNode.ID, execCtl)
+			if err != nil {
+				woc.log.Errorf("Failed to update execution control of %s: %+v", gcNode, err)
+				if firstErr == nil {
+					firstErr = err
+				}
+			}
+		}
+	}
+	return firstErr
+}
+
+// updateExecutionControl updates the execution control parameters
+func (woc *wfOperationCtx) updateExecutionControl(podName string, execCtl common.ExecutionControl) error {
+	execCtlBytes, err := json.Marshal(execCtl)
+	if err != nil {
+		return errors.InternalWrapError(err)
+	}
+
+	woc.log.Infof("Updating execution control of %s: %s", podName, execCtlBytes)
+	err = common.AddPodAnnotation(
+		woc.controller.kubeclientset,
+		podName,
+		woc.wf.ObjectMeta.Namespace,
+		common.AnnotationKeyExecutionControl,
+		string(execCtlBytes),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Ideally we would simply annotate the pod with the updates and be done with it, allowing
+	// the executor to notice the updates naturally via the Downward API annotations volume
+	// mounted file. However, updates to the Downward API volumes take a very long time to
+	// propagate (minutes). The following code fast-tracks this by signaling the executor
+	// using SIGUSR2 that something changed.
+	woc.log.Infof("Signalling %s of updates", podName)
+	exec, err := common.ExecPodContainer(
+		woc.controller.restConfig, woc.wf.ObjectMeta.Namespace, podName,
+		common.WaitContainerName, true, true, "sh", "-c", "kill -s USR2 1",
+	)
+	if err != nil {
+		return err
+	}
+	go func() {
+		// This call is necessary to actually send the exec. Since signalling is best effort,
+		// it is launched as a goroutine and the error is discarded
+		_, _, err = common.GetExecutorOutput(exec)
+		if err != nil {
+			log.Warnf("Signal command failed: %v", err)
+			return
+		}
+		log.Infof("Signal of %s (%s) successfully issued", podName, common.WaitContainerName)
+	}()
+
+	return nil
+}

--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -150,11 +150,11 @@ func readJSON(reader *bufio.Reader) ([]byte, error) {
 
 // SaveResourceParameters will save any resource output parameters
 func (we *WorkflowExecutor) SaveResourceParameters(resourceName string) error {
-	log.Infof("Saving resource output parameters")
 	if len(we.Template.Outputs.Parameters) == 0 {
-		log.Infof("No output parameters, nothing to do")
+		log.Infof("No output parameters")
 		return nil
 	}
+	log.Infof("Saving resource output parameters")
 	for i, param := range we.Template.Outputs.Parameters {
 		if param.ValueFrom == nil {
 			continue


### PR DESCRIPTION
This change creates a downward communication channel from the controller to executor through
the use of pod annotations. Its initial use will be to terminate daemoned containers by
updating 'ExecutionControl' parameters to the executor. In this case, it updates the deadline
value to be a zero-value timestamp. The executor has been modified to now monitor updates to the annotations and will obey the updated deadline, allowing deadlines to be set/updated/unset after initial start.

In the future, ExecutionControl can be extended to support things like workflow, step, dag
level timeouts, as well as the ability to to cancel a workflow without deleting pods.

Resolves issue #499.
Partially implements support for #527.