### PR TITLE
Improvements to `argo list`

### DIFF
--- a/cmd/argo/commands/list.go
+++ b/cmd/argo/commands/list.go
@@ -4,24 +4,37 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sort"
+	"strings"
 	"text/tabwriter"
 	"time"
 
 	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo/pkg/client/clientset/versioned/typed/workflow/v1alpha1"
+	"github.com/argoproj/argo/workflow/common"
 	humanize "github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 )
 
 func init() {
 	RootCmd.AddCommand(listCmd)
 	listCmd.Flags().BoolVar(&listArgs.allNamespaces, "all-namespaces", false, "show workflows from all namespaces")
+	listCmd.Flags().StringVar(&listArgs.status, "status", "", "filter by status (comma separated)")
+	listCmd.Flags().BoolVar(&listArgs.completed, "completed", false, "show only completed workflows")
+	listCmd.Flags().BoolVar(&listArgs.running, "running", false, "show only running workflows")
+	listCmd.Flags().StringVarP(&listArgs.output, "output", "o", "", "Output format. One of: wide|name")
 }
 
 type listFlags struct {
-	allNamespaces bool // --all-namespaces
+	allNamespaces bool   // --all-namespaces
+	status        string // --status
+	completed     bool   // --completed
+	running       bool   // --running
+	output        string // --output
 }
 
 var listArgs listFlags
@@ -50,28 +63,107 @@ func listWorkflows(cmd *cobra.Command, args []string) {
 	} else {
 		wfClient = InitWorkflowClient()
 	}
-	wfList, err := wfClient.List(metav1.ListOptions{})
+	listOpts := metav1.ListOptions{}
+	labelSelector := labels.NewSelector()
+	if listArgs.status != "" {
+		req, _ := labels.NewRequirement(common.LabelKeyPhase, selection.In, strings.Split(listArgs.status, ","))
+		labelSelector = labelSelector.Add(*req)
+	}
+	if listArgs.completed {
+		req, _ := labels.NewRequirement(common.LabelKeyCompleted, selection.Equals, []string{"true"})
+		labelSelector = labelSelector.Add(*req)
+	}
+	if listArgs.running {
+		req, _ := labels.NewRequirement(common.LabelKeyCompleted, selection.NotEquals, []string{"true"})
+		labelSelector = labelSelector.Add(*req)
+	}
+	listOpts.LabelSelector = labelSelector.String()
+	wfList, err := wfClient.List(listOpts)
 	if err != nil {
 		log.Fatal(err)
 	}
+	switch listArgs.output {
+	case "wide":
+		printTable(wfList)
+	case "name":
+		for _, wf := range wfList.Items {
+			fmt.Println(wf.ObjectMeta.Name)
+		}
+	default:
+		log.Fatalf("Unknown output mode: %s", listArgs.output)
+	}
+}
+
+func printTable(wfList *wfv1.WorkflowList) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 	if listArgs.allNamespaces {
-		fmt.Fprintln(w, "NAMESPACE\tNAME\tSTATUS\tAGE\tDURATION")
-	} else {
-		fmt.Fprintln(w, "NAME\tSTATUS\tAGE\tDURATION")
+		fmt.Fprint(w, "NAMESPACE\t")
 	}
-
+	fmt.Fprint(w, "NAME\tSTATUS\tAGE\tDURATION")
+	if listArgs.output == "wide" {
+		fmt.Fprint(w, "\tPARAMETERS")
+	}
+	fmt.Fprint(w, "\n")
+	sort.Sort(ByFinishedAt(wfList.Items))
 	for _, wf := range wfList.Items {
 		cTime := time.Unix(wf.ObjectMeta.CreationTimestamp.Unix(), 0)
 		ageStr := humanize.CustomRelTime(cTime, time.Now(), "", "", timeMagnitudes)
 		durationStr := humanizeDurationShort(wf.Status.StartedAt, wf.Status.FinishedAt)
 		if listArgs.allNamespaces {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", wf.ObjectMeta.Namespace, wf.ObjectMeta.Name, worklowStatus(&wf), ageStr, durationStr)
-		} else {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", wf.ObjectMeta.Name, worklowStatus(&wf), ageStr, durationStr)
+			fmt.Fprintf(w, "%s\t", wf.ObjectMeta.Namespace)
 		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s", wf.ObjectMeta.Name, worklowStatus(&wf), ageStr, durationStr)
+		if listArgs.output == "wide" {
+			fmt.Fprintf(w, "\t%s", parameterString(wf.Spec.Arguments.Parameters))
+		}
+		fmt.Fprintf(w, "\n")
 	}
 	_ = w.Flush()
+}
+
+// parameterString returns a human readable display string of the parameters, truncating if necessary
+func parameterString(params []wfv1.Parameter) string {
+	truncateString := func(str string, num int) string {
+		bnoden := str
+		if len(str) > num {
+			if num > 3 {
+				num -= 3
+			}
+			bnoden = str[0:num-15] + "..." + str[len(str)-15:]
+		}
+		return bnoden
+	}
+
+	pStrs := make([]string, 0)
+	for _, p := range params {
+		if p.Value != nil {
+			str := fmt.Sprintf("%s=%s", p.Name, truncateString(*p.Value, 50))
+			pStrs = append(pStrs, str)
+		}
+	}
+	return strings.Join(pStrs, ",")
+}
+
+// ByFinishedAt is a sort interface which sorts running jobs earlier before considering FinishedAt
+type ByFinishedAt []wfv1.Workflow
+
+func (f ByFinishedAt) Len() int      { return len(f) }
+func (f ByFinishedAt) Swap(i, j int) { f[i], f[j] = f[j], f[i] }
+func (f ByFinishedAt) Less(i, j int) bool {
+	iStart := f[i].ObjectMeta.CreationTimestamp
+	iFinish := f[i].Status.FinishedAt
+	jStart := f[j].ObjectMeta.CreationTimestamp
+	jFinish := f[j].Status.FinishedAt
+	if iFinish.IsZero() && jFinish.IsZero() {
+		return !iStart.Before(&jStart)
+	}
+	if iFinish.IsZero() && !jFinish.IsZero() {
+		return true
+	}
+	if !iFinish.IsZero() && jFinish.IsZero() {
+		return false
+	}
+	return jFinish.Before(&iFinish)
 }
 
 func worklowStatus(wf *wfv1.Workflow) wfv1.NodePhase {

--- a/examples/influxdb-ci.yaml
+++ b/examples/influxdb-ci.yaml
@@ -5,6 +5,12 @@ metadata:
 
 spec:
   entrypoint: influxdb-ci
+  arguments:
+    parameters:
+    - name: repo
+      value: https://github.com/influxdata/influxdb.git
+    - name: revision
+      value: master
 
   templates:
   - name: influxdb-ci
@@ -42,8 +48,8 @@ spec:
       - name: source
         path: /src
         git:
-          repo: https://github.com/argoproj/influxdb.git
-          revision: "master"
+          repo: "{{workflow.parameters.repo}}"
+          revision: "{{workflow.parameters.revision}}"
     outputs:
       artifacts:
       - name: source


### PR DESCRIPTION
* sort workflows by finished time
* add --running, --completed, --status XXX filters
* add -o wide option to show parameters

Example output:
```
$ go run cmd/argo/main.go list -o wide
NAME                      STATUS      AGE    DURATION   PARAMETERS
hello-world-zjq7g         Pending     2m     1d
influxdb-ci-kpphp         Running     5m     5m         repo=https://github.com/influxdata/influxdb.git,revision=master
argo-ci-4jjwj             Running     5m     5m         revision=master,repo=https://github.com/argoproj/argo.git
influxdb-ci-5bssm         Failed      1d     1d
argo-ci-gqsrc             Failed      31m    12m        revision=master,repo=https://github.com/argoproj/argo.git
argo-ci-27v92             Succeeded   32m    13m        revision=master,repo=https://github.com/argoproj/argo.git
influxdb-ci-vkcj7         Succeeded   1h     12m        repo=https://github.com/argoproj/influxdb.git,revision=master
influxdb-ci-795rz         Failed      1d     7m
influxdb-ci-9df7r         Failed      1d     1d
influxdb-ci-845qp         Failed      1d     1d
influxdb-ci-pq2p5         Succeeded   1d     7m
influxdb-ci-6477f         Succeeded   1d     7m
container-retries-h94tf   Succeeded   1d     4s
container-retries-bkfst   Succeeded   1d     29s
daemon-nginx-fx8gm        Succeeded   1d     10s
daemon-nginx-7c4xv        Error       1d     4s
```