### PR TITLE
Switch to Updating workflow resources instead of Patching 

### DIFF
--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -11,6 +11,7 @@ import (
 	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	fakewfclientset "github.com/argoproj/argo/pkg/client/clientset/versioned/fake"
 	"github.com/ghodss/yaml"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -73,5 +74,7 @@ func TestOperateWorkflowPanicRecover(t *testing.T) {
 	// intentionally set clientset to nil to induce panic
 	controller.kubeclientset = nil
 	wf := unmarshalWF(helloWorldWf)
+	_, err := controller.wfclientset.ArgoprojV1alpha1().Workflows("").Create(wf)
+	assert.Nil(t, err)
 	controller.operateWorkflow(wf)
 }


### PR DESCRIPTION
Resolves issue #686

Relying on a JSON merge patch to persist workflow updates has been shown to be unreliable.
This change switches us to use the Update mechanism, which may not be as performant, and
will on occasion cause the controller to redo work (upon resource conflicts), but it will
likely be more reliable way of persisting workflow resource changes.
