### PR TITLE
ADD hooks to push containers to GCP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,12 @@ $(error IMAGE_NAMESPACE must be set to push images (e.g. IMAGE_NAMESPACE=argopro
 endif
 endif
 
+ifeq (${GCP_PUSH},true)
+ifndef GOOGLE_PROJECT_ID
+$(error GOOGLE_PROJECT_ID must be set to push images to GCP)
+endif
+endif
+
 ifdef IMAGE_NAMESPACE
 IMAGE_PREFIX=${IMAGE_NAMESPACE}/
 endif
@@ -88,6 +94,7 @@ controller-linux: builder
 controller-image: controller-linux
 	docker build -t $(IMAGE_PREFIX)workflow-controller:$(IMAGE_TAG) -f Dockerfile-workflow-controller .
 	@if [ "$(DOCKER_PUSH)" = "true" ] ; then docker push $(IMAGE_PREFIX)workflow-controller:$(IMAGE_TAG) ; fi
+	@if [ "$(GCP_PUSH)" = "true" ] ; then docker tag $(IMAGE_PREFIX)workflow-controller:$(IMAGE_TAG) "gcr.io/$(GOOGLE_PROJECT_ID)/workflow-controller:$(IMAGE_TAG)"; gcloud docker -- push gcr.io/$(GOOGLE_PROJECT_ID)/workflow-controller:$(IMAGE_TAG) ; fi
 
 .PHONY: executor
 executor:
@@ -101,6 +108,7 @@ executor-linux: builder
 executor-image: executor-linux
 	docker build -t $(IMAGE_PREFIX)argoexec:$(IMAGE_TAG) -f Dockerfile-argoexec .
 	@if [ "$(DOCKER_PUSH)" = "true" ] ; then docker push $(IMAGE_PREFIX)argoexec:$(IMAGE_TAG) ; fi
+	@if [ "$(GCP_PUSH)" = "true" ] ; then docker tag $(IMAGE_PREFIX)argoexec:$(IMAGE_TAG) "gcr.io/$(GOOGLE_PROJECT_ID)/argoexec:$(IMAGE_TAG)"; gcloud docker -- push gcr.io/$(GOOGLE_PROJECT_ID)/argoexec:$(IMAGE_TAG) ; fi
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
not sure if you are interested in this patch, but
we use GCP, not dockerhub as our container registry for GKE
and for that reason, when I needed to recompile argo to debug something
(patch pending), I redeployed into GKE as a part of that process, so I
need to update the Makefile to support GKE.

This patch adds two environment variables:
* GOOGLE_PROJECT_ID
* GCP_PUSH

ensures that GOOGLE_PROJECT_ID is set when GCP_PUSH is set, and pushes
all built containers to GCP in that project namespaces when the
respective jobs are built.