### PR TITLE
[For discussion] Validate no unused arguments.

### DIFF
--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -130,6 +130,7 @@ func ProcessArgs(tmpl *wfv1.Template, args wfv1.Arguments, globalParams map[stri
 	// 2) if not, use default value.
 	// 3) if no default value, it is an error
 	tmpl = tmpl.DeepCopy()
+
 	for i, inParam := range tmpl.Inputs.Parameters {
 		if inParam.Default != nil {
 			// first set to default value
@@ -146,6 +147,14 @@ func ProcessArgs(tmpl *wfv1.Template, args wfv1.Arguments, globalParams map[stri
 		}
 		tmpl.Inputs.Parameters[i] = inParam
 	}
+
+	// ensure no unused arguments are provided
+	for _, param := range args.Parameters {
+		if tmpl.Inputs.GetParameterByName(param.Name) == nil {
+			return nil, errors.Errorf(errors.CodeBadRequest, "inputs.parameters.%s supplied but no such parameter declared", param.Name)
+		}
+	}
+
 	tmpl, err := substituteParams(tmpl, globalParams)
 	if err != nil {
 		return nil, err

--- a/workflow/common/validate_test.go
+++ b/workflow/common/validate_test.go
@@ -222,6 +222,34 @@ func TestUnsatisfiedParam(t *testing.T) {
 	}
 }
 
+var undeclaredParam = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: hello-world-
+spec:
+  entrypoint: call
+  templates:
+  - name: call
+    steps:
+      - - name: call
+          template: no-params
+          arguments:
+            parameters:
+              - name: undeclared
+                value: undeclaredValue
+  - name: no-params
+    container:
+      image: docker/whalesay:latest
+`
+
+func TestUndeclaredParam(t *testing.T) {
+	err := validate(undeclaredParam)
+	if assert.NotNil(t, err) {
+		assert.Contains(t, err.Error(), "inputs.parameters.undeclared supplied but no such parameter declared")
+	}
+}
+
 var globalParam = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow


### PR DESCRIPTION
I was caught out today passing irrelevant arguments when programatically generating a workflow.  It seems sensible to me to validate that no more arguments are passed than parameters declared when invoking a template.  However, this breaks TestGlobal which has an argument passed to the entrypoint template that isn't declared by it, but is used as `{{workflow.parameters.message2}}` to pass it through to one of its steps.

Does this validation seem sensible?  Do we need to special case the entrypoint, or should all global parameters be declared?