### PR TITLE
examples: use alpine python image

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -334,7 +334,7 @@ spec:
 
   - name: gen-random-int-python
     script:
-      image: python:3.6
+      image: python:alpine3.6
       command: [python]
       source: |
         import random
@@ -547,7 +547,7 @@ spec:
   # Generate a list of numbers in JSON format
   - name: gen-number-list
     script:
-      image: python:3.6
+      image: python:alpine3.6
       command: [python]
       source: |
         import json
@@ -590,7 +590,7 @@ spec:
   # Return heads or tails based on a random number
   - name: flip-coin
     script:
-      image: python:3.6
+      image: python:alpine3.6
       command: [python]
       source: |
         import random
@@ -635,7 +635,7 @@ spec:
     
   - name: flip-coin
     script:
-      image: python:3.6
+      image: python:alpine3.6
       command: [python]
       source: |
         import random

--- a/examples/coinflip-recursive.yaml
+++ b/examples/coinflip-recursive.yaml
@@ -23,7 +23,7 @@ spec:
 
   - name: flip-coin
     script:
-      image: python:3.6
+      image: python:alpine3.6
       command: [python]
       source: |
         import random

--- a/examples/coinflip.yaml
+++ b/examples/coinflip.yaml
@@ -23,7 +23,7 @@ spec:
 
   - name: flip-coin
     script:
-      image: python:3.6
+      image: python:alpine3.6
       command: [python]
       source: |
         import random

--- a/examples/dag-coinflip.yaml
+++ b/examples/dag-coinflip.yaml
@@ -17,7 +17,7 @@ spec:
         when: "{{steps.flip-coin.outputs.result}} == tails"
   - name: flip-coin
     script:
-      image: python:3.6
+      image: python:alpine3.6
       command: [python]
       source: |
         import random

--- a/examples/k8s-orchestration.yaml
+++ b/examples/k8s-orchestration.yaml
@@ -49,7 +49,7 @@ spec:
             spec:
               containers:
               - name: rand
-                image: python:3.6
+                image: python:alpine3.6
                 command: ["python", "-c", "import random; import time; print(random.randint(1, 1000)); time.sleep(10)"]
               restartPolicy: Never
     outputs:

--- a/examples/loops-param-result.yaml
+++ b/examples/loops-param-result.yaml
@@ -21,7 +21,7 @@ spec:
 
   - name: gen-number-list
     script:
-      image: python:3.6
+      image: python:alpine3.6
       command: [python]
       source: |
         import json

--- a/examples/parallelism-limit.yaml
+++ b/examples/parallelism-limit.yaml
@@ -4,7 +4,7 @@ metadata:
   generateName: parallelism-limit-
 spec:
   entrypoint: parallelism-limit
-  parallelism: 2
+  parallelism: 100
   templates:
   - name: parallelism-limit
     steps:

--- a/examples/resubmit.yaml
+++ b/examples/resubmit.yaml
@@ -41,6 +41,6 @@ spec:
   # fail with a 33% probability
   - name: random-fail
     container:
-      image: python:3.6
+      image: python:alpine3.6
       command: ["python", -c]
       args: ["import random; import sys; exit_code = random.choice([0, 0, 1]); print('exiting with code {}'.format(exit_code)); sys.exit(exit_code)"]

--- a/examples/retry-container.yaml
+++ b/examples/retry-container.yaml
@@ -10,7 +10,7 @@ spec:
     retryStrategy:
       limit: 10
     container:
-      image: python:3.6
+      image: python:alpine3.6
       command: ["python", -c]
       # fail with a 66% probability
       args: ["import random; import sys; exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]

--- a/examples/retry-with-steps.yaml
+++ b/examples/retry-with-steps.yaml
@@ -18,7 +18,7 @@ spec:
     retryStrategy:
       limit: 10
     container:
-      image: python:3.6
+      image: python:alpine3.6
       command: [python, -c]
       # fail with a 66% probability
       args: ["import random; import sys; exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]

--- a/examples/scripts-python.yaml
+++ b/examples/scripts-python.yaml
@@ -25,7 +25,7 @@ spec:
 
   - name: gen-random-int
     script:
-      image: python:3.6
+      image: python:alpine3.6
       command: [python]
       source: |
         import random

--- a/test/e2e/functional/sidecar-volumes.yaml
+++ b/test/e2e/functional/sidecar-volumes.yaml
@@ -23,7 +23,7 @@ spec:
 
   - name: generate
     script:
-      image: python:3.6
+      image: python:alpine3.6
       command: [python]
       source: |
         import time

--- a/test/e2e/stress/pod-limits.yaml
+++ b/test/e2e/stress/pod-limits.yaml
@@ -31,7 +31,7 @@ spec:
       parameters:
       - name: count
     script:
-      image: python:3.6
+      image: python:alpine3.6
       command: [python]
       source: |
         import json

--- a/workflow/common/validate_test.go
+++ b/workflow/common/validate_test.go
@@ -654,7 +654,7 @@ spec:
       command: [sh, -c]
       args: ["cowsay hello world | tee /tmp/hello_world.txt"]
     script:
-      image: python:3.6
+      image: python:alpine3.6
       command: [python]
       source: |
         import random

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -52,7 +52,7 @@ spec:
   templates:
   - name: sidecar-with-volumes
     script:
-      image: python:3.6
+      image: python:alpine3.6
       command: [python]
       source: |
         print("hello world")


### PR DESCRIPTION
Alpine based python image is 8x times smaller, so it is reasonable to use it
instead of giant debian/jessie one.

docker.io/python    3.6                 336d482502ab        9 days ago          692 MB
docker.io/python    alpine3.6           78d64a211a65        6 weeks ago         83.8 MB