### PR TITLE
Fix for https://github.com/argoproj/argo/issues/739 Nested stepgroups…

### DIFF
--- a/cmd/argo/commands/get.go
+++ b/cmd/argo/commands/get.go
@@ -371,13 +371,13 @@ func renderChild(w *tabwriter.Writer, wf *wfv1.Workflow, nInfo renderNode, depth
 			subp = "  "
 		} else if childIndex == 0 {
 			part = "·-"
-			subp = "  "
+			subp = "| "
 		} else if childIndex == maxIndex {
 			part = "└-"
 			subp = "  "
 		} else {
 			part = "├-"
-			subp = "  "
+			subp = "| "
 		}
 	} else if !parentFiltered {
 		if childIndex == maxIndex {


### PR DESCRIPTION
… render correctly

Based on my testing this works fine now for the influx ci example and other examples. This code change only affects stepgroups and this makes logical sense for those.