### PR TITLE
Omit empty status fields.

### DIFF
--- a/pkg/apis/workflow/v1alpha1/types.go
+++ b/pkg/apis/workflow/v1alpha1/types.go
@@ -380,7 +380,7 @@ type Sidecar struct {
 // +k8s:openapi-gen=false
 type WorkflowStatus struct {
 	// Phase a simple, high-level summary of where the workflow is in its lifecycle.
-	Phase NodePhase `json:"phase"`
+	Phase NodePhase `json:"phase,omitempty"`
 
 	// Time at which this workflow started
 	StartedAt metav1.Time `json:"startedAt,omitempty"`
@@ -392,7 +392,7 @@ type WorkflowStatus struct {
 	Message string `json:"message,omitempty"`
 
 	// Nodes is a mapping between a node ID and the node's status.
-	Nodes map[string]NodeStatus `json:"nodes"`
+	Nodes map[string]NodeStatus `json:"nodes,omitempty"`
 
 	// PersistentVolumeClaims tracks all PVCs that were created as part of the workflow.
 	// The contents of this list are drained at the end of the workflow.
@@ -429,7 +429,7 @@ type NodeStatus struct {
 
 	// Phase a simple, high-level summary of where the node is in its lifecycle.
 	// Can be used as a state machine.
-	Phase NodePhase `json:"phase"`
+	Phase NodePhase `json:"phase,omitempty"`
 
 	// BoundaryID indicates the node ID of the associated template root node in which this node belongs to
 	BoundaryID string `json:"boundaryID,omitempty"`


### PR DESCRIPTION
Primary motivation is to avoid an empty string phase value, which is
awkward to map to JSON in languages other than Go, and surprising as
it only arises in ADDED events.

This is could be a disruptive change for workflow clients expecting the
empty value, but not sure this is likely in practice.

A newly added workflow now gives:
```json
    "status": {
        "finishedAt": null,
        "startedAt": null
    }
```

The time values already have omitempty but as they're structs this
doesn't help. The nulls here are consistent with time serialization
elsewhere in Kubernetes so probably best left as is.