### PR TITLE
Minimal shell completion support

### DIFF
--- a/cmd/argo/commands/completion.go
+++ b/cmd/argo/commands/completion.go
@@ -1,0 +1,43 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCompletionCommand() *cobra.Command {
+	var command = &cobra.Command{
+		Use:   "completion SHELL",
+		Short: "output shell completion code for the specified shell (bash or zsh)",
+		Long: `Write bash or zsh shell completion code to standard output.
+
+For bash, ensure you have bash completions installed & enabled.
+Either run
+$ source <(argo completion bash)
+Or write it to a file and source in .bash_profile
+
+For zsh, output to a file in a directory referenced by the $fpath shell
+variable.
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) != 1 {
+				cmd.HelpFunc()(cmd, args)
+				os.Exit(1)
+			}
+			var shell = args[0]
+			rootCommand := NewCommand()
+			if shell == "bash" {
+				rootCommand.GenBashCompletion(os.Stdout)
+			} else if shell == "zsh" {
+				rootCommand.GenZshCompletion(os.Stdout)
+			} else {
+				fmt.Printf("Invalid shell '%s'. The supported shells are bash and zsh.\n", shell)
+				os.Exit(1)
+			}
+		},
+	}
+
+	return command
+}

--- a/cmd/argo/commands/completion.go
+++ b/cmd/argo/commands/completion.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"fmt"
+	"io"
+	"log"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -26,15 +28,19 @@ variable.
 				cmd.HelpFunc()(cmd, args)
 				os.Exit(1)
 			}
-			var shell = args[0]
+			shell := args[0]
 			rootCommand := NewCommand()
-			if shell == "bash" {
-				rootCommand.GenBashCompletion(os.Stdout)
-			} else if shell == "zsh" {
-				rootCommand.GenZshCompletion(os.Stdout)
-			} else {
+			availableCompletions := map[string]func(io.Writer) error{
+				"bash": rootCommand.GenBashCompletion,
+				"zsh":  rootCommand.GenZshCompletion,
+			}
+			completion, ok := availableCompletions[shell]
+			if !ok {
 				fmt.Printf("Invalid shell '%s'. The supported shells are bash and zsh.\n", shell)
 				os.Exit(1)
+			}
+			if err := completion(os.Stdout); err != nil {
+				log.Fatal(err)
 			}
 		},
 	}

--- a/cmd/argo/commands/completion.go
+++ b/cmd/argo/commands/completion.go
@@ -13,10 +13,10 @@ func NewCompletionCommand() *cobra.Command {
 		Short: "output shell completion code for the specified shell (bash or zsh)",
 		Long: `Write bash or zsh shell completion code to standard output.
 
-For bash, ensure you have bash completions installed & enabled.
-Either run
+For bash, ensure you have bash completions installed and enabled.
+To access completions in your current shell, run
 $ source <(argo completion bash)
-Or write it to a file and source in .bash_profile
+Alternatively, write it to a file and source in .bash_profile
 
 For zsh, output to a file in a directory referenced by the $fpath shell
 variable.

--- a/cmd/argo/commands/root.go
+++ b/cmd/argo/commands/root.go
@@ -23,6 +23,7 @@ func NewCommand() *cobra.Command {
 		},
 	}
 
+	command.AddCommand(NewCompletionCommand())
 	command.AddCommand(NewDeleteCommand())
 	command.AddCommand(NewGetCommand())
 	command.AddCommand(NewInstallCommand())


### PR DESCRIPTION
The subcommand follows the pattern of kubectl's completion support,
though that has considerable extensions.

zsh support in cobra is minimal at the moment and doesn't support flag
completion. However, there are open PRs against it, so it doesn't seem
worth going the Kubernetes route which modifies the bash output to make
it suitable for zsh.

An obvious next step would be completing to workflow names. I doubt this
would be as useful as pod completions in kubectl, as there isn't often
a useful prefix (if you run many of the same type of workflow).