### PR TITLE
install & uninstall commands use --namespace flag

### DIFF
--- a/cmd/argo/commands/common.go
+++ b/cmd/argo/commands/common.go
@@ -13,6 +13,7 @@ import (
 	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	wfclientset "github.com/argoproj/argo/pkg/client/clientset/versioned"
 	"github.com/argoproj/argo/pkg/client/clientset/versioned/typed/workflow/v1alpha1"
+	"github.com/argoproj/argo/workflow/common"
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
@@ -142,4 +143,17 @@ func splitYAMLFile(body []byte) ([]wfv1.Workflow, error) {
 		manifests = append(manifests, wf)
 	}
 	return manifests, nil
+}
+
+//InstallNamespace returns either the namespace specified via the --namespace
+//flag or the default argo installation namespace (kube-system)
+func InstallNamespace() string {
+	namespace, wasSpecified, err := clientConfig.Namespace()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if wasSpecified {
+		return namespace
+	}
+	return common.DefaultControllerNamespace
 }

--- a/cmd/argo/commands/install.go
+++ b/cmd/argo/commands/install.go
@@ -28,6 +28,13 @@ func NewInstallCommand() *cobra.Command {
 		Short: "install Argo",
 		Run: func(cmd *cobra.Command, args []string) {
 			_ = initKubeClient()
+
+			namespace, _, err := clientConfig.Namespace()
+			if err != nil {
+				log.Fatal(err)
+			}
+			installArgs.Namespace = namespace
+
 			installer, err := install.NewInstaller(restConfig, installArgs)
 			if err != nil {
 				log.Fatal(err)
@@ -37,7 +44,6 @@ func NewInstallCommand() *cobra.Command {
 	}
 	command.Flags().BoolVar(&installArgs.Upgrade, "upgrade", false, "upgrade controller/ui deployments and configmap if already installed")
 	command.Flags().BoolVar(&installArgs.DryRun, "dry-run", false, "print the kubernetes manifests to stdout instead of installing")
-	command.Flags().StringVar(&installArgs.Namespace, "install-namespace", common.DefaultControllerNamespace, "install into a specific Namespace")
 	command.Flags().StringVar(&installArgs.InstanceID, "instanceid", "", "optional instance id to use for the controller (for multi-controller environments)")
 	command.Flags().StringVar(&installArgs.ConfigMap, "configmap", common.DefaultConfigMapName(common.DefaultControllerDeploymentName), "install controller using preconfigured configmap")
 	command.Flags().StringVar(&installArgs.ControllerImage, "controller-image", DefaultControllerImage, "use a specified controller image")

--- a/cmd/argo/commands/install.go
+++ b/cmd/argo/commands/install.go
@@ -29,12 +29,7 @@ func NewInstallCommand() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			_ = initKubeClient()
 
-			namespace, _, err := clientConfig.Namespace()
-			if err != nil {
-				log.Fatal(err)
-			}
-			installArgs.Namespace = namespace
-
+			installArgs.Namespace = InstallNamespace()
 			installer, err := install.NewInstaller(restConfig, installArgs)
 			if err != nil {
 				log.Fatal(err)

--- a/cmd/argo/commands/uninstall.go
+++ b/cmd/argo/commands/uninstall.go
@@ -27,11 +27,7 @@ func NewUninstallCommand() *cobra.Command {
 		Use:   "uninstall",
 		Short: "uninstall Argo",
 		Run: func(cmd *cobra.Command, args []string) {
-			namespace, _, err := clientConfig.Namespace()
-			if err != nil {
-				log.Fatal(err)
-			}
-			uninstallArgs.namespace = namespace
+			uninstallArgs.namespace = InstallNamespace()
 			uninstall(&uninstallArgs)
 		},
 	}

--- a/cmd/argo/commands/uninstall.go
+++ b/cmd/argo/commands/uninstall.go
@@ -16,7 +16,7 @@ type uninstallFlags struct {
 	controllerName string // --controller-name
 	uiName         string // --ui-name
 	configMap      string // --configmap
-	namespace      string // --install-namespace
+	namespace      string // --namespace
 }
 
 func NewUninstallCommand() *cobra.Command {
@@ -27,13 +27,17 @@ func NewUninstallCommand() *cobra.Command {
 		Use:   "uninstall",
 		Short: "uninstall Argo",
 		Run: func(cmd *cobra.Command, args []string) {
+			namespace, _, err := clientConfig.Namespace()
+			if err != nil {
+				log.Fatal(err)
+			}
+			uninstallArgs.namespace = namespace
 			uninstall(&uninstallArgs)
 		},
 	}
 	command.Flags().StringVar(&uninstallArgs.controllerName, "controller-name", common.DefaultControllerDeploymentName, "name of controller deployment")
 	command.Flags().StringVar(&uninstallArgs.uiName, "ui-name", ArgoUIDeploymentName, "name of ui deployment")
 	command.Flags().StringVar(&uninstallArgs.configMap, "configmap", common.DefaultConfigMapName(common.DefaultControllerDeploymentName), "name of configmap to uninstall")
-	command.Flags().StringVar(&uninstallArgs.namespace, "install-namespace", common.DefaultControllerNamespace, "uninstall from a specific namespace")
 	return command
 }
 

--- a/demo.md
+++ b/demo.md
@@ -28,7 +28,7 @@ NOTE:
 ```
 $ kubectl create clusterrolebinding YOURNAME-cluster-admin-binding --clusterrole=cluster-admin --user=YOUREMAIL@gmail.com
 ```
-* The subsequent instructions below assume the installation of argo into the `kube-system` namespace (the default behavior). A different namespace can be chosen using the `argo install --install-namespace <name>` flag, in which case you should substitute `kube-system` with your chosen namespace in the examples below.
+* The subsequent instructions below assume the installation of argo into the `kube-system` namespace (the default behavior). A different namespace can be chosen using the `argo install --namespace <name>` flag, in which case you should substitute `kube-system` with your chosen namespace in the examples below.
 
 ## 3. Configure the service account to run workflows (required for RBAC clusters)
 For clusters with RBAC enabled, the 'default' service account is too limited to do any kind of meaningful work. Run the following command to grant admin privileges to the 'default' service account in the namespace 'default':

--- a/install/install.go
+++ b/install/install.go
@@ -31,7 +31,7 @@ import (
 type InstallOptions struct {
 	Upgrade          bool   // --upgrade
 	DryRun           bool   // --dry-run
-	Namespace        string // --install-namespace
+	Namespace        string // --namespace
 	InstanceID       string // --instanceid
 	ConfigMap        string // --configmap
 	ControllerImage  string // --controller-image


### PR DESCRIPTION
This update the argo cli commands for `install` and `uninstall` to use the same `--namespace` flag as all other commands instead of the installation-specific flag `--install-namespace` (removing it entirely).

Closes #812