### PR TITLE
Use octal syntax for mode values

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -976,7 +976,7 @@ spec:
       # Download kubectl 1.8.0 and place it at /bin/kubectl
       - name: kubectl
         path: /bin/kubectl
-        mode: 755
+        mode: 0755
         http:
           url: https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl
       # Copy an s3 bucket and place it at /s3

--- a/examples/arguments-artifacts.yaml
+++ b/examples/arguments-artifacts.yaml
@@ -22,7 +22,7 @@ spec:
       artifacts:
       - name: kubectl
         path: /usr/local/bin/kubectl
-        mode: 755
+        mode: 0755
     container:
       image: debian:9.1
       command: [sh, -c]

--- a/examples/input-artifact-http.yaml
+++ b/examples/input-artifact-http.yaml
@@ -11,7 +11,7 @@ spec:
       artifacts:
       - name: kubectl
         path: /bin/kubectl
-        mode: 755
+        mode: 0755
         http:
           url: https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl
     container:

--- a/test/e2e/functional/global-param-sub-with-artifacts.yaml
+++ b/test/e2e/functional/global-param-sub-with-artifacts.yaml
@@ -19,7 +19,7 @@ spec:
       artifacts:
       - name: foo-artifact
         path: /tmp/foo.txt
-        mode: 0755
+        mode: 0644
     container:
       image: alpine:latest
       command: ["cat"]

--- a/test/e2e/functional/global-param-sub-with-artifacts.yaml
+++ b/test/e2e/functional/global-param-sub-with-artifacts.yaml
@@ -19,7 +19,7 @@ spec:
       artifacts:
       - name: foo-artifact
         path: /tmp/foo.txt
-        mode: 755
+        mode: 0755
     container:
       image: alpine:latest
       command: ["cat"]

--- a/test/e2e/functional/param-sub-with-artifacts.yaml
+++ b/test/e2e/functional/param-sub-with-artifacts.yaml
@@ -17,7 +17,7 @@ spec:
       artifacts:
       - name: foo-artifact
         path: /tmp/foo.txt
-        mode: 0755
+        mode: 0644
         http:
           url: "{{inputs.parameters.artifact-url}}"
 

--- a/test/e2e/functional/param-sub-with-artifacts.yaml
+++ b/test/e2e/functional/param-sub-with-artifacts.yaml
@@ -17,7 +17,7 @@ spec:
       artifacts:
       - name: foo-artifact
         path: /tmp/foo.txt
-        mode: 755
+        mode: 0755
         http:
           url: "{{inputs.parameters.artifact-url}}"
 

--- a/workflow/common/validate_test.go
+++ b/workflow/common/validate_test.go
@@ -346,7 +346,7 @@ spec:
       artifacts:
       - name: -kubectl
         path: /usr/local/bin/kubectl
-        mode: 755
+        mode: 0755
     container:
       image: debian:9.1
       command: [sh, -c]


### PR DESCRIPTION
All these examples were 755 which still left files executable but weirdly: --wxrw--wx.

I've changed the txt file to 0644 as it doesn't make much sense for that to be executable.

Related discussion: https://argoproj.slack.com/archives/C8J6SGN12/p1524363671000019