### PR TITLE
Bump from debian:9.1 to debian:9.4.

### DIFF
--- a/Dockerfile-argoexec
+++ b/Dockerfile-argoexec
@@ -1,4 +1,4 @@
-FROM debian:9.1
+FROM debian:9.4
 
 RUN apt-get update && \
     apt-get install -y curl jq procps git tar && \

--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -1,4 +1,4 @@
-FROM debian:9.1
+FROM debian:9.4
 
 RUN apt-get update && apt-get install -y \
     git \

--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -1,4 +1,4 @@
-FROM debian:9.1
+FROM debian:9.4
 
 COPY dist/argo /bin/
 

--- a/Dockerfile-workflow-controller
+++ b/Dockerfile-workflow-controller
@@ -1,4 +1,4 @@
-FROM debian:9.1
+FROM debian:9.4
 
 COPY dist/workflow-controller /bin/
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -327,7 +327,7 @@ spec:
 
   - name: gen-random-int-bash
     script:
-      image: debian:9.1
+      image: debian:9.4
       command: [bash]
       source: |                                         # Contents of the here-script
         cat /dev/urandom | od -N2 -An -i | awk -v f=1 -v r=100 '{printf "%i\n", f + r * $1 / 65536}'

--- a/examples/arguments-artifacts.yaml
+++ b/examples/arguments-artifacts.yaml
@@ -24,6 +24,6 @@ spec:
         path: /usr/local/bin/kubectl
         mode: 0755
     container:
-      image: debian:9.1
+      image: debian:9.4
       command: [sh, -c]
       args: ["kubectl version"]

--- a/examples/ci-output-artifact.yaml
+++ b/examples/ci-output-artifact.yaml
@@ -75,7 +75,7 @@ spec:
 
   - name: release-artifact
     container:
-      image: debian:9.1
+      image: debian:9.4
     outputs:
       artifacts:
       - name: release

--- a/examples/influxdb-ci.yaml
+++ b/examples/influxdb-ci.yaml
@@ -195,7 +195,7 @@ spec:
         path: /app
     daemon: true
     container:
-      image: debian:9.1
+      image: debian:9.4
       restartPolicy: Always
       readinessProbe:
         httpGet:

--- a/examples/input-artifact-http.yaml
+++ b/examples/input-artifact-http.yaml
@@ -15,6 +15,6 @@ spec:
         http:
           url: https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl
     container:
-      image: debian:9.1
+      image: debian:9.4
       command: [sh, -c]
       args: ["kubectl version"]

--- a/examples/scripts-bash.yaml
+++ b/examples/scripts-bash.yaml
@@ -25,7 +25,7 @@ spec:
 
   - name: gen-random-int
     script:
-      image: debian:9.1
+      image: debian:9.4
       command: [bash]
       source: |
         cat /dev/urandom | od -N2 -An -i | awk -v f=1 -v r=100 '{printf "%i\n", f + r * $1 / 65536}'

--- a/workflow/common/validate_test.go
+++ b/workflow/common/validate_test.go
@@ -348,7 +348,7 @@ spec:
         path: /usr/local/bin/kubectl
         mode: 0755
     container:
-      image: debian:9.1
+      image: debian:9.4
       command: [sh, -c]
       args: ["kubectl version"]
 `
@@ -796,7 +796,7 @@ spec:
   - name: leaf-with-parallelism
     parallelism: 2
     container:
-      image: debian:9.1
+      image: debian:9.4
       command: [sh, -c]
       args: ["kubectl version"]
 `
@@ -824,7 +824,7 @@ spec:
         template: try
   - name: try
     container:
-      image: debian:9.1
+      image: debian:9.4
       command: [sh, -c]
       args: ["kubectl version"]
 `
@@ -1018,7 +1018,7 @@ spec:
   templates:
   - name: pod-name-variable
     container:
-      image: debian:9.1
+      image: debian:9.4
       command: [sh, -c]
       args: ["kubectl {{pod.name}}"]
     outputs:


### PR DESCRIPTION
This address CVEs relevant to the base image for sensible-utils and util-linux as raised by Alex Weidner on Slack.

Related discussion:
https://argoproj.slack.com/archives/C8J6SGN12/p1524752782000431
https://argoproj.slack.com/archives/C8J6SGN12/p1524756128000408

Builds, installs + runs hello world fine. New containers have the updated versions noted in the container scanning report.
