### PR TITLE
Add gladly as an official argo user

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ As the Argo Community grows, we'd like to keep track of our users. Please send a
 Currently **officially** using Argo:
 
 1. [Cyrus Biotechnology](https://cyrusbio.com/)
+1. [Gladly](https://gladly.com/)
 1. [Google](https://www.google.com/intl/en/about/our-company/)
 1. [Intuit](https://www.intuit.com/) [[@mukulikak](https://github.com/mukulikak)]
 1. [NVIDIA](http://www.nvidia.com/)


### PR DESCRIPTION
At Gladly we set out to reinvent customer service, and we're using argo to help us do it. Currently we're using argo to orchestrate the building of our production machine learning models and see the potential to apply argo to several other use cases.