### PR TITLE
Avoid `println` which outputs to stderr

### DIFF
--- a/cmd/argo/commands/logs.go
+++ b/cmd/argo/commands/logs.go
@@ -272,7 +272,7 @@ func (p *logPrinter) printLogEntry(entry logEntry) {
 		colorIndex := int(math.Mod(float64(h.Sum32()), float64(len(colors))))
 		line = ansiFormat(entry.displayName, colors[colorIndex]) + ":	" + line
 	}
-	println(line)
+	fmt.Println(line)
 }
 
 func (p *logPrinter) ensureContainerStarted(podName string, podNamespace string, container string, retryCnt int, retryTimeout time.Duration) error {


### PR DESCRIPTION
Argo 2.0 outputted logs to stdout (via kubectl). This reinstates that behaviour by avoiding the builtin println in favour of fmt.Println.