### PR TITLE
Add workflow node pending status for imagePullError issue

### DIFF
--- a/pkg/apis/workflow/v1alpha1/types.go
+++ b/pkg/apis/workflow/v1alpha1/types.go
@@ -32,6 +32,7 @@ const (
 	NodeSkipped   NodePhase = "Skipped"
 	NodeFailed    NodePhase = "Failed"
 	NodeError     NodePhase = "Error"
+	NodePending   NodePhase = "Pending"
 )
 
 // NodeType is the type of a node

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -90,7 +90,6 @@ const (
 	workflowResyncPeriod        = 20 * time.Minute
 	workflowMetricsResyncPeriod = 1 * time.Minute
 	podResyncPeriod             = 30 * time.Minute
-	ImagePullBackOff            = "ImagePullBackOff"
 )
 
 // ArtifactRepository represents a artifact repository in which a controller will store its artifacts
@@ -306,18 +305,6 @@ func (wfc *WorkflowController) processNextPodItem() bool {
 		return true
 	}
 
-	foundImagePullBackOffFlag := false
-	for _, containerStatus := range pod.Status.ContainerStatuses {
-		if containerStatus.State.Waiting != nil && containerStatus.State.Waiting.Reason == ImagePullBackOff {
-			foundImagePullBackOffFlag = true
-			break
-		}
-	}
-
-	if !foundImagePullBackOffFlag {
-		return true
-	}
-
 	// TODO: currently we reawaken the workflow on *any* pod updates.
 	// But this could be be much improved to become smarter by only
 	// requeue the workflow when there are changes that we care about.
@@ -513,7 +500,7 @@ func (wfc *WorkflowController) newWorkflowPodWatch() *cache.ListWatch {
 	c := wfc.kubeclientset.CoreV1().RESTClient()
 	resource := "pods"
 	namespace := wfc.Config.Namespace
-	//fieldSelector := fields.ParseSelectorOrDie("status.phase!=Pending")
+	// fieldSelector := fields.ParseSelectorOrDie("status.phase!=Pending")
 	// completed=false
 	incompleteReq, _ := labels.NewRequirement(common.LabelKeyCompleted, selection.Equals, []string{"false"})
 	labelSelector := labels.NewSelector().
@@ -521,7 +508,7 @@ func (wfc *WorkflowController) newWorkflowPodWatch() *cache.ListWatch {
 		Add(wfc.instanceIDRequirement())
 
 	listFunc := func(options metav1.ListOptions) (runtime.Object, error) {
-		//	options.FieldSelector = fieldSelector.String()
+		//options.FieldSelector = fieldSelector.String()
 		options.LabelSelector = labelSelector.String()
 		req := c.Get().
 			Namespace(namespace).
@@ -531,7 +518,7 @@ func (wfc *WorkflowController) newWorkflowPodWatch() *cache.ListWatch {
 	}
 	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
 		options.Watch = true
-		//	options.FieldSelector = fieldSelector.String()
+		//options.FieldSelector = fieldSelector.String()
 		options.LabelSelector = labelSelector.String()
 		req := c.Get().
 			Namespace(namespace).


### PR DESCRIPTION
In many cases,  when user set the error image address or image does not exists. Kubernetes will report  `ImagePullBackOff` as the pod's status. But argo will think this workflow is running and node is health.   If the job will cost much time, when user find that image address is wrong, maybe 10 hours have been cost.  

Argo should report that `ImagePullBackOff` is the failed workflow. So user can find this issue quickly, fix it and won't waste much time.

```
[root@iZbp1flqunhs6fp1b9pe8pZ arg-example]# argo get steps-jxggl
Name:                steps-jxggl
Namespace:           default
ServiceAccount:      default
Status:              Failed
Message:             child 'steps-jxggl-1508661637' failed
Created:             Mon Aug 13 18:17:51 +0800 (10 minutes ago)
Started:             Mon Aug 13 18:17:51 +0800 (10 minutes ago)
Finished:            Mon Aug 13 18:17:57 +0800 (10 minutes ago)
Duration:            6 seconds

STEP            PODNAME                 DURATION  MESSAGE
 ✖ steps-jxggl                                    child 'steps-jxggl-1508661637' failed
 └---✖ hello0   steps-jxggl-1508661637  5s        Back-off pulling image "ttdocker/whalesay"
[root@iZbp1flqunhs6fp1b9pe8pZ arg-example]# kubectl get pods
NAME                     READY     STATUS             RESTARTS   AGE
batchrelease-test-0      1/1       Running            0          6d
batchrelease-test-1      1/1       Running            0          6d
batchrelease-test-2      1/1       Running            0          6d
batchrelease-test-3      1/1       Running            0          6d
steps-jxggl-1508661637   0/2       ImagePullBackOff   0          1h
```

This PR will report image pull error event and set the workflow to failed status.   User can find the issue easily by just run `argo get` command.