### PR TITLE
Add parameter-file support

### DIFF
--- a/cmd/argo/commands/submit.go
+++ b/cmd/argo/commands/submit.go
@@ -187,9 +187,10 @@ func submitWorkflow(wf *wfv1.Workflow, submitArgs *submitFlags) (string, error) 
 			}
 
 			for k, v := range yamlParams {
+				value := v
 				param := wfv1.Parameter{
 					Name:  k,
-					Value: &v,
+					Value: &value,
 				}
 				if _, ok := passedParams[param.Name]; ok {
 					// this parameter was overridden via command line

--- a/cmd/argo/commands/submit.go
+++ b/cmd/argo/commands/submit.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bufio"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -180,14 +181,14 @@ func submitWorkflow(wf *wfv1.Workflow, submitArgs *submitFlags) (string, error) 
 				}
 			}
 
-			yamlParams := map[string]string{}
+			yamlParams := map[string]interface{}{}
 			err = yaml.Unmarshal(body, &yamlParams)
 			if err != nil {
 				log.Fatal(err)
 			}
 
 			for k, v := range yamlParams {
-				value := v
+				value := fmt.Sprintf("%v", v)
 				param := wfv1.Parameter{
 					Name:  k,
 					Value: &value,


### PR DESCRIPTION
For workflows that have many parameters, or cases where the workflows should be run with slightly different requirements, it can be useful to have a file containing parameters instead of submitting via the command line.

This commit adds support for the `--parameter-file` (`-f`) command line option to provide a new-line-delimited file of parameters.  These parameters can still be overridden by the `--parameter` (`-p`) flags.

Comments in parameter files are also supported and denoted by a `#` character.

See #796 for more information