### PR TITLE
Add imagePullPolicy config for executors

### DIFF
--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -29,13 +29,14 @@ const (
 // NewRootCommand returns an new instance of the workflow-controller main entrypoint
 func NewRootCommand() *cobra.Command {
 	var (
-		clientConfig    clientcmd.ClientConfig
-		configMap       string // --configmap
-		executorImage   string // --executor-image
-		logLevel        string // --loglevel
-		glogLevel       int    // --gloglevel
-		workflowWorkers int    // --workflow-workers
-		podWorkers      int    // --pod-workers
+		clientConfig            clientcmd.ClientConfig
+		configMap               string // --configmap
+		executorImage           string // --executor-image
+		executorImagePullPolicy string // --executor-image-pull-policy
+		logLevel                string // --loglevel
+		glogLevel               int    // --gloglevel
+		workflowWorkers         int    // --workflow-workers
+		podWorkers              int    // --pod-workers
 	)
 
 	var command = cobra.Command{
@@ -68,7 +69,7 @@ func NewRootCommand() *cobra.Command {
 			wflientset := wfclientset.NewForConfigOrDie(config)
 
 			// start a controller on instances of our custom resource
-			wfController := controller.NewWorkflowController(config, kubeclientset, wflientset, namespace, executorImage, configMap)
+			wfController := controller.NewWorkflowController(config, kubeclientset, wflientset, namespace, executorImage, executorImagePullPolicy, configMap)
 			err = wfController.ResyncConfig()
 			if err != nil {
 				return err
@@ -91,6 +92,7 @@ func NewRootCommand() *cobra.Command {
 	command.AddCommand(cmdutil.NewVersionCmd(CLIName))
 	command.Flags().StringVar(&configMap, "configmap", "workflow-controller-configmap", "Name of K8s configmap to retrieve workflow controller configuration")
 	command.Flags().StringVar(&executorImage, "executor-image", "", "Executor image to use (overrides value in configmap)")
+	command.Flags().StringVar(&executorImagePullPolicy, "executor-image-pull-policy", "", "Executor imagePullPolicy to use (overrides value in configmap)")
 	command.Flags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")
 	command.Flags().IntVar(&glogLevel, "gloglevel", 0, "Set the glog logging level")
 	command.Flags().IntVar(&workflowWorkers, "workflow-workers", 8, "Number of workflow workers")

--- a/workflow/controller/config.go
+++ b/workflow/controller/config.go
@@ -24,6 +24,9 @@ type WorkflowControllerConfig struct {
 	// ExecutorImage is the image name of the executor to use when running pods
 	ExecutorImage string `json:"executorImage,omitempty"`
 
+	// ExecutorImagePullPolicy is the imagePullPolicy of the executor to use when running pods
+	ExecutorImagePullPolicy string `json:"executorImagePullPolicy,omitempty"`
+
 	// ExecutorResources specifies the resource requirements that will be used for the executor sidecar
 	ExecutorResources *apiv1.ResourceRequirements `json:"executorResources,omitempty"`
 
@@ -120,6 +123,17 @@ func (wfc *WorkflowController) executorImage() string {
 		return wfc.cliExecutorImage
 	}
 	return wfc.Config.ExecutorImage
+}
+
+// executorImagePullPolicy returns the imagePullPolicy to use for the workflow executor
+func (wfc *WorkflowController) executorImagePullPolicy() apiv1.PullPolicy {
+	var policy string
+	if wfc.cliExecutorImagePullPolicy != "" {
+		policy = wfc.cliExecutorImagePullPolicy
+	} else {
+		policy = wfc.Config.ExecutorImagePullPolicy
+	}
+	return apiv1.PullPolicy(policy)
 }
 
 func (wfc *WorkflowController) watchControllerConfigMap(ctx context.Context) (cache.Controller, error) {

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -42,6 +42,9 @@ type WorkflowController struct {
 	// cliExecutorImage is the executor image as specified from the command line
 	cliExecutorImage string
 
+	// cliExecutorImagePullPolicy is the executor imagePullPolicy as specified from the command line
+	cliExecutorImagePullPolicy string
+
 	// restConfig is used by controller to send a SIGUSR1 to the wait sidecar using remotecommand.NewSPDYExecutor().
 	restConfig    *rest.Config
 	kubeclientset kubernetes.Interface
@@ -68,18 +71,20 @@ func NewWorkflowController(
 	wfclientset wfclientset.Interface,
 	namespace,
 	executorImage,
+	executorImagePullPolicy,
 	configMap string,
 ) *WorkflowController {
 	wfc := WorkflowController{
-		restConfig:       restConfig,
-		kubeclientset:    kubeclientset,
-		wfclientset:      wfclientset,
-		configMap:        configMap,
-		namespace:        namespace,
-		cliExecutorImage: executorImage,
-		wfQueue:          workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
-		podQueue:         workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
-		completedPods:    make(chan string, 512),
+		restConfig:                 restConfig,
+		kubeclientset:              kubeclientset,
+		wfclientset:                wfclientset,
+		configMap:                  configMap,
+		namespace:                  namespace,
+		cliExecutorImage:           executorImage,
+		cliExecutorImagePullPolicy: executorImagePullPolicy,
+		wfQueue:                    workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		podQueue:                   workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		completedPods:              make(chan string, 512),
 	}
 	return &wfc
 }

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -329,9 +329,10 @@ func (woc *wfOperationCtx) createVolumes() []apiv1.Volume {
 
 func (woc *wfOperationCtx) newExecContainer(name string, privileged bool) *apiv1.Container {
 	exec := apiv1.Container{
-		Name:  name,
-		Image: woc.controller.executorImage(),
-		Env:   woc.createEnvVars(),
+		Name:            name,
+		Image:           woc.controller.executorImage(),
+		ImagePullPolicy: woc.controller.executorImagePullPolicy(),
+		Env:             woc.createEnvVars(),
 		SecurityContext: &apiv1.SecurityContext{
 			Privileged: &privileged,
 		},


### PR DESCRIPTION
I'm customizing some features of Argo with minikube and want to use locally built controller and executor images. I'd like to specify executor image pull policy along with executor image. Could you consider adding this feature?