### PR TITLE
Don't force gzip filtering in the tar test

### DIFF
--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -614,7 +614,7 @@ func (we *WorkflowExecutor) AddAnnotation(key, value string) error {
 
 // isTarball returns whether or not the file is a tarball
 func isTarball(filePath string) bool {
-	cmd := exec.Command("tar", "-tzf", filePath)
+	cmd := exec.Command("tar", "-tf", filePath)
 	log.Info(cmd.Args)
 	err := cmd.Run()
 	return err == nil


### PR DESCRIPTION
`tar -tf` will detect compressed tars correctly.

`tar -tzf` will seemingly blindly filter with gzip which causes single-file ZIPs to be accidentally understood as tgz files.

If we match such a tar we explode trying to untar as that call doesn't pass the option to uncompress and correctly spots that the file is not a tar.

Closes #984.