### PR TITLE
Fix example pod name

### DIFF
--- a/examples/archive-location.yaml
+++ b/examples/archive-location.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  generateName: hello-world-
+  generateName: archive-location-
 spec:
   entrypoint: whalesay
   templates:


### PR DESCRIPTION
I found the `generateName` of this example is different from the file name of the example while the other examples are the same as the filenames.