### PR TITLE
K8sAPI Executor

### DIFF
--- a/cmd/argoexec/commands/root.go
+++ b/cmd/argoexec/commands/root.go
@@ -79,7 +79,7 @@ func initExecutor() *executor.WorkflowExecutor {
 	var cre executor.ContainerRuntimeExecutor
 	switch os.Getenv(common.EnvVarContainerRuntimeExecutor) {
 	case common.ContainerRuntimeExecutorK8sAPI:
-		cre, err = k8sapi.NewK8sAPIExecutor()
+		cre, err = k8sapi.NewK8sAPIExecutor(clientset, config, podName, namespace)
 		if err != nil {
 			panic(err.Error())
 		}

--- a/cmd/argoexec/commands/root.go
+++ b/cmd/argoexec/commands/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/argoproj/argo/workflow/common"
 	"github.com/argoproj/argo/workflow/executor"
 	"github.com/argoproj/argo/workflow/executor/docker"
+	"github.com/argoproj/argo/workflow/executor/k8sapi"
 	"github.com/argoproj/argo/workflow/executor/kubelet"
 )
 
@@ -77,6 +78,11 @@ func initExecutor() *executor.WorkflowExecutor {
 
 	var cre executor.ContainerRuntimeExecutor
 	switch os.Getenv(common.EnvVarContainerRuntimeExecutor) {
+	case common.ContainerRuntimeExecutorK8sAPI:
+		cre, err = k8sapi.NewK8sAPIExecutor()
+		if err != nil {
+			panic(err.Error())
+		}
 	case common.ContainerRuntimeExecutorKubelet:
 		cre, err = kubelet.NewKubeletExecutor()
 		if err != nil {

--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -67,6 +67,10 @@ data:
     # disable the TLS verification of the kubelet executo (default: false)
     kubeletInsecure: false
 
+    # Config file path when using k8sapi executor.
+    # Empty string indicates in-cluster service account. (default: "")
+    k8sAPIConfigPath: ""
+
     # executorResources specifies the resource requirements that will be used for the executor
     # sidecar/init container. This is useful in clusters which require resources to be specified as
     # part of admission control.

--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -33,7 +33,7 @@ data:
         bucket: my-bucket
         region: us-west-2
         # keyFormat is a format pattern to define how artifacts will be organized in a bucket.
-        # It can reference workflow metadata variables such as workflow.namespace, workflow.name, 
+        # It can reference workflow metadata variables such as workflow.namespace, workflow.name,
         # pod.name. Can also use strftime formating of workflow.creationTimestamp so that workflow
         # artifacts can be organized by date. If omitted, will use `{{workflow.name}}/{{pod.name}}`,
         # which has potential for have collisions.
@@ -66,10 +66,6 @@ data:
 
     # disable the TLS verification of the kubelet executo (default: false)
     kubeletInsecure: false
-
-    # Config file path when using k8sapi executor.
-    # Empty string indicates in-cluster service account. (default: "")
-    k8sAPIConfigPath: ""
 
     # executorResources specifies the resource requirements that will be used for the executor
     # sidecar/init container. This is useful in clusters which require resources to be specified as

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -91,13 +91,6 @@ const (
 	// EnvVarKubeletInsecure is used to disable the TLS verification
 	EnvVarKubeletInsecure = "ARGO_KUBELET_INSECURE"
 
-	// EnvVarK8sAPIConfigPath is used to specify Kubernetes API config path
-	EnvVarK8sAPIConfigPath = "ARGO_K8SAPI_CONFIG_PATH"
-	// EnvVarK8sAPITargetNamespace is used to specify target namespace
-	EnvVarK8sAPITargetNamespace = "ARGO_K8SAPI_TARGET_NAMESPACE"
-	// EnvVarK8sAPITargetPodName is used to specify target pod name
-	EnvVarK8sAPITargetPodName = "ARGO_K8SAPI_TARGET_POD_NAME"
-
 	// ContainerRuntimeExecutorDocker to use docker as container runtime executor
 	ContainerRuntimeExecutorDocker = "docker"
 

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -91,11 +91,21 @@ const (
 	// EnvVarKubeletInsecure is used to disable the TLS verification
 	EnvVarKubeletInsecure = "ARGO_KUBELET_INSECURE"
 
+	// EnvVarK8sAPIConfigPath is used to specify Kubernetes API config path
+	EnvVarK8sAPIConfigPath = "ARGO_K8SAPI_CONFIG_PATH"
+	// EnvVarK8sAPITargetNamespace is used to specify target namespace
+	EnvVarK8sAPITargetNamespace = "ARGO_K8SAPI_TARGET_NAMESPACE"
+	// EnvVarK8sAPITargetPodName is used to specify target pod name
+	EnvVarK8sAPITargetPodName = "ARGO_K8SAPI_TARGET_POD_NAME"
+
 	// ContainerRuntimeExecutorDocker to use docker as container runtime executor
 	ContainerRuntimeExecutorDocker = "docker"
 
 	// ContainerRuntimeExecutorKubelet to use the kubelet as container runtime executor
 	ContainerRuntimeExecutorKubelet = "kubelet"
+
+	// ContainerRuntimeExecutorK8sAPI to use the Kubernetes API server as container runtime executor
+	ContainerRuntimeExecutorK8sAPI = "k8sapi"
 
 	// Variables that are added to the scope during template execution and can be referenced using {{}} syntax
 

--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -96,7 +96,7 @@ func ExecPodContainer(restConfig *rest.Config, namespace string, pod string, con
 }
 
 // GetExecutorOutput returns the output of an remotecommand.Executor
-func GetExecutorOutput(exec remotecommand.Executor) (string, string, error) {
+func GetExecutorOutput(exec remotecommand.Executor) (*bytes.Buffer, *bytes.Buffer, error) {
 	var stdOut bytes.Buffer
 	var stdErr bytes.Buffer
 	err := exec.Stream(remotecommand.StreamOptions{
@@ -105,9 +105,9 @@ func GetExecutorOutput(exec remotecommand.Executor) (string, string, error) {
 		Tty:    false,
 	})
 	if err != nil {
-		return "", "", errors.InternalWrapError(err)
+		return nil, nil, errors.InternalWrapError(err)
 	}
-	return stdOut.String(), stdErr.String(), nil
+	return &stdOut, &stdErr, nil
 }
 
 // ProcessArgs sets in the inputs, the values either passed via arguments, or the hardwired values

--- a/workflow/controller/config.go
+++ b/workflow/controller/config.go
@@ -39,9 +39,6 @@ type WorkflowControllerConfig struct {
 	// KubeletInsecure disable the TLS verification of the kubelet containerRuntimeExecutor, default to false
 	KubeletInsecure bool `json:"kubeletInsecure,omitempty"`
 
-	// K8sAPIConfigPath is needed when using the k8sapi containerRuntimeExecutor, default to use in cluster config
-	K8sAPIConfigPath string `json:"k8sAPIConfigPath,omitempty"`
-
 	// ArtifactRepository contains the default location of an artifact repository for container artifacts
 	ArtifactRepository ArtifactRepository `json:"artifactRepository,omitempty"`
 

--- a/workflow/controller/config.go
+++ b/workflow/controller/config.go
@@ -39,6 +39,9 @@ type WorkflowControllerConfig struct {
 	// KubeletInsecure disable the TLS verification of the kubelet containerRuntimeExecutor, default to false
 	KubeletInsecure bool `json:"kubeletInsecure,omitempty"`
 
+	// K8sAPIConfigPath is needed when using the k8sapi containerRuntimeExecutor, default to use in cluster config
+	K8sAPIConfigPath string `json:"k8sAPIConfigPath,omitempty"`
+
 	// ArtifactRepository contains the default location of an artifact repository for container artifacts
 	ArtifactRepository ArtifactRepository `json:"artifactRepository,omitempty"`
 

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -281,12 +281,6 @@ func (woc *wfOperationCtx) createEnvVars() []apiv1.EnvVar {
 				Name:  common.EnvVarContainerRuntimeExecutor,
 				Value: woc.controller.Config.ContainerRuntimeExecutor,
 			},
-			apiv1.EnvVar{
-				Name:  common.EnvVarK8sAPIConfigPath,
-				Value: woc.controller.Config.K8sAPIConfigPath,
-			},
-			envFromField(common.EnvVarK8sAPITargetNamespace, "metadata.namespace"),
-			envFromField(common.EnvVarK8sAPITargetPodName, "metadata.name"),
 		)
 	case common.ContainerRuntimeExecutorKubelet:
 		return append(execEnvVars,

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -275,6 +275,19 @@ func (woc *wfOperationCtx) newWaitContainer(tmpl *wfv1.Template) (*apiv1.Contain
 
 func (woc *wfOperationCtx) createEnvVars() []apiv1.EnvVar {
 	switch woc.controller.Config.ContainerRuntimeExecutor {
+	case common.ContainerRuntimeExecutorK8sAPI:
+		return append(execEnvVars,
+			apiv1.EnvVar{
+				Name:  common.EnvVarContainerRuntimeExecutor,
+				Value: woc.controller.Config.ContainerRuntimeExecutor,
+			},
+			apiv1.EnvVar{
+				Name:  common.EnvVarK8sAPIConfigPath,
+				Value: woc.controller.Config.K8sAPIConfigPath,
+			},
+			envFromField(common.EnvVarK8sAPITargetNamespace, "metadata.namespace"),
+			envFromField(common.EnvVarK8sAPITargetPodName, "metadata.name"),
+		)
 	case common.ContainerRuntimeExecutorKubelet:
 		return append(execEnvVars,
 			apiv1.EnvVar{

--- a/workflow/executor/common/common.go
+++ b/workflow/executor/common/common.go
@@ -1,0 +1,140 @@
+package common
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	containerShimPrefix = "://"
+)
+
+// killGracePeriod is the time in seconds after sending SIGTERM before
+// forcefully killing the sidecar with SIGKILL (value matches k8s)
+const killGracePeriod = 10
+
+// GetContainerID returns container ID of a ContainerStatus resource
+func GetContainerID(container *v1.ContainerStatus) string {
+	i := strings.Index(container.ContainerID, containerShimPrefix)
+	if i == -1 {
+		return ""
+	}
+	return container.ContainerID[i+len(containerShimPrefix):]
+}
+
+// KubernetesClientInterface is the interface to implement getContainerStatus method
+type KubernetesClientInterface interface {
+	getContainerStatus(containerID string) (*v1.Pod, *v1.ContainerStatus, error)
+	killContainer(pod *v1.Pod, container *v1.ContainerStatus, sig syscall.Signal) error
+	createArchive(containerID, sourcePath string) (*bytes.Buffer, error)
+}
+
+// WaitForTermination of the given containerID, set the timeout to 0 to discard it
+func WaitForTermination(c KubernetesClientInterface, containerID string, timeout time.Duration) error {
+	ticker := time.NewTicker(time.Second * 1)
+	defer ticker.Stop()
+	timer := time.NewTimer(timeout)
+	if timeout == 0 {
+		timer.Stop()
+	} else {
+		defer timer.Stop()
+	}
+
+	log.Infof("Starting to wait completion of containerID %s ...", containerID)
+	for {
+		select {
+		case <-ticker.C:
+			_, containerStatus, err := c.getContainerStatus(containerID)
+			if err != nil {
+				return err
+			}
+			if containerStatus.State.Terminated == nil {
+				continue
+			}
+			log.Infof("ContainerID %q is terminated: %v", containerID, containerStatus.String())
+			return nil
+		case <-timer.C:
+			return fmt.Errorf("timeout after %s", timeout.String())
+		}
+	}
+}
+
+// TerminatePodWithContainerID invoke the given SIG against the PID1 of the container.
+// No-op if the container is on the hostPID
+func TerminatePodWithContainerID(c KubernetesClientInterface, containerID string, sig syscall.Signal) error {
+	pod, container, err := c.getContainerStatus(containerID)
+	if err != nil {
+		return err
+	}
+	if container.State.Terminated != nil {
+		log.Infof("Container %s is already terminated: %v", container.ContainerID, container.State.Terminated.String())
+		return nil
+	}
+	if pod.Spec.HostPID {
+		return fmt.Errorf("cannot terminate a hostPID Pod %s", pod.Name)
+	}
+	if pod.Spec.RestartPolicy != "Never" {
+		return fmt.Errorf("cannot terminate pod with a %q restart policy", pod.Spec.RestartPolicy)
+	}
+	return c.killContainer(pod, container, sig)
+}
+
+// KillGracefully kills a container gracefully.
+func KillGracefully(c KubernetesClientInterface, containerID string) error {
+	log.Infof("SIGTERM containerID %q ...", containerID, syscall.SIGTERM.String())
+	err := TerminatePodWithContainerID(c, containerID, syscall.SIGTERM)
+	if err != nil {
+		return err
+	}
+	err = WaitForTermination(c, containerID, time.Second*killGracePeriod)
+	if err == nil {
+		log.Infof("ContainerID %q successfully killed", containerID)
+		return nil
+	}
+	log.Infof("SIGKILL containerID %q ...", containerID, syscall.SIGKILL.String())
+	err = TerminatePodWithContainerID(c, containerID, syscall.SIGKILL)
+	if err != nil {
+		return err
+	}
+	err = WaitForTermination(c, containerID, time.Second*killGracePeriod)
+	if err != nil {
+		return err
+	}
+	log.Infof("ContainerID %q successfully killed", containerID)
+	return nil
+}
+
+// CopyArchive downloads files and directories as a tarball and saves it to a specified path.
+func CopyArchive(c KubernetesClientInterface, containerID, sourcePath, destPath string) error {
+	log.Infof("Archiving %s:%s to %s", containerID, sourcePath, destPath)
+	b, err := c.createArchive(containerID, sourcePath)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(destPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
+	if err != nil {
+		return err
+	}
+	w := gzip.NewWriter(f)
+	_, err = w.Write(b.Bytes())
+	if err != nil {
+		return err
+	}
+	err = w.Flush()
+	if err != nil {
+		return err
+	}
+	err = w.Close()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/workflow/executor/k8sapi/client.go
+++ b/workflow/executor/k8sapi/client.go
@@ -1,0 +1,217 @@
+package k8sapi
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/argoproj/argo/errors"
+	"github.com/argoproj/argo/workflow/common"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	readWSResponseTimeout = time.Minute * 1
+	containerShimPrefix   = "://"
+)
+
+type k8sAPIClient struct {
+	clientset *kubernetes.Clientset
+	config    *restclient.Config
+	podName   string
+	namespace string
+}
+
+func newK8sAPIClient() (*k8sAPIClient, error) {
+	kubeconfigPath := os.Getenv(common.EnvVarK8sAPIConfigPath)
+	kubeConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	if err != nil {
+		return nil, errors.InternalWrapError(err)
+	}
+	clientset, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		return nil, errors.InternalWrapError(err)
+	}
+
+	namespace := os.Getenv(common.EnvVarK8sAPITargetNamespace)
+	if namespace == "" {
+		return nil, errors.New(errors.CodeBadRequest, fmt.Sprintf("namespace must be specified"))
+	}
+
+	podName := os.Getenv(common.EnvVarK8sAPITargetPodName)
+	if podName == "" {
+		return nil, errors.New(errors.CodeBadRequest, fmt.Sprintf("pod name must be specified"))
+	}
+
+	return &k8sAPIClient{
+		clientset: clientset,
+		config:    kubeConfig,
+		podName:   podName,
+		namespace: namespace,
+	}, nil
+}
+
+func (c *k8sAPIClient) getFileContents(containerID, sourcePath string) (string, error) {
+	containerStatus, err := c.getContainerStatus(containerID)
+	if err != nil {
+		return "", err
+	}
+	command := []string{"cat", sourcePath}
+	exec, err := common.ExecPodContainer(c.config, c.namespace, c.podName, containerStatus.Name, true, false, command...)
+	if err != nil {
+		return "", err
+	}
+	stdOut, _, err := common.GetExecutorOutput(exec)
+	if err != nil {
+		return "", err
+	}
+	return stdOut.String(), nil
+}
+
+func (c *k8sAPIClient) createArchive(containerID, sourcePath string) (*bytes.Buffer, error) {
+	containerStatus, err := c.getContainerStatus(containerID)
+	if err != nil {
+		return nil, err
+	}
+	command := []string{"tar", "cf", "-", sourcePath}
+	exec, err := common.ExecPodContainer(c.config, c.namespace, c.podName, containerStatus.Name, true, false, command...)
+	if err != nil {
+		return nil, err
+	}
+	stdOut, _, err := common.GetExecutorOutput(exec)
+	if err != nil {
+		return nil, err
+	}
+	return stdOut, nil
+}
+
+func (c *k8sAPIClient) getLogsAsStream(containerID string) (io.ReadCloser, error) {
+	containerStatus, err := c.getContainerStatus(containerID)
+	if err != nil {
+		return nil, err
+	}
+	return c.clientset.CoreV1().Pods(c.namespace).
+		GetLogs(c.podName, &v1.PodLogOptions{Container: containerStatus.Name, SinceTime: nil}).Stream()
+}
+
+func (c *k8sAPIClient) getLogs(containerID string) (string, error) {
+	reader, err := c.getLogsAsStream(containerID)
+	if err != nil {
+		return "", err
+	}
+	bytes, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return "", errors.InternalWrapError(err)
+	}
+	return string(bytes), nil
+}
+
+func (c *k8sAPIClient) saveLogs(containerID, path string) error {
+	reader, err := c.getLogsAsStream(containerID)
+	if err != nil {
+		return err
+	}
+	outFile, err := os.Create(path)
+	if err != nil {
+		return errors.InternalWrapError(err)
+	}
+	defer outFile.Close()
+	_, err = io.Copy(outFile, reader)
+	if err != nil {
+		return errors.InternalWrapError(err)
+	}
+	return nil
+}
+
+func (c *k8sAPIClient) terminatePodWithContainerID(containerID string, sig syscall.Signal) error {
+	containerStatus, err := c.getContainerStatus(containerID)
+	if err != nil {
+		return err
+	}
+	if containerStatus.State.Terminated != nil {
+		log.Infof("Container %s is already terminated: %v", containerID, containerStatus.State.Terminated.String())
+		return nil
+	}
+	pod, err := c.getPod()
+	if err != nil {
+		return err
+	}
+	if pod.Spec.HostPID {
+		return fmt.Errorf("cannot terminate a hostPID Pod %s", pod.Name)
+	}
+	if pod.Spec.RestartPolicy != v1.RestartPolicyNever {
+		return fmt.Errorf("cannot terminate pod with a %q restart policy", pod.Spec.RestartPolicy)
+	}
+	command := []string{"/bin/sh", "-c", fmt.Sprintf("kill -%d 1", sig)}
+	exec, err := common.ExecPodContainer(c.config, c.namespace, c.podName, containerStatus.Name, false, false, command...)
+	if err != nil {
+		return err
+	}
+	_, _, err = common.GetExecutorOutput(exec)
+	return err
+}
+
+func getContainerID(container *v1.ContainerStatus) string {
+	i := strings.Index(container.ContainerID, containerShimPrefix)
+	if i == -1 {
+		return ""
+	}
+	return container.ContainerID[i+len(containerShimPrefix):]
+}
+
+func (c *k8sAPIClient) getPod() (*v1.Pod, error) {
+	return c.clientset.CoreV1().Pods(c.namespace).Get(c.podName, metav1.GetOptions{})
+}
+
+func (c *k8sAPIClient) getContainerStatus(containerID string) (*v1.ContainerStatus, error) {
+	pod, err := c.getPod()
+	if err != nil {
+		return nil, err
+	}
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		if getContainerID(&containerStatus) != containerID {
+			continue
+		}
+		return &containerStatus, nil
+	}
+	return nil, errors.New(errors.CodeNotFound, fmt.Sprintf("containerID %q is not found in the pod %s", containerID, c.podName))
+}
+
+func (c *k8sAPIClient) waitForTermination(containerID string, timeout time.Duration) error {
+	ticker := time.NewTicker(time.Second * 1)
+	defer ticker.Stop()
+	timer := time.NewTimer(timeout)
+	if timeout == 0 {
+		timer.Stop()
+	} else {
+		defer timer.Stop()
+	}
+
+	log.Infof("Starting to wait completion of containerID %s ...", containerID)
+	for {
+		select {
+		case <-ticker.C:
+			containerStatus, err := c.getContainerStatus(containerID)
+			if err != nil {
+				return err
+			}
+			if containerStatus.State.Terminated == nil {
+				continue
+			}
+			log.Infof("ContainerID %q is terminated: %v", containerID, containerStatus.String())
+			return nil
+		case <-timer.C:
+			return errors.New(errors.CodeTimeout, fmt.Sprintf("timeout after %s", timeout.String()))
+		}
+	}
+}

--- a/workflow/executor/k8sapi/client.go
+++ b/workflow/executor/k8sapi/client.go
@@ -98,7 +98,7 @@ func (c *k8sAPIClient) getLogsAsStream(containerID string) (io.ReadCloser, error
 		return nil, err
 	}
 	return c.clientset.CoreV1().Pods(c.namespace).
-		GetLogs(c.podName, &v1.PodLogOptions{Container: containerStatus.Name, SinceTime: nil}).Stream()
+		GetLogs(c.podName, &v1.PodLogOptions{Container: containerStatus.Name, SinceTime: &metav1.Time{}}).Stream()
 }
 
 func (c *k8sAPIClient) getLogs(containerID string) (string, error) {

--- a/workflow/executor/k8sapi/client.go
+++ b/workflow/executor/k8sapi/client.go
@@ -12,12 +12,10 @@ import (
 	"github.com/argoproj/argo/errors"
 	"github.com/argoproj/argo/workflow/common"
 	execcommon "github.com/argoproj/argo/workflow/executor/common"
-	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 type k8sAPIClient struct {
@@ -29,30 +27,10 @@ type k8sAPIClient struct {
 	namespace string
 }
 
-func newK8sAPIClient() (*k8sAPIClient, error) {
-	kubeconfigPath := os.Getenv(common.EnvVarK8sAPIConfigPath)
-	kubeConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
-	if err != nil {
-		return nil, errors.InternalWrapError(err)
-	}
-	clientset, err := kubernetes.NewForConfig(kubeConfig)
-	if err != nil {
-		return nil, errors.InternalWrapError(err)
-	}
-
-	namespace := os.Getenv(common.EnvVarK8sAPITargetNamespace)
-	if namespace == "" {
-		return nil, errors.New(errors.CodeBadRequest, fmt.Sprintf("namespace must be specified"))
-	}
-
-	podName := os.Getenv(common.EnvVarK8sAPITargetPodName)
-	if podName == "" {
-		return nil, errors.New(errors.CodeBadRequest, fmt.Sprintf("pod name must be specified"))
-	}
-
+func newK8sAPIClient(clientset *kubernetes.Clientset, config *restclient.Config, podName, namespace string) (*k8sAPIClient, error) {
 	return &k8sAPIClient{
 		clientset: clientset,
-		config:    kubeConfig,
+		config:    config,
 		podName:   podName,
 		namespace: namespace,
 	}, nil

--- a/workflow/executor/k8sapi/k8sapi.go
+++ b/workflow/executor/k8sapi/k8sapi.go
@@ -1,18 +1,9 @@
 package k8sapi
 
 import (
-	"compress/gzip"
-	"os"
-	"syscall"
-	"time"
-
 	"github.com/argoproj/argo/errors"
 	log "github.com/sirupsen/logrus"
 )
-
-// killGracePeriod is the time in seconds after sending SIGTERM before
-// forcefully killing the sidecar with SIGKILL (value matches k8s)
-const killGracePeriod = 10
 
 type K8sAPIExecutor struct {
 	client *k8sAPIClient
@@ -35,29 +26,7 @@ func (k *K8sAPIExecutor) GetFileContents(containerID string, sourcePath string) 
 }
 
 func (k *K8sAPIExecutor) CopyFile(containerID string, sourcePath string, destPath string) error {
-	log.Infof("Archiving %s:%s to %s", containerID, sourcePath, destPath)
-	b, err := k.client.createArchive(containerID, sourcePath)
-	if err != nil {
-		return err
-	}
-	f, err := os.OpenFile(destPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
-	if err != nil {
-		return err
-	}
-	w := gzip.NewWriter(f)
-	_, err = w.Write(b.Bytes())
-	if err != nil {
-		return err
-	}
-	err = w.Flush()
-	if err != nil {
-		return err
-	}
-	err = w.Close()
-	if err != nil {
-		return err
-	}
-	return nil
+	return k.client.copyArchive(containerID, sourcePath, destPath)
 }
 
 // GetOutput returns the entirety of the container output as a string
@@ -83,26 +52,10 @@ func (k *K8sAPIExecutor) Wait(containerID string) error {
 func (k *K8sAPIExecutor) Kill(containerIDs []string) error {
 	log.Infof("Killing containers %s", containerIDs)
 	for _, containerID := range containerIDs {
-		log.Infof("SIGTERM containerID %q ...", containerID, syscall.SIGTERM.String())
-		err := k.client.terminatePodWithContainerID(containerID, syscall.SIGTERM)
+		err := k.client.killGracefully(containerID)
 		if err != nil {
 			return err
 		}
-		err = k.client.waitForTermination(containerID, time.Second*killGracePeriod)
-		if err == nil {
-			log.Infof("ContainerID %q successfully killed", containerID)
-			continue
-		}
-		log.Infof("SIGKILL containerID %q ...", containerID, syscall.SIGKILL.String())
-		err = k.client.terminatePodWithContainerID(containerID, syscall.SIGKILL)
-		if err != nil {
-			return err
-		}
-		err = k.client.waitForTermination(containerID, time.Second*killGracePeriod)
-		if err != nil {
-			return err
-		}
-		log.Infof("ContainerID %q successfully killed", containerID)
 	}
 	return nil
 }

--- a/workflow/executor/k8sapi/k8sapi.go
+++ b/workflow/executor/k8sapi/k8sapi.go
@@ -3,15 +3,17 @@ package k8sapi
 import (
 	"github.com/argoproj/argo/errors"
 	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
 )
 
 type K8sAPIExecutor struct {
 	client *k8sAPIClient
 }
 
-func NewK8sAPIExecutor() (*K8sAPIExecutor, error) {
+func NewK8sAPIExecutor(clientset *kubernetes.Clientset, config *restclient.Config, podName, namespace string) (*K8sAPIExecutor, error) {
 	log.Infof("Creating a K8sAPI executor")
-	client, err := newK8sAPIClient()
+	client, err := newK8sAPIClient(clientset, config, podName, namespace)
 	if err != nil {
 		return nil, errors.InternalWrapError(err)
 	}

--- a/workflow/executor/k8sapi/k8sapi.go
+++ b/workflow/executor/k8sapi/k8sapi.go
@@ -1,0 +1,108 @@
+package k8sapi
+
+import (
+	"compress/gzip"
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/argoproj/argo/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// killGracePeriod is the time in seconds after sending SIGTERM before
+// forcefully killing the sidecar with SIGKILL (value matches k8s)
+const killGracePeriod = 10
+
+type K8sAPIExecutor struct {
+	client *k8sAPIClient
+}
+
+func NewK8sAPIExecutor() (*K8sAPIExecutor, error) {
+	log.Infof("Creating a K8sAPI executor")
+	client, err := newK8sAPIClient()
+	if err != nil {
+		return nil, errors.InternalWrapError(err)
+	}
+	return &K8sAPIExecutor{
+		client: client,
+	}, nil
+}
+
+func (k *K8sAPIExecutor) GetFileContents(containerID string, sourcePath string) (string, error) {
+	log.Infof("Getting file contents of %s:%s", containerID, sourcePath)
+	return k.client.getFileContents(containerID, sourcePath)
+}
+
+func (k *K8sAPIExecutor) CopyFile(containerID string, sourcePath string, destPath string) error {
+	log.Infof("Archiving %s:%s to %s", containerID, sourcePath, destPath)
+	b, err := k.client.createArchive(containerID, sourcePath)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(destPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
+	if err != nil {
+		return err
+	}
+	w := gzip.NewWriter(f)
+	_, err = w.Write(b.Bytes())
+	if err != nil {
+		return err
+	}
+	err = w.Flush()
+	if err != nil {
+		return err
+	}
+	err = w.Close()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetOutput returns the entirety of the container output as a string
+// Used to capturing script results as an output parameter
+func (k *K8sAPIExecutor) GetOutput(containerID string) (string, error) {
+	log.Infof("Getting output of %s", containerID)
+	return k.client.getLogs(containerID)
+}
+
+// Logs copies logs to a given path
+func (k *K8sAPIExecutor) Logs(containerID, path string) error {
+	log.Infof("Saving output of %s to %s", containerID, path)
+	return k.client.saveLogs(containerID, path)
+}
+
+// Wait for the container to complete
+func (k *K8sAPIExecutor) Wait(containerID string) error {
+	log.Infof("Waiting for container %s to complete", containerID)
+	return k.client.waitForTermination(containerID, 0)
+}
+
+// Kill kills a list of containerIDs first with a SIGTERM then with a SIGKILL after a grace period
+func (k *K8sAPIExecutor) Kill(containerIDs []string) error {
+	log.Infof("Killing containers %s", containerIDs)
+	for _, containerID := range containerIDs {
+		log.Infof("SIGTERM containerID %q ...", containerID, syscall.SIGTERM.String())
+		err := k.client.terminatePodWithContainerID(containerID, syscall.SIGTERM)
+		if err != nil {
+			return err
+		}
+		err = k.client.waitForTermination(containerID, time.Second*killGracePeriod)
+		if err == nil {
+			log.Infof("ContainerID %q successfully killed", containerID)
+			continue
+		}
+		log.Infof("SIGKILL containerID %q ...", containerID, syscall.SIGKILL.String())
+		err = k.client.terminatePodWithContainerID(containerID, syscall.SIGKILL)
+		if err != nil {
+			return err
+		}
+		err = k.client.waitForTermination(containerID, time.Second*killGracePeriod)
+		if err != nil {
+			return err
+		}
+		log.Infof("ContainerID %q successfully killed", containerID)
+	}
+	return nil
+}

--- a/workflow/executor/kubelet/kubelet.go
+++ b/workflow/executor/kubelet/kubelet.go
@@ -1,18 +1,9 @@
 package kubelet
 
 import (
-	"compress/gzip"
-	"os"
-	"syscall"
-	"time"
-
 	"github.com/argoproj/argo/errors"
 	log "github.com/sirupsen/logrus"
 )
-
-// killGracePeriod is the time in seconds after sending SIGTERM before
-// forcefully killing the sidecar with SIGKILL (value matches k8s)
-const killGracePeriod = 10
 
 type KubeletExecutor struct {
 	cli *kubeletClient
@@ -38,29 +29,7 @@ func (k *KubeletExecutor) GetFileContents(containerID string, sourcePath string)
 }
 
 func (k *KubeletExecutor) CopyFile(containerID string, sourcePath string, destPath string) error {
-	log.Infof("Archiving %s:%s to %s", containerID, sourcePath, destPath)
-	b, err := k.cli.CreateArchive(containerID, sourcePath)
-	if err != nil {
-		return err
-	}
-	f, err := os.OpenFile(destPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
-	if err != nil {
-		return err
-	}
-	w := gzip.NewWriter(f)
-	_, err = w.Write(b.Bytes())
-	if err != nil {
-		return err
-	}
-	err = w.Flush()
-	if err != nil {
-		return err
-	}
-	err = w.Close()
-	if err != nil {
-		return err
-	}
-	return f.Close()
+	return k.cli.CopyArchive(containerID, sourcePath, destPath)
 }
 
 // GetOutput returns the entirety of the container output as a string
@@ -82,26 +51,10 @@ func (k *KubeletExecutor) Wait(containerID string) error {
 // Kill kills a list of containerIDs first with a SIGTERM then with a SIGKILL after a grace period
 func (k *KubeletExecutor) Kill(containerIDs []string) error {
 	for _, containerID := range containerIDs {
-		log.Infof("SIGTERM containerID %q ...", containerID, syscall.SIGTERM.String())
-		err := k.cli.TerminatePodWithContainerID(containerID, syscall.SIGTERM)
+		err := k.cli.KillGracefully(containerID)
 		if err != nil {
 			return err
 		}
-		err = k.cli.WaitForTermination(containerID, time.Second*killGracePeriod)
-		if err == nil {
-			log.Infof("ContainerID %q successfully killed", containerID)
-			continue
-		}
-		log.Infof("SIGKILL containerID %q ...", containerID, syscall.SIGKILL.String())
-		err = k.cli.TerminatePodWithContainerID(containerID, syscall.SIGKILL)
-		if err != nil {
-			return err
-		}
-		err = k.cli.WaitForTermination(containerID, time.Second*killGracePeriod)
-		if err != nil {
-			return err
-		}
-		log.Infof("ContainerID %q successfully killed", containerID)
 	}
 	return nil
 }


### PR DESCRIPTION
I implemented Kubernetes API executor which has been discussed in #902.

Although I implemented the same functions as Kubelet executor, the kubelet originally doesn't work as I submmited the issue #1003. So far, I confirmed `argo logs` and the hello-world, archive-location, scripts-bash and timeouts-step examples work with my Kubernetes API executor, and I tested other functions by returning nil immediately in `Wait()` function of the executor and put a short sleep in workflow steps to workaround the issue #1003.

I think it's enough to use Argo with simple examples like hello-world. Could you consider merging it?

By the way, I use Argo in my company [Preferred Networks](https://www.preferred-networks.jp/en). Please also consider adding my company to the list as described [here](https://github.com/argoproj/argo#who-uses-argo) if it gets merged.