### PR TITLE
Fix error in env syntax

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -173,15 +173,15 @@ spec:
     container:
       image: containerA
       env:
-        - name: LOG_LEVEL
-        - value: "{{workflow.parameters.log_level}}"
+      - name: LOG_LEVEL
+        value: "{{workflow.parameters.log_level}}"
       command: [runA]
   - - name: B
       container:
         image: containerB
         env:
-          - name: LOG_LEVEL
-          - value: "{{workflow.parameters.log_level}}"
+        - name: LOG_LEVEL
+          value: "{{workflow.parameters.log_level}}"
         command: [runB]
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -173,13 +173,15 @@ spec:
     container:
       image: containerA
       env:
-        - "LOG_LEVEL={{workflow.parameters.log_level}}"
+        - name: LOG_LEVEL
+        - value: "{{workflow.parameters.log_level}}"
       command: [runA]
   - - name: B
       container:
         image: containerB
         env:
-          - "LOG_LEVEL={{workflow.parameters.log_level}}"
+          - name: LOG_LEVEL
+          - value: "{{workflow.parameters.log_level}}"
         command: [runB]
 ```
 


### PR DESCRIPTION
I was getting 
```
2018/09/23 17:00:20 Failed to parse workflow: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go struct field ScriptTemplate.env of type v1.EnvVar
```
before this change