### PR TITLE
Issue #1033 - Workflow executor panic: workflows.argoproj.io/template workflows.argoproj.io/template not found in annotation file

### DIFF
--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -939,10 +939,7 @@ func unmarshalAnnotationField(filePath string, key string, into interface{}) err
 				break
 			}
 		}
-		// The end of the annotation file
-		if err == io.EOF {
-			break
-		}
+
 		line := buffer.String()
 
 		// Read property
@@ -970,6 +967,11 @@ func unmarshalAnnotationField(filePath string, key string, into interface{}) err
 				return errors.InternalWrapError(err)
 			}
 			return nil
+		}
+
+		// The end of the annotation file
+		if err == io.EOF {
+			break
 		}
 	}
 


### PR DESCRIPTION
Closes https://github.com/argoproj/argo/issues/1033