### PR TITLE
Parameter and Argument names should support snake case

### DIFF
--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -464,7 +464,7 @@ func validateOutputs(scope map[string]interface{}, tmpl *wfv1.Template) error {
 			}
 		}
 		if art.GlobalName != "" && !isParameter(art.GlobalName) {
-			errs := isValidWorkflowFieldName(art.GlobalName)
+			errs := isValidParamOrArtifactName(art.GlobalName)
 			if len(errs) > 0 {
 				return errors.Errorf(errors.CodeBadRequest, "templates.%s.%s.globalName: %s", tmpl.Name, artRef, errs[0])
 			}
@@ -492,7 +492,7 @@ func validateOutputs(scope map[string]interface{}, tmpl *wfv1.Template) error {
 			}
 		}
 		if param.GlobalName != "" && !isParameter(param.GlobalName) {
-			errs := isValidWorkflowFieldName(param.GlobalName)
+			errs := isValidParamOrArtifactName(param.GlobalName)
 			if len(errs) > 0 {
 				return errors.Errorf(errors.CodeBadRequest, "%s.globalName: %s", paramRef, errs[0])
 			}
@@ -556,7 +556,14 @@ func validateWorkflowFieldNames(slice interface{}) error {
 		if name == "" {
 			return errors.Errorf(errors.CodeBadRequest, "[%d].name is required", i)
 		}
-		if errs := isValidWorkflowFieldName(name); len(errs) != 0 {
+		var errs []string
+		t := reflect.TypeOf(item)
+		if t == reflect.TypeOf(wfv1.Parameter{}) || t == reflect.TypeOf(wfv1.Artifact{}) {
+			errs = isValidParamOrArtifactName(name)
+		} else {
+			errs = isValidWorkflowFieldName(name)
+		}
+		if len(errs) != 0 {
 			return errors.Errorf(errors.CodeBadRequest, "[%d].name: '%s' is invalid: %s", i, name, strings.Join(errs, ";"))
 		}
 		_, ok := names[name]
@@ -715,11 +722,20 @@ func verifyNoCycles(tmpl *wfv1.Template, nameToTask map[string]wfv1.DAGTask) err
 
 var (
 	// paramRegex matches a parameter. e.g. {{inputs.parameters.blah}}
-	paramRegex = regexp.MustCompile(`{{[-a-zA-Z0-9]+(\.[-a-zA-Z0-9]+)*}}`)
+	paramRegex               = regexp.MustCompile(`{{[-a-zA-Z0-9]+(\.[-a-zA-Z0-9_]+)*}}`)
+	paramOrArtifactNameRegex = regexp.MustCompile(`^[-a-zA-Z0-9_]+[-a-zA-Z0-9_]*$`)
 )
 
 func isParameter(p string) bool {
 	return paramRegex.MatchString(p)
+}
+
+func isValidParamOrArtifactName(p string) []string {
+	var errs []string
+	if !paramOrArtifactNameRegex.MatchString(p) {
+		return append(errs, "Parameter/Artifact name must consist of alpha-numeric characters, '_' or '-' e.g. my_param_1, MY-PARAM-1")
+	}
+	return errs
 }
 
 const (


### PR DESCRIPTION
Implements [#1047](https://github.com/argoproj/argo/issues/1047)

This workflow should be valid now:
```
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: spec-arg-snake-case-
spec:
  entrypoint: whalesay
  arguments:
    artifacts:
    - name: __kubectl
      http:
        url: https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl
    parameters:
    - name: my_snake_case_param
      value: "hello world"
  templates:
  - name: whalesay
    inputs:
      artifacts:
      - name: __kubectl
        path: /usr/local/bin/kubectl
        mode: 0755
    container:
      image: docker/whalesay:latest
      command: [sh, -c]
      args: ["cowsay {{workflow.parameters.my_snake_case_param}} | tee /tmp/hello_world.txt && ls  /usr/local/bin/kubectl"]
```