### PR TITLE
Add namespace explicitly to pod metadata

### DIFF
--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -110,7 +110,8 @@ func (woc *wfOperationCtx) createWorkflowPod(nodeName string, mainCtr apiv1.Cont
 	mainCtr.Name = common.MainContainerName
 	pod := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: nodeID,
+			Name:      nodeID,
+			Namespace: woc.wf.ObjectMeta.Namespace,
 			Labels: map[string]string{
 				common.LabelKeyWorkflow:  woc.wf.ObjectMeta.Name, // Allows filtering by pods related to specific workflow
 				common.LabelKeyCompleted: "false",                // Allows filtering by incomplete workflow pods


### PR DESCRIPTION
Use case:
We have an admission webhook that looks at all the pods and adds further annotations apart from other processing based on namespace. Since the pod does not have the namespace explicitly set, we have to go through hoops to figure out the namespace. Having the namespace set explicitly simplifies the process. This should help others with similar use-cases.