### PR TITLE
Raise not implemented error

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -10,12 +10,13 @@ import (
 
 // Externally visible error codes
 const (
-	CodeUnauthorized = "ERR_UNAUTHORIZED"
-	CodeBadRequest   = "ERR_BAD_REQUEST"
-	CodeForbidden    = "ERR_FORBIDDEN"
-	CodeNotFound     = "ERR_NOT_FOUND"
-	CodeTimeout      = "ERR_TIMEOUT"
-	CodeInternal     = "ERR_INTERNAL"
+	CodeUnauthorized   = "ERR_UNAUTHORIZED"
+	CodeBadRequest     = "ERR_BAD_REQUEST"
+	CodeForbidden      = "ERR_FORBIDDEN"
+	CodeNotFound       = "ERR_NOT_FOUND"
+	CodeNotImplemented = "ERR_NOT_INPLEMENTED"
+	CodeTimeout        = "ERR_TIMEOUT"
+	CodeInternal       = "ERR_INTERNAL"
 )
 
 // ArgoError is an error interface that additionally adds support for

--- a/workflow/executor/k8sapi/k8sapi.go
+++ b/workflow/executor/k8sapi/k8sapi.go
@@ -23,12 +23,11 @@ func NewK8sAPIExecutor(clientset *kubernetes.Clientset, config *restclient.Confi
 }
 
 func (k *K8sAPIExecutor) GetFileContents(containerID string, sourcePath string) (string, error) {
-	log.Infof("Getting file contents of %s:%s", containerID, sourcePath)
-	return k.client.getFileContents(containerID, sourcePath)
+	return "", errors.Errorf(errors.CodeNotImplemented, "GetFileContents() is not implemented in the k8sapi executor.")
 }
 
 func (k *K8sAPIExecutor) CopyFile(containerID string, sourcePath string, destPath string) error {
-	return k.client.copyArchive(containerID, sourcePath, destPath)
+	return errors.Errorf(errors.CodeNotImplemented, "CopyFile() is not implemented in the k8sapi executor.")
 }
 
 // GetOutput returns the entirety of the container output as a string

--- a/workflow/executor/kubelet/client.go
+++ b/workflow/executor/kubelet/client.go
@@ -287,8 +287,8 @@ func (k *kubeletClient) readFileContents(u *url.URL) (*bytes.Buffer, error) {
 	}
 }
 
-// CreateArchive exec in the given containerID and create a tarball of the given sourcePath. Works with directory
-func (k *kubeletClient) CreateArchive(containerID, sourcePath string) (*bytes.Buffer, error) {
+// createArchive exec in the given containerID and create a tarball of the given sourcePath. Works with directory
+func (k *kubeletClient) createArchive(containerID, sourcePath string) (*bytes.Buffer, error) {
 	return k.getCommandOutput(containerID, fmt.Sprintf("command=tar&command=-cf&command=-&command=%s&output=1", sourcePath))
 }
 

--- a/workflow/executor/kubelet/kubelet.go
+++ b/workflow/executor/kubelet/kubelet.go
@@ -21,15 +21,11 @@ func NewKubeletExecutor() (*KubeletExecutor, error) {
 }
 
 func (k *KubeletExecutor) GetFileContents(containerID string, sourcePath string) (string, error) {
-	b, err := k.cli.GetFileContents(containerID, sourcePath)
-	if err != nil {
-		return "", err
-	}
-	return b.String(), nil
+	return "", errors.Errorf(errors.CodeNotImplemented, "GetFileContents() is not implemented in the kubelet executor.")
 }
 
 func (k *KubeletExecutor) CopyFile(containerID string, sourcePath string, destPath string) error {
-	return k.cli.CopyArchive(containerID, sourcePath, destPath)
+	return errors.Errorf(errors.CodeNotImplemented, "CopyFile() is not implemented in the kubelet executor.")
 }
 
 // GetOutput returns the entirety of the container output as a string


### PR DESCRIPTION
Currently, the kubelet executor emits an error log like below.

```
failed to save outputs: container docker://58a3e33e584d0daaaeed73f1ad91ae5bfec4b8cea30775efec9a037346af7f4d is terminated: &ContainerStateTerminated{ExitCode:0,Signal:0,Reason:Completed,Message:,StartedAt:2018-10-28 14:07:26 +0000 UTC,FinishedAt:2018-10-28 14:07:26 +0000 UTC,ContainerID:docker://58a3e33e584d0daaaeed73f1ad91ae5bfec4b8cea30775efec9a037346af7f4d,}
```

And the k8sapi executor emits an error log like below.

```
failed to save outputs: unable to upgrade connection: container not found ("main")
```

However, I think it's not clear for users what to do by these errors. We should raise a clear error if the called method is not supported in the executor. 