### PR TITLE
Fix manifests for namespace install

### DIFF
--- a/manifests/base/00a_argo-namespace.yaml
+++ b/manifests/base/00a_argo-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argo

--- a/manifests/cluster-install/kustomization.yaml
+++ b/manifests/cluster-install/kustomization.yaml
@@ -1,6 +1,7 @@
 namespace: argo
 
 resources:
+- ../base/00a_argo-namespace.yaml
 - ../base/01a_workflow-crd.yaml
 - ../base/01b_workflow-aggregate-roles.yaml
 - ../base/02a_workflow-controller-sa.yaml

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -1,4 +1,9 @@
 # This is an auto-generated file. DO NOT EDIT
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argo
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1,4 +1,9 @@
 # This is an auto-generated file. DO NOT EDIT
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argo
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -27,6 +27,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: argo-role
+  namespace: argo
 rules:
 - apiGroups:
   - ""
@@ -41,14 +42,6 @@ rules:
   - update
   - patch
   - delete
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - watch
-  - list
 - apiGroups:
   - ""
   resources:
@@ -73,6 +66,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: argo-ui-role
+  namespace: argo
 rules:
 - apiGroups:
   - ""
@@ -100,9 +94,24 @@ rules:
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argo-cm-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: argo-binding
+  namespace: argo
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -110,11 +119,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argo
+  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: argo-ui-binding
+  namespace: argo
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -122,6 +133,19 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argo-ui
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-cm-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argo-cm-role
+subjects:
+- kind: ServiceAccount
+  name: argo
 ---
 apiVersion: v1
 data:
@@ -158,14 +182,13 @@ spec:
       containers:
       - env:
         - name: ARGO_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
+          value: argo
         - name: IN_CLUSTER
           value: "true"
         - name: ENABLE_WEB_CONSOLE
           value: "false"
+        - name: FORCE_NAMESPACE_ISOLATION
+          value: "true"
         - name: BASE_HREF
           value: /
         image: argoproj/argoui:v2.2.1

--- a/manifests/namespace-install/02b_workflow-controller-role.yaml
+++ b/manifests/namespace-install/02b_workflow-controller-role.yaml
@@ -1,7 +1,22 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: argo-cm-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   name: argo-role
+  namespace: argo
 rules:
 - apiGroups:
   - ""
@@ -16,14 +31,6 @@ rules:
   - update
   - patch
   - delete
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - watch
-  - list
 - apiGroups:
   - ""
   resources:

--- a/manifests/namespace-install/02c_workflow-controller-rolebinding.yaml
+++ b/manifests/namespace-install/02c_workflow-controller-rolebinding.yaml
@@ -1,7 +1,20 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  name: argo-cm-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argo-cm-role
+subjects:
+- kind: ServiceAccount
+  name: argo
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
   name: argo-binding
+  namespace: argo
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -9,3 +22,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argo
+  namespace: default

--- a/manifests/namespace-install/03b_argo-ui-role.yaml
+++ b/manifests/namespace-install/03b_argo-ui-role.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: argo-ui-role
+  namespace: argo
 rules:
 - apiGroups:
   - ""

--- a/manifests/namespace-install/03c_argo-ui-rolebinding.yaml
+++ b/manifests/namespace-install/03c_argo-ui-rolebinding.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: argo-ui-binding
+  namespace: argo
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -9,3 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argo-ui
+  namespace: default

--- a/manifests/namespace-install/03d_argo-ui-deployment.yaml
+++ b/manifests/namespace-install/03d_argo-ui-deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: argo-ui
+spec:
+  selector:
+    matchLabels:
+      app: argo-ui
+  template:
+    metadata:
+      labels:
+        app: argo-ui
+    spec:
+      serviceAccountName: argo-ui
+      containers:
+      - name: argo-ui
+        image: argoproj/argoui:v2.2.1
+        env:
+        - name: ARGO_NAMESPACE
+          value: "argo"
+        - name: IN_CLUSTER
+          value: "true"
+        - name: ENABLE_WEB_CONSOLE
+          value: "false"
+        - name: FORCE_NAMESPACE_ISOLATION
+          value: "true"
+        - name: BASE_HREF
+          value: /

--- a/manifests/namespace-install/kustomization.yaml
+++ b/manifests/namespace-install/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- ../base/00a_argo-namespace.yaml
 - ../base/01a_workflow-crd.yaml
 - ../base/02a_workflow-controller-sa.yaml
 - ./02b_workflow-controller-role.yaml

--- a/manifests/namespace-install/kustomization.yaml
+++ b/manifests/namespace-install/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
 - ../base/03a_argo-ui-sa.yaml
 - ./03b_argo-ui-role.yaml
 - ./03c_argo-ui-rolebinding.yaml
-- ../base/03d_argo-ui-deployment.yaml
+- ./03d_argo-ui-deployment.yaml
 - ../base/03e_argo-ui-service.yaml


### PR DESCRIPTION
I wasn't able to use Argo by just installing from [the current `manifests/namespace-install.yaml`](https://github.com/argoproj/argo/blob/0a928e93dac6d8522682931a0a68c52add310cdb/manifests/namespace-install.yaml) because the `workflow-controller` and `argo-ui` are installed in `default` namespace while workflows are expected to run in `argo` namespace, which the used service account doesn't have access to. I fixed the `Role`, `RoleBinding` and the option of `argo-ui` so it works by just installing the manifests. Please check if this is what you intended.

I didn't update the aggregated manifests which are supposed to be generated by Kustomize because `./hack/update-manifests.sh` shows the following error.

```bash
$ ./hack/update-manifests.sh
Error: json: unknown field "namespace"
Usage:
  kustomize build [path] [flags]

Examples:
Use the file somedir/kustomization.yaml to generate a set of api resources:
build somedir/

Flags:
  -h, --help   help for build

Global Flags:
      --alsologtostderr                  log to standard error as well as files
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --logtostderr                      log to standard error instead of files
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
  -v, --v Level                          log level for V logs
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
```

It seems `namespace` in `manifests/cluster-install/kustomization.yaml` is not recognized as a valid field. Could you tell me how to update the aggregated manifests, or please do it on your side.