### PR TITLE
Mount workflow controller configmap as a volume

### DIFF
--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -30,6 +30,7 @@ const (
 func NewRootCommand() *cobra.Command {
 	var (
 		clientConfig            clientcmd.ClientConfig
+		configPath              string // --config-path
 		configMap               string // --configmap
 		executorImage           string // --executor-image
 		executorImagePullPolicy string // --executor-image-pull-policy
@@ -69,7 +70,7 @@ func NewRootCommand() *cobra.Command {
 			wflientset := wfclientset.NewForConfigOrDie(config)
 
 			// start a controller on instances of our custom resource
-			wfController := controller.NewWorkflowController(config, kubeclientset, wflientset, namespace, executorImage, executorImagePullPolicy, configMap)
+			wfController := controller.NewWorkflowController(config, kubeclientset, wflientset, namespace, executorImage, executorImagePullPolicy, configMap, configPath)
 			err = wfController.ResyncConfig()
 			if err != nil {
 				return err
@@ -91,6 +92,7 @@ func NewRootCommand() *cobra.Command {
 	clientConfig = cli.AddKubectlFlagsToCmd(&command)
 	command.AddCommand(cmdutil.NewVersionCmd(CLIName))
 	command.Flags().StringVar(&configMap, "configmap", "workflow-controller-configmap", "Name of K8s configmap to retrieve workflow controller configuration")
+	command.Flags().StringVar(&configPath, "config-path", "workflow-controller config file path", "path to workflow controller configuration file (overrides value in configmap)")
 	command.Flags().StringVar(&executorImage, "executor-image", "", "Executor image to use (overrides value in configmap)")
 	command.Flags().StringVar(&executorImagePullPolicy, "executor-image-pull-policy", "", "Executor imagePullPolicy to use (overrides value in configmap)")
 	command.Flags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")

--- a/manifests/base/02e_workflow-controller-deployment.yaml
+++ b/manifests/base/02e_workflow-controller-deployment.yaml
@@ -18,7 +18,14 @@ spec:
         command:
         - workflow-controller
         args:
-        - --configmap
-        - workflow-controller-configmap
+        - --config-path
+        - /controller-config/config
         - --executor-image
         - argoproj/argoexec:v2.2.1
+        volumeMounts:
+        - name: config
+          path: /controller-config
+      volumes:
+      - name: config
+        configMap:
+          name: workflow-controller-configmap

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -253,12 +253,19 @@ spec:
     spec:
       containers:
       - args:
-        - --configmap
-        - workflow-controller-configmap
+        - --config-path
+        - /controller-config/config
         - --executor-image
         - argoproj/argoexec:v2.2.1
         command:
         - workflow-controller
         image: argoproj/workflow-controller:v2.2.1
         name: workflow-controller
+        volumeMounts:
+        - name: config
+          path: /controller-config
       serviceAccountName: argo
+      volumes:
+      - name: config
+        configMap:
+          name: workflow-controller-configmap

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -187,12 +187,19 @@ spec:
     spec:
       containers:
       - args:
-        - --configmap
-        - workflow-controller-configmap
+        - --config-path
+        - /controller-config/config
         - --executor-image
         - argoproj/argoexec:v2.2.1
         command:
         - workflow-controller
         image: argoproj/workflow-controller:v2.2.1
         name: workflow-controller
+        volumeMounts:
+        - name: config
+          path: /controller-config
       serviceAccountName: argo
+      volumes:
+      - name: config
+        configMap:
+          name: workflow-controller-configmap

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -36,6 +36,8 @@ type WorkflowController struct {
 	namespace string
 	// configMap is the name of the config map in which to derive configuration of the controller from
 	configMap string
+	// configPath is the path to the configuration file of the controller
+	configPath string
 	// Config is the workflow controller's configuration
 	Config WorkflowControllerConfig
 
@@ -72,13 +74,15 @@ func NewWorkflowController(
 	namespace,
 	executorImage,
 	executorImagePullPolicy,
-	configMap string,
+	configMap,
+	configPath string,
 ) *WorkflowController {
 	wfc := WorkflowController{
 		restConfig:                 restConfig,
 		kubeclientset:              kubeclientset,
 		wfclientset:                wfclientset,
 		configMap:                  configMap,
+		configPath:                 configPath,
 		namespace:                  namespace,
 		cliExecutorImage:           executorImage,
 		cliExecutorImagePullPolicy: executorImagePullPolicy,


### PR DESCRIPTION
In the old way, if I want to deploy the controller in a different cluster with the workflow workloads,  the controller will read the workflow-controller-configmap in the 'workload cluster', which is not expected. 

Mounting configmap as a volume for the workflow controller deployment will solve this. 