### PR TITLE
Fix examples docs of parameters.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -167,7 +167,7 @@ spec:
   entrypoint: A
   arguments:
     parameters:
-    - name: log_level
+    - name: log-level
       value: INFO
 
   templates:
@@ -176,15 +176,15 @@ spec:
       image: containerA
       env:
       - name: LOG_LEVEL
-        value: "{{workflow.parameters.log_level}}"
+        value: "{{workflow.parameters.log-level}}"
       command: [runA]
-  - - name: B
-      container:
-        image: containerB
-        env:
-        - name: LOG_LEVEL
-          value: "{{workflow.parameters.log_level}}"
-        command: [runB]
+  - name: B
+    container:
+      image: containerB
+      env:
+      - name: LOG_LEVEL
+        value: "{{workflow.parameters.log-level}}"
+      command: [runB]
 ```
 
 In this workflow, both steps `A` and `B` would have the same log level set to `INFO` and can easily be changed between workflow submissions using the `-p` flag.


### PR DESCRIPTION
Fixed as the following error occurred.

error message:
```
2018/12/03 11:30:18 Failed to submit workflow: spec.arguments.parameters[0].name: 
'log_level' is invalid: name must consist of alpha-numeric characters or '-', 
and must start with an alpha-numeric character (e.g. My-name1-2, 123-NAME)
```

```
2018/12/03 11:31:14 Failed to parse workflow: error unmarshaling JSON: 
while decoding JSON: json: cannot unmarshal array into Go struct field Template.name 
of type v1alpha1.Template
```

version:
```
argo: v2.2.1
  BuildDate: 2018-10-11T16:25:59Z
  GitCommit: 3b52b26190163d1f72f3aef1a39f9f291378dafb
  GitTreeState: clean
  GitTag: v2.2.1
  GoVersion: go1.10.3
  Compiler: gc
  Platform: darwin/amd64
```