### PR TITLE
Remove docker_lib mount volume which is not needed anymore

### DIFF
--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -29,10 +29,6 @@ const (
 	// PodMetadataAnnotationsPath is the file path containing pod metadata annotations. Examined by executor
 	PodMetadataAnnotationsPath = PodMetadataMountPath + "/" + PodMetadataAnnotationsVolumePath
 
-	// DockerLibVolumeName is the volume name for the /var/lib/docker host path volume
-	DockerLibVolumeName = "docker-lib"
-	// DockerLibHostPath is the host directory path containing docker runtime state
-	DockerLibHostPath = "/var/lib/docker"
 	// DockerSockVolumeName is the volume name for the /var/run/docker.sock host path volume
 	DockerSockVolumeName = "docker-sock"
 

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -46,24 +46,6 @@ var (
 	hostPathDir    = apiv1.HostPathDirectory
 	hostPathSocket = apiv1.HostPathSocket
 
-	// volumeDockerLib provides the wait container access to the minion's host docker containers
-	// runtime files (e.g. /var/lib/docker/container). This is used by the executor to access
-	// the main container's logs (and potentially storage to upload output artifacts)
-	volumeDockerLib = apiv1.Volume{
-		Name: common.DockerLibVolumeName,
-		VolumeSource: apiv1.VolumeSource{
-			HostPath: &apiv1.HostPathVolumeSource{
-				Path: common.DockerLibHostPath,
-				Type: &hostPathDir,
-			},
-		},
-	}
-	volumeMountDockerLib = apiv1.VolumeMount{
-		Name:      volumeDockerLib.Name,
-		MountPath: volumeDockerLib.VolumeSource.HostPath.Path,
-		ReadOnly:  true,
-	}
-
 	// volumeDockerSock provides the wait container direct access to the minion's host docker daemon.
 	// The primary purpose of this is to make available `docker cp` to collect an output artifact
 	// from a container. Alternatively, we could use `kubectl cp`, but `docker cp` avoids the extra
@@ -319,7 +301,7 @@ func (woc *wfOperationCtx) createVolumeMounts() []apiv1.VolumeMount {
 	case common.ContainerRuntimeExecutorKubelet:
 		return volumeMounts
 	default:
-		return append(volumeMounts, volumeMountDockerLib, volumeMountDockerSock)
+		return append(volumeMounts, volumeMountDockerSock)
 	}
 }
 
@@ -331,7 +313,7 @@ func (woc *wfOperationCtx) createVolumes() []apiv1.Volume {
 	case common.ContainerRuntimeExecutorKubelet:
 		return volumes
 	default:
-		return append(volumes, volumeDockerLib, volumeDockerSock)
+		return append(volumes, volumeDockerSock)
 	}
 }
 

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -43,7 +43,6 @@ var (
 		MountPath: common.PodMetadataMountPath,
 	}
 
-	hostPathDir    = apiv1.HostPathDirectory
 	hostPathSocket = apiv1.HostPathSocket
 
 	// volumeDockerSock provides the wait container direct access to the minion's host docker daemon.


### PR DESCRIPTION
Currently the workflow pod may report an exception 
> Got an exception “hostPath type check failed: /var/lib/docker is not a directory”
if the path is not available.

According to chat in the slack room with @jessesuen , volumeDockerLib is not needed anymore.