### PR TITLE
allow ownerReferences

### DIFF
--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -132,14 +132,14 @@ func IsWorkflowCompleted(wf *wfv1.Workflow) bool {
 
 // SubmitOpts are workflow submission options
 type SubmitOpts struct {
-	Name           string                // --name
-	GenerateName   string                // --generate-name
-	InstanceID     string                // --instanceid
-	Entrypoint     string                // --entrypoint
-	Parameters     []string              // --parameter
-	ParameterFile  string                // --parameter-file
-	ServiceAccount string                // --serviceaccount
-	OwnerReference metav1.OwnerReference // useful if your custom controller creates argo workflow resources
+	Name           string                 // --name
+	GenerateName   string                 // --generate-name
+	InstanceID     string                 // --instanceid
+	Entrypoint     string                 // --entrypoint
+	Parameters     []string               // --parameter
+	ParameterFile  string                 // --parameter-file
+	ServiceAccount string                 // --serviceaccount
+	OwnerReference *metav1.OwnerReference // useful if your custom controller creates argo workflow resources
 }
 
 // SubmitWorkflow validates and submit a single workflow and override some of the fields of the workflow
@@ -234,8 +234,8 @@ func SubmitWorkflow(wfIf v1alpha1.WorkflowInterface, wf *wfv1.Workflow, opts *Su
 	if opts.Name != "" {
 		wf.ObjectMeta.Name = opts.Name
 	}
-	if opts.OwnerReference != (metav1.OwnerReference{}) {
-		wf.SetOwnerReferences(append(wf.GetOwnerReferences(), opts.OwnerReference))
+	if opts.OwnerReference != nil {
+		wf.SetOwnerReferences(append(wf.GetOwnerReferences(), *opts.OwnerReference))
 	}
 
 	err := validate.ValidateWorkflow(wf)

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -132,13 +132,14 @@ func IsWorkflowCompleted(wf *wfv1.Workflow) bool {
 
 // SubmitOpts are workflow submission options
 type SubmitOpts struct {
-	Name           string   // --name
-	GenerateName   string   // --generate-name
-	InstanceID     string   // --instanceid
-	Entrypoint     string   // --entrypoint
-	Parameters     []string // --parameter
-	ParameterFile  string   // --parameter-file
-	ServiceAccount string   // --serviceaccount
+	Name           string                // --name
+	GenerateName   string                // --generate-name
+	InstanceID     string                // --instanceid
+	Entrypoint     string                // --entrypoint
+	Parameters     []string              // --parameter
+	ParameterFile  string                // --parameter-file
+	ServiceAccount string                // --serviceaccount
+	OwnerReference metav1.OwnerReference // useful if your custom controller creates argo workflow resources
 }
 
 // SubmitWorkflow validates and submit a single workflow and override some of the fields of the workflow
@@ -233,6 +234,10 @@ func SubmitWorkflow(wfIf v1alpha1.WorkflowInterface, wf *wfv1.Workflow, opts *Su
 	if opts.Name != "" {
 		wf.ObjectMeta.Name = opts.Name
 	}
+	if opts.OwnerReference != (metav1.OwnerReference{}) {
+		wf.SetOwnerReferences(append(wf.GetOwnerReferences(), opts.OwnerReference))
+	}
+
 	err := validate.ValidateWorkflow(wf)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I am creating a custom controller which creates argo workflows, it would be easier if there is a way to include `	OwnerReferences` on the workflow resources. This will help cleaning up all the workflows when the custom resource (owner) is deleted.

Verified the code by including and not including OwnerRef object.