### PR TITLE
Fix output artifact and parameter conflict

### DIFF
--- a/cmd/argoexec/commands/wait.go
+++ b/cmd/argoexec/commands/wait.go
@@ -40,13 +40,14 @@ func waitContainer() error {
 		wfExecutor.AddError(err)
 		return err
 	}
-	err = wfExecutor.SaveArtifacts()
+	// Saving output parameters
+	err = wfExecutor.SaveParameters()
 	if err != nil {
 		wfExecutor.AddError(err)
 		return err
 	}
-	// Saving output parameters
-	err = wfExecutor.SaveParameters()
+	// Saving output artifacts
+	err = wfExecutor.SaveArtifacts()
 	if err != nil {
 		wfExecutor.AddError(err)
 		return err


### PR DESCRIPTION
`SaveArtifacts` deletes the files that `SaveParameters` might still need, so we're calling `SaveParameters` first.
Fixes https://github.com/argoproj/argo/issues/1124