### PR TITLE
Mount workflow controller configmap as a volume

### DIFF
--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -31,6 +31,7 @@ const (
 func NewRootCommand() *cobra.Command {
 	var (
 		clientConfig            clientcmd.ClientConfig
+		configPath              string // --config-path
 		configMap               string // --configmap
 		executorImage           string // --executor-image
 		executorImagePullPolicy string // --executor-image-pull-policy
@@ -70,7 +71,7 @@ func NewRootCommand() *cobra.Command {
 			wflientset := wfclientset.NewForConfigOrDie(config)
 
 			// start a controller on instances of our custom resource
-			wfController := controller.NewWorkflowController(config, kubeclientset, wflientset, namespace, executorImage, executorImagePullPolicy, configMap)
+			wfController := controller.NewWorkflowController(config, kubeclientset, wflientset, namespace, executorImage, executorImagePullPolicy, configMap, configPath)
 			err = wfController.ResyncConfig()
 			if err != nil {
 				return err
@@ -92,6 +93,7 @@ func NewRootCommand() *cobra.Command {
 	clientConfig = cli.AddKubectlFlagsToCmd(&command)
 	command.AddCommand(cmdutil.NewVersionCmd(CLIName))
 	command.Flags().StringVar(&configMap, "configmap", "workflow-controller-configmap", "Name of K8s configmap to retrieve workflow controller configuration")
+	command.Flags().StringVar(&configPath, "config-path", "workflow-controller config file path", "path to workflow controller configuration file (overrides value in configmap)")
 	command.Flags().StringVar(&executorImage, "executor-image", "", "Executor image to use (overrides value in configmap)")
 	command.Flags().StringVar(&executorImagePullPolicy, "executor-image-pull-policy", "", "Executor imagePullPolicy to use (overrides value in configmap)")
 	command.Flags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")

--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -93,7 +93,7 @@ func NewRootCommand() *cobra.Command {
 	clientConfig = cli.AddKubectlFlagsToCmd(&command)
 	command.AddCommand(cmdutil.NewVersionCmd(CLIName))
 	command.Flags().StringVar(&configMap, "configmap", "workflow-controller-configmap", "Name of K8s configmap to retrieve workflow controller configuration")
-	command.Flags().StringVar(&configPath, "config-path", "workflow-controller config file path", "path to workflow controller configuration file (overrides value in configmap)")
+	command.Flags().StringVar(&configPath, "config-path", "", "path to workflow controller configuration file (overrides configmap)")
 	command.Flags().StringVar(&executorImage, "executor-image", "", "Executor image to use (overrides value in configmap)")
 	command.Flags().StringVar(&executorImagePullPolicy, "executor-image-pull-policy", "", "Executor imagePullPolicy to use (overrides value in configmap)")
 	command.Flags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")

--- a/workflow/controller/config.go
+++ b/workflow/controller/config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"os"
 
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -141,7 +140,7 @@ func (wfc *WorkflowController) ResyncConfig() error {
 		}
 	}
 	if wfc.cliExecutorImage == "" && wfc.Config.ExecutorImage == "" {
-		return errors.Errorf(errors.CodeBadRequest, "ConfigMap '%s' does not have executorImage", wfc.configMap)
+		return errors.Errorf(errors.CodeBadRequest, "executorImage unspecified")
 	}
 	return nil
 }
@@ -163,11 +162,7 @@ func (wfc *WorkflowController) updateConfig(cm *apiv1.ConfigMap) error {
 }
 
 func (wfc *WorkflowController) loadConfigFile(path string) error {
-	f, e := os.Open(path)
-	if e != nil {
-		return errors.InternalWrapError(e, "open config file failed")
-	}
-	buf, e := ioutil.ReadAll(f)
+	buf, e := ioutil.ReadFile(path)
 	if e != nil {
 		return errors.InternalWrapError(e, "read config file failed")
 	}

--- a/workflow/controller/config.go
+++ b/workflow/controller/config.go
@@ -3,6 +3,8 @@ package controller
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
+	"os"
 
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -124,12 +126,24 @@ type HDFSArtifactRepository struct {
 
 // ResyncConfig reloads the controller config from the configmap
 func (wfc *WorkflowController) ResyncConfig() error {
-	cmClient := wfc.kubeclientset.CoreV1().ConfigMaps(wfc.namespace)
-	cm, err := cmClient.Get(wfc.configMap, metav1.GetOptions{})
-	if err != nil {
-		return errors.InternalWrapError(err)
+	if wfc.configPath != "" {
+		if e := wfc.loadConfigFile(wfc.configPath); e != nil {
+			return errors.InternalWrapError(e)
+		}
+	} else if wfc.configMap != "" {
+		cmClient := wfc.kubeclientset.CoreV1().ConfigMaps(wfc.namespace)
+		cm, err := cmClient.Get(wfc.configMap, metav1.GetOptions{})
+		if err != nil {
+			return errors.InternalWrapError(err)
+		}
+		if err := wfc.updateConfig(cm); err != nil {
+			return errors.InternalWrapError(err)
+		}
 	}
-	return wfc.updateConfig(cm)
+	if wfc.cliExecutorImage == "" && wfc.Config.ExecutorImage == "" {
+		return errors.Errorf(errors.CodeBadRequest, "ConfigMap '%s' does not have executorImage", wfc.configMap)
+	}
+	return nil
 }
 
 func (wfc *WorkflowController) updateConfig(cm *apiv1.ConfigMap) error {
@@ -144,9 +158,24 @@ func (wfc *WorkflowController) updateConfig(cm *apiv1.ConfigMap) error {
 		return errors.InternalWrapError(err)
 	}
 	log.Printf("workflow controller configuration from %s:\n%s", wfc.configMap, configStr)
-	if wfc.cliExecutorImage == "" && config.ExecutorImage == "" {
-		return errors.Errorf(errors.CodeBadRequest, "ConfigMap '%s' does not have executorImage", wfc.configMap)
+	wfc.Config = config
+	return nil
+}
+
+func (wfc *WorkflowController) loadConfigFile(path string) error {
+	f, e := os.Open(path)
+	if e != nil {
+		return errors.InternalWrapError(e, "open config file failed")
 	}
+	buf, e := ioutil.ReadAll(f)
+	if e != nil {
+		return errors.InternalWrapError(e, "read config file failed")
+	}
+	var config WorkflowControllerConfig
+	if e := yaml.Unmarshal(buf, &config); e != nil {
+		return errors.InternalWrapError(e, "parse config file failed")
+	}
+	log.Printf("workflow controller configuration from %s:\n%s", path, string(buf))
 	wfc.Config = config
 	wfc.throttler.SetParallelism(config.Parallelism)
 	return nil

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -134,11 +134,15 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, podWorkers in
 
 	log.Infof("Workflow Controller (version: %s) starting", argo.GetVersion())
 	log.Infof("Workers: workflow: %d, pod: %d", wfWorkers, podWorkers)
-	log.Info("Watch Workflow controller config map updates")
-	_, err := wfc.watchControllerConfigMap(ctx)
-	if err != nil {
-		log.Errorf("Failed to register watch for controller config map: %v", err)
-		return
+
+	// if config path is specified, do not watch configmap
+	if wfc.configPath == "" {
+		log.Info("Watch Workflow controller config map updates")
+		_, err := wfc.watchControllerConfigMap(ctx)
+		if err != nil {
+			log.Errorf("Failed to register watch for controller config map: %v", err)
+			return
+		}
 	}
 
 	wfc.wfInformer = util.NewWorkflowInformer(wfc.restConfig, wfc.Config.Namespace, workflowResyncPeriod, wfc.tweakWorkflowlist)

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -36,6 +36,8 @@ type WorkflowController struct {
 	namespace string
 	// configMap is the name of the config map in which to derive configuration of the controller from
 	configMap string
+	// configPath is the path to the configuration file of the controller
+	configPath string
 	// Config is the workflow controller's configuration
 	Config WorkflowControllerConfig
 
@@ -73,13 +75,15 @@ func NewWorkflowController(
 	namespace,
 	executorImage,
 	executorImagePullPolicy,
-	configMap string,
+	configMap,
+	configPath string,
 ) *WorkflowController {
 	wfc := WorkflowController{
 		restConfig:                 restConfig,
 		kubeclientset:              kubeclientset,
 		wfclientset:                wfclientset,
 		configMap:                  configMap,
+		configPath:                 configPath,
 		namespace:                  namespace,
 		cliExecutorImage:           executorImage,
 		cliExecutorImagePullPolicy: executorImagePullPolicy,


### PR DESCRIPTION
We deploy our workflow controller in a different cluster with the one running the workflow workloads. In the old way we had to create the controller configmap in the *workloads cluster* rather than the *controller cluster*, which is not expected. 

With mounting the configmap as a volume of the workflow controller deployment, the configmap could be in the same cluster with the controller.