### PR TITLE
Executor can access the k8s apiserver with a out-of-cluster config file

### DIFF
--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -22,6 +22,19 @@ data:
     # (available since Argo v2.3)
     parallelism: 10
 
+    # uncomment flowing lines if workflow controller runs in a different k8s cluster with the 
+    # workflow workloads, or needs to communicate with the k8s apiserver using an out-of-cluster
+    # kubeconfig secret
+    # kubeConfig:
+    #   # name of the kubeconfig secret, may not be empty when kubeConfig specified
+    #   secretName: kubeconfig-secret
+    #   # key of the kubeconfig secret, may not be empty when kubeConfig specified
+    #   secretKey: kubeconfig
+    #   # mounting path of the kubeconfig secret, default to /kube/config
+    #   mountPath: /kubeconfig/mount/path
+    #   # volume name when mounting the secret, default to kubeconfig
+    #   volumeName: kube-config-volume
+
     # artifactRepository defines the default location to be used as the artifact repository for
     # container artifacts.
     artifactRepository:

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -111,7 +111,7 @@ const (
 	// LocalVarPodName is a step level variable that references the name of the pod
 	LocalVarPodName = "pod.name"
 
-	KubeConfigDefaultMountPath  = "/kube/.config"
+	KubeConfigDefaultMountPath  = "/kube/config"
 	KubeConfigDefaultVolumeName = "kubeconfig"
 )
 

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -111,9 +111,8 @@ const (
 	// LocalVarPodName is a step level variable that references the name of the pod
 	LocalVarPodName = "pod.name"
 
-	EnvVarKubeConfig     = "KUBECONFIG"
-	KubeConfigVolumeName = "kube-config"
-	KubeConfigMountPath  = "/root/.kube"
+	KubeConfigDefaultMountPath  = "/kube/.config"
+	KubeConfigDefaultVolumeName = "kubeconfig"
 )
 
 // ExecutionControl contains execution control parameters for executor to decide how to execute the container

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -110,6 +110,10 @@ const (
 	GlobalVarWorkflowCreationTimestamp = "workflow.creationTimestamp"
 	// LocalVarPodName is a step level variable that references the name of the pod
 	LocalVarPodName = "pod.name"
+
+	EnvVarKubeConfig     = "KUBECONFIG"
+	KubeConfigVolumeName = "kube-config"
+	KubeConfigMountPath  = "/root/.kube"
 )
 
 // ExecutionControl contains execution control parameters for executor to decide how to execute the container

--- a/workflow/controller/config.go
+++ b/workflow/controller/config.go
@@ -30,11 +30,8 @@ type WorkflowControllerConfig struct {
 	// ExecutorResources specifies the resource requirements that will be used for the executor sidecar
 	ExecutorResources *apiv1.ResourceRequirements `json:"executorResources,omitempty"`
 
-	// KubeConfigSecretName should be set when the executor access the apiserver use out of cluster config
-	KubeConfigSecretName string `json:"kubeConfigSecretName,omitempty"`
-
-	// KubeConfigSecretKey should be set when the executor access the apiserver use out of cluster config
-	KubeConfigSecretKey string `json:"kubeConfigSecretKey, omitempty"`
+	// KubeConfig specifies a kube config file for the wait & init containers
+	KubeConfig *KubeConfig `json:"kubeConfig,omitempty"`
 
 	// ContainerRuntimeExecutor specifies the container runtime interface to use, default is docker
 	ContainerRuntimeExecutor string `json:"containerRuntimeExecutor,omitempty"`
@@ -66,6 +63,21 @@ type WorkflowControllerConfig struct {
 
 	// Parallelism limits the max total parallel workflows that can execute at the same time
 	Parallelism int `json:"parallelism,omitempty"`
+}
+
+// KubeConfig is used for wait & init sidecar containers to communicate with a k8s apiserver by a outofcluster method,
+// it is used when the workflow controller is in a different cluster with the workflow workloads
+type KubeConfig struct {
+	// SecretName of the kubeconfig secret
+	// may not be empty if kuebConfig specified
+	SecretName string `json:"secretName"`
+	// SecretKey of the kubeconfig in the secret
+	// may not be empty if kubeConfig specified
+	SecretKey string `json:"secretKey"`
+	// VolumeName of kubeconfig, default to 'kubeconfig'
+	VolumeName string `json:"volumeName,omitempty"`
+	// MountPath of the kubeconfig secret, default to '/kube/.config'
+	MountPath string `json:"mountPath,omitempty"`
 }
 
 // ArtifactRepository represents a artifact repository in which a controller will store its artifacts

--- a/workflow/controller/config.go
+++ b/workflow/controller/config.go
@@ -30,13 +30,10 @@ type WorkflowControllerConfig struct {
 	// ExecutorResources specifies the resource requirements that will be used for the executor sidecar
 	ExecutorResources *apiv1.ResourceRequirements `json:"executorResources,omitempty"`
 
-	// ExecutorOutOfCluster uses a out of cluster config to access the kubernetes apiserver
-	ExecutorOutOfCluster bool `json:"executorOutOfCluster,omitempty"`
-
-	// KubeConfigSecretName should be set when access the apiserver use out of cluster config
+	// KubeConfigSecretName should be set when the executor access the apiserver use out of cluster config
 	KubeConfigSecretName string `json:"kubeConfigSecretName,omitempty"`
 
-	// KubeConfigSecretKey should be set when access the apiserver use out of cluster config
+	// KubeConfigSecretKey should be set when the executor access the apiserver use out of cluster config
 	KubeConfigSecretKey string `json:"kubeConfigSecretKey, omitempty"`
 
 	// ContainerRuntimeExecutor specifies the container runtime interface to use, default is docker

--- a/workflow/controller/config.go
+++ b/workflow/controller/config.go
@@ -76,7 +76,7 @@ type KubeConfig struct {
 	SecretKey string `json:"secretKey"`
 	// VolumeName of kubeconfig, default to 'kubeconfig'
 	VolumeName string `json:"volumeName,omitempty"`
-	// MountPath of the kubeconfig secret, default to '/kube/.config'
+	// MountPath of the kubeconfig secret, default to '/kube/config'
 	MountPath string `json:"mountPath,omitempty"`
 }
 

--- a/workflow/controller/config.go
+++ b/workflow/controller/config.go
@@ -30,6 +30,15 @@ type WorkflowControllerConfig struct {
 	// ExecutorResources specifies the resource requirements that will be used for the executor sidecar
 	ExecutorResources *apiv1.ResourceRequirements `json:"executorResources,omitempty"`
 
+	// ExecutorOutOfCluster uses a out of cluster config to access the kubernetes apiserver
+	ExecutorOutOfCluster bool `json:"executorOutOfCluster,omitempty"`
+
+	// KubeConfigSecretName should be set when access the apiserver use out of cluster config
+	KubeConfigSecretName string `json:"kubeConfigSecretName,omitempty"`
+
+	// KubeConfigSecretKey should be set when access the apiserver use out of cluster config
+	KubeConfigSecretKey string `json:"kubeConfigSecretKey, omitempty"`
+
 	// ContainerRuntimeExecutor specifies the container runtime interface to use, default is docker
 	ContainerRuntimeExecutor string `json:"containerRuntimeExecutor,omitempty"`
 

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -248,13 +248,13 @@ func substituteGlobals(pod *apiv1.Pod, globalParams map[string]string) (*apiv1.P
 
 func (woc *wfOperationCtx) newInitContainer(tmpl *wfv1.Template) apiv1.Container {
 	ctr := woc.newExecContainer(common.InitContainerName, false, "init")
-	ctr.VolumeMounts = append(ctr.VolumeMounts, volumeMountPodMetadata)
+	ctr.VolumeMounts = append([]apiv1.VolumeMount{volumeMountPodMetadata}, ctr.VolumeMounts...)
 	return *ctr
 }
 
 func (woc *wfOperationCtx) newWaitContainer(tmpl *wfv1.Template) (*apiv1.Container, error) {
 	ctr := woc.newExecContainer(common.WaitContainerName, false, "wait")
-	ctr.VolumeMounts = append(ctr.VolumeMounts, woc.createVolumeMounts()...)
+	ctr.VolumeMounts = append(woc.createVolumeMounts(), ctr.VolumeMounts...)
 	return ctr, nil
 }
 

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -260,7 +260,7 @@ func (woc *wfOperationCtx) newWaitContainer(tmpl *wfv1.Template) (*apiv1.Contain
 	ctr := woc.newExecContainer(common.WaitContainerName, false)
 	ctr.Command = []string{"argoexec"}
 	ctr.Args = []string{"wait"}
-	if woc.controller.Config.ExecutorOutOfCluster {
+	if woc.controller.Config.KubeConfigSecretName != "" && woc.controller.Config.KubeConfigSecretKey != "" {
 		ctr.Args = append(ctr.Args, "--kubeconfig="+common.KubeConfigMountPath+"/"+woc.controller.Config.KubeConfigSecretKey)
 	}
 	ctr.VolumeMounts = woc.createVolumeMounts()
@@ -308,7 +308,7 @@ func (woc *wfOperationCtx) createVolumeMounts() []apiv1.VolumeMount {
 	volumeMounts := []apiv1.VolumeMount{
 		volumeMountPodMetadata,
 	}
-	if woc.controller.Config.ExecutorOutOfCluster {
+	if woc.controller.Config.KubeConfigSecretName != "" && woc.controller.Config.KubeConfigSecretKey != "" {
 		volumeMounts = append(volumeMounts, apiv1.VolumeMount{
 			Name:      common.KubeConfigVolumeName,
 			MountPath: common.KubeConfigMountPath,
@@ -326,7 +326,7 @@ func (woc *wfOperationCtx) createVolumes() []apiv1.Volume {
 	volumes := []apiv1.Volume{
 		volumePodMetadata,
 	}
-	if woc.controller.Config.ExecutorOutOfCluster {
+	if woc.controller.Config.KubeConfigSecretName != "" && woc.controller.Config.KubeConfigSecretKey != "" {
 		volumes = append(volumes, apiv1.Volume{
 			Name: common.KubeConfigVolumeName,
 			VolumeSource: apiv1.VolumeSource{

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -283,8 +283,11 @@ func TestOutOfCluster(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, "kubeconfig", pod.Spec.Volumes[1].Name)
 		assert.Equal(t, "foo", pod.Spec.Volumes[1].VolumeSource.Secret.SecretName)
-		assert.Equal(t, "kubeconfig", pod.Spec.Containers[1].VolumeMounts[0].Name)
-		assert.Equal(t, "/kube/config", pod.Spec.Containers[1].VolumeMounts[0].MountPath)
+
+		// kubeconfig volume is the last one
+		idx := len(pod.Spec.Containers[1].VolumeMounts) - 1
+		assert.Equal(t, "kubeconfig", pod.Spec.Containers[1].VolumeMounts[idx].Name)
+		assert.Equal(t, "/kube/config", pod.Spec.Containers[1].VolumeMounts[idx].MountPath)
 		assert.Equal(t, "--kubeconfig=/kube/config", pod.Spec.Containers[1].Args[1])
 	}
 	// custom mount path & volume name, in case name collision
@@ -304,8 +307,11 @@ func TestOutOfCluster(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, "kube-config-secret", pod.Spec.Volumes[1].Name)
 		assert.Equal(t, "foo", pod.Spec.Volumes[1].VolumeSource.Secret.SecretName)
-		assert.Equal(t, "kube-config-secret", pod.Spec.Containers[1].VolumeMounts[0].Name)
-		assert.Equal(t, "/some/path/config", pod.Spec.Containers[1].VolumeMounts[0].MountPath)
+
+		// kubeconfig volume is the last one
+		idx := len(pod.Spec.Containers[1].VolumeMounts) - 1
+		assert.Equal(t, "kube-config-secret", pod.Spec.Containers[1].VolumeMounts[idx].Name)
+		assert.Equal(t, "/some/path/config", pod.Spec.Containers[1].VolumeMounts[idx].MountPath)
 		assert.Equal(t, "--kubeconfig=/some/path/config", pod.Spec.Containers[1].Args[1])
 	}
 }

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -290,6 +290,7 @@ func TestOutOfCluster(t *testing.T) {
 		assert.Equal(t, "/kube/config", pod.Spec.Containers[1].VolumeMounts[idx].MountPath)
 		assert.Equal(t, "--kubeconfig=/kube/config", pod.Spec.Containers[1].Args[1])
 	}
+
 	// custom mount path & volume name, in case name collision
 	{
 		woc := newWoc()

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -284,8 +284,8 @@ func TestOutOfCluster(t *testing.T) {
 		assert.Equal(t, "kubeconfig", pod.Spec.Volumes[1].Name)
 		assert.Equal(t, "foo", pod.Spec.Volumes[1].VolumeSource.Secret.SecretName)
 		assert.Equal(t, "kubeconfig", pod.Spec.Containers[1].VolumeMounts[0].Name)
-		assert.Equal(t, "/kube/.config", pod.Spec.Containers[1].VolumeMounts[0].MountPath)
-		assert.Equal(t, "--kubeconfig=/kube/.config", pod.Spec.Containers[1].Args[1])
+		assert.Equal(t, "/kube/config", pod.Spec.Containers[1].VolumeMounts[0].MountPath)
+		assert.Equal(t, "--kubeconfig=/kube/config", pod.Spec.Containers[1].Args[1])
 	}
 	// custom mount path & volume name, in case name collision
 	{

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -265,9 +265,10 @@ func TestVolumeAndVolumeMounts(t *testing.T) {
 		assert.Equal(t, 1, len(pod.Spec.Containers[0].VolumeMounts))
 		assert.Equal(t, "volume-name", pod.Spec.Containers[0].VolumeMounts[0].Name)
 	}
+}
+
 func TestOutOfCluster(t *testing.T) {
 	woc := newWoc()
-	woc.controller.Config.ExecutorOutOfCluster = true
 	woc.controller.Config.KubeConfigSecretName = "foo"
 	woc.controller.Config.KubeConfigSecretKey = "bar"
 


### PR DESCRIPTION
Our production k8s cluster operators have banned accessing the k8s apiserver with an in-cluster strategy (using a service account). We have to configure the executor with a kube config file to access it in an out-of-cluster strategy. It may be helpful for other users.