### PR TITLE
add support for other archs

### DIFF
--- a/Dockerfile-argoexec
+++ b/Dockerfile-argoexec
@@ -3,12 +3,12 @@ FROM debian:9.5-slim
 RUN apt-get update && \
     apt-get install -y curl jq procps git tar && \
     rm -rf /var/lib/apt/lists/* && \
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/$(uname -m|sed 's/x86_64/amd64/g')/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /bin/
 
 ENV DOCKER_VERSION=18.06.0
-RUN curl -O https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}-ce.tgz && \
+RUN curl -O https://download.docker.com/linux/static/stable/$(uname -m)/docker-${DOCKER_VERSION}-ce.tgz && \
   tar -xzf docker-${DOCKER_VERSION}-ce.tgz && \
   mv docker/docker /usr/local/bin/docker && \
   rm -rf ./docker

--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -10,16 +10,16 @@ RUN apt-get update && apt-get install -y \
 
 # Install go
 ENV GO_VERSION 1.10.3
-ENV GO_ARCH amd64
 ENV GOPATH /root/go
 ENV PATH ${GOPATH}/bin:/usr/local/go/bin:${PATH}
-RUN wget https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
-    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
-    rm /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
-    wget https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 -O /usr/local/bin/dep && \
+RUN ARCH=$(uname -m|sed 's/x86_64/amd64/g') && \
+    wget https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${ARCH}.tar.gz && \
+    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${ARCH}.tar.gz && \
+    rm /go${GO_VERSION}.linux-${ARCH}.tar.gz && \
+    wget https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-${ARCH} -O /usr/local/bin/dep && \
     chmod +x /usr/local/bin/dep && \
     mkdir -p ${GOPATH}/bin && \
-    curl -sLo- https://github.com/alecthomas/gometalinter/releases/download/v2.0.5/gometalinter-2.0.5-linux-amd64.tar.gz | \
+    curl -sLo- https://github.com/alecthomas/gometalinter/releases/download/v2.0.5/gometalinter-2.0.5-linux-${ARCH}.tar.gz | \
       tar -xzC "$GOPATH/bin" --exclude COPYING --exclude README.md --strip-components 1 -f-
 
 # A dummy directory is created under $GOPATH/src/dummy so we are able to use dep

--- a/Dockerfile-ci-builder
+++ b/Dockerfile-ci-builder
@@ -2,11 +2,11 @@ FROM golang:1.10.3
 
 WORKDIR /tmp
 
-RUN curl -O https://download.docker.com/linux/static/stable/x86_64/docker-18.06.0-ce.tgz && \
+RUN curl -O https://download.docker.com/linux/static/stable/$(uname -m)/docker-18.06.0-ce.tgz && \
   tar -xzf docker-18.06.0-ce.tgz && \
   mv docker/docker /usr/local/bin/docker && \
   rm -rf ./docker && \
-  wget https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 -O /usr/local/bin/dep && \
+  wget https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-$(uname -m|sed 's/x86_64/amd64/g') -O /usr/local/bin/dep && \
   chmod +x /usr/local/bin/dep && \
-  curl -sLo- https://github.com/alecthomas/gometalinter/releases/download/v2.0.5/gometalinter-2.0.5-linux-amd64.tar.gz | \
+  curl -sLo- https://github.com/alecthomas/gometalinter/releases/download/v2.0.5/gometalinter-2.0.5-linux-$(uname -m|sed 's/x86_64/amd64/g').tar.gz | \
     tar -xzC "$GOPATH/bin" --exclude COPYING --exclude README.md --strip-components 1 -f-


### PR DESCRIPTION
Add support for multiple archs.

NOTE: gometalinter does not support ppc64le currently, but this PR does not block the amd64.