### PR TITLE
Fix the workflow state inconsistency when use steps with retry limit

### DIFF
--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -203,7 +203,7 @@ func (woc *wfOperationCtx) executeStepGroup(stepGroup []wfv1.WorkflowStep, sgNod
 		}
 		if childNode != nil {
 			woc.addChildNode(sgNodeName, childNodeName)
-			if childNode.Completed() && !childNode.Successful() {
+			if childNode.Completed() && !childNode.Successful() && len(step.WithItems) == 0 {
 				break
 			}
 		}


### PR DESCRIPTION
I have a yaml like this below
```
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: steps-
spec:
  entrypoint: hello-hello-hello

  templates:
  - name: hello-hello-hello
    steps:
    - - name: hello1            #hello1 is run before the following steps
        template: whalesay
    - - name: hello2a           #double dash => run after previous step
        template: retry-container
        withItems: [1, 2, 3]

  - name: whalesay
    container:
      image: python:alpine3.6
      command: ["python", -c]
      args: ["import time; time.sleep(3)"]

  - name: retry-container
    retryStrategy:
      limit: 2
    container:
      image: python:alpine3.6
      command: ["python", -c]
      args: ["import random; import sys; exit_code = random.choice([1, 1]); sys.exit(exit_code)"]
```

Every time `argo submit test.yaml` , the pod will all failed & completed, but the workflow status will be `Running` forever,  this's a bug that in `steps`  with `retry`.
The result here
```
Name:                steps-k65m7
Namespace:           default
ServiceAccount:      default
Status:              Running
Created:             Thu Dec 27 20:26:17 +0800 (19 seconds ago)
Started:             Thu Dec 27 20:26:17 +0800 (19 seconds ago)
Duration:            19 seconds

STEP                      PODNAME                 DURATION  MESSAGE
 ● steps-k65m7
 ├---✔ hello1             steps-k65m7-3995602950  4s
 └-·-✖ hello2a(0:1)                                         No more retries left
   | ├-✖ hello2a(0:1)(0)  steps-k65m7-3038008680  2s        failed with exit code 1
   | ├-✖ hello2a(0:1)(1)  steps-k65m7-1091657781  2s        failed with exit code 1
   | └-✖ hello2a(0:1)(2)  steps-k65m7-420405926   2s        failed with exit code 1
   ├-● hello2a(1:2)
   | ├-✖ hello2a(1:2)(0)  steps-k65m7-96146110    3s        failed with exit code 1
   | ├-✖ hello2a(1:2)(1)  steps-k65m7-565772347   3s        failed with exit code 1
   | └-● hello2a(1:2)(2)  steps-k65m7-2176865056  4s
   └-✖ hello2a(2:3)                                         No more retries left
     ├-✖ hello2a(2:3)(0)  steps-k65m7-3542037624  1s        failed with exit code 1
     ├-✖ hello2a(2:3)(1)  steps-k65m7-1595686725  4s        failed with exit code 1
     └-✖ hello2a(2:3)(2)  steps-k65m7-1998202486  4s        failed with exit code 1
```
You can see that `hello2a(1:2)` has no `  No more retries left`, the workflow will `Running` forever.
In my fix, it will turn it to be right state. The new result will be like this 

```
Name:                steps-k65m7
Namespace:           default
ServiceAccount:      default
Status:              Failed
Message:             child 'steps-k65m7-372465681' failed
Created:             Thu Dec 27 20:26:17 +0800 (19 seconds ago)
Started:             Thu Dec 27 20:26:17 +0800 (19 seconds ago)
Finished:            Thu Dec 27 20:26:36 +0800 (now)
Duration:            19 seconds

STEP                      PODNAME                 DURATION  MESSAGE
 ✖ steps-k65m7                                              child 'steps-k65m7-372465681' failed
 ├---✔ hello1             steps-k65m7-3995602950  4s
 └-·-✖ hello2a(0:1)                                         No more retries left
   | ├-✖ hello2a(0:1)(0)  steps-k65m7-3038008680  2s        failed with exit code 1
   | ├-✖ hello2a(0:1)(1)  steps-k65m7-1091657781  2s        failed with exit code 1
   | └-✖ hello2a(0:1)(2)  steps-k65m7-420405926   2s        failed with exit code 1
   ├-✖ hello2a(1:2)                                         No more retries left
   | ├-✖ hello2a(1:2)(0)  steps-k65m7-96146110    3s        failed with exit code 1
   | ├-✖ hello2a(1:2)(1)  steps-k65m7-565772347   3s        failed with exit code 1
   | └-✖ hello2a(1:2)(2)  steps-k65m7-2176865056  2s        failed with exit code 1
   └-✖ hello2a(2:3)                                         No more retries left
     ├-✖ hello2a(2:3)(0)  steps-k65m7-3542037624  1s        failed with exit code 1
     ├-✖ hello2a(2:3)(1)  steps-k65m7-1595686725  4s        failed with exit code 1
     └-✖ hello2a(2:3)(2)  steps-k65m7-1998202486  4s        failed with exit code 1
```

@jessesuen   WDYT ?