### PR TITLE
Validate ArchiveLocation Artifacts

### DIFF
--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -133,6 +133,12 @@ func (ctx *wfValidationCtx) validateTemplate(tmpl *wfv1.Template, args wfv1.Argu
 	if err != nil {
 		return err
 	}
+	if tmpl.ArchiveLocation != nil {
+		err = validateArtifactLocation("templates.archiveLocation", *tmpl.ArchiveLocation)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -184,7 +190,7 @@ func validateInputs(tmpl *wfv1.Template) (map[string]interface{}, error) {
 			return nil, errors.Errorf(errors.CodeBadRequest, "templates.%s.%s.from not valid in inputs", tmpl.Name, artRef)
 		}
 		errPrefix := fmt.Sprintf("templates.%s.%s", tmpl.Name, artRef)
-		err = validateArtifactLocation(errPrefix, art)
+		err = validateArtifactLocation(errPrefix, art.ArtifactLocation)
 		if err != nil {
 			return nil, err
 		}
@@ -192,7 +198,7 @@ func validateInputs(tmpl *wfv1.Template) (map[string]interface{}, error) {
 	return scope, nil
 }
 
-func validateArtifactLocation(errPrefix string, art wfv1.Artifact) error {
+func validateArtifactLocation(errPrefix string, art wfv1.ArtifactLocation) error {
 	if art.Git != nil {
 		if art.Git.Repo == "" {
 			return errors.Errorf(errors.CodeBadRequest, "%s.git.repo is required", errPrefix)


### PR DESCRIPTION
I think we should validate `Artifacts` in `ArchiveLocation` because it is copied to artifacts in inputs and outputs later.