### PR TITLE
Set executor image pull policy for resource templates

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1462,9 +1462,10 @@ func (woc *wfOperationCtx) executeResource(nodeName string, tmpl *wfv1.Template,
 		return node
 	}
 	mainCtr := apiv1.Container{
-		Image:   woc.controller.executorImage(),
-		Command: []string{"argoexec"},
-		Args:    []string{"resource", tmpl.Resource.Action},
+		Image:           woc.controller.executorImage(),
+		ImagePullPolicy: woc.controller.executorImagePullPolicy(),
+		Command:         []string{"argoexec"},
+		Args:            []string{"resource", tmpl.Resource.Action},
 		VolumeMounts: []apiv1.VolumeMount{
 			volumeMountPodMetadata,
 		},


### PR DESCRIPTION
I found an error while I'm setting up the Argo controller. I wanted to set the executor image pull policy file by configmap but it was not taken for resource templates.