### PR TITLE
Do not mount unnecessary docker socket

### DIFF
--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -306,10 +306,10 @@ func (woc *wfOperationCtx) createVolumeMounts() []apiv1.VolumeMount {
 		volumeMountPodMetadata,
 	}
 	switch woc.controller.Config.ContainerRuntimeExecutor {
-	case common.ContainerRuntimeExecutorDocker:
-		return append(volumeMounts, volumeMountDockerSock)
-	default:
+	case common.ContainerRuntimeExecutorKubelet, common.ContainerRuntimeExecutorK8sAPI:
 		return volumeMounts
+	default:
+		return append(volumeMounts, volumeMountDockerSock)
 	}
 }
 
@@ -318,10 +318,10 @@ func (woc *wfOperationCtx) createVolumes() []apiv1.Volume {
 		volumePodMetadata,
 	}
 	switch woc.controller.Config.ContainerRuntimeExecutor {
-	case common.ContainerRuntimeExecutorDocker:
-		return append(volumes, volumeDockerSock)
-	default:
+	case common.ContainerRuntimeExecutorKubelet, common.ContainerRuntimeExecutorK8sAPI:
 		return volumes
+	default:
+		return append(volumes, volumeDockerSock)
 	}
 }
 

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -306,10 +306,10 @@ func (woc *wfOperationCtx) createVolumeMounts() []apiv1.VolumeMount {
 		volumeMountPodMetadata,
 	}
 	switch woc.controller.Config.ContainerRuntimeExecutor {
-	case common.ContainerRuntimeExecutorKubelet:
-		return volumeMounts
-	default:
+	case common.ContainerRuntimeExecutorDocker:
 		return append(volumeMounts, volumeMountDockerSock)
+	default:
+		return volumeMounts
 	}
 }
 
@@ -318,10 +318,10 @@ func (woc *wfOperationCtx) createVolumes() []apiv1.Volume {
 		volumePodMetadata,
 	}
 	switch woc.controller.Config.ContainerRuntimeExecutor {
-	case common.ContainerRuntimeExecutorKubelet:
-		return volumes
-	default:
+	case common.ContainerRuntimeExecutorDocker:
 		return append(volumes, volumeDockerSock)
+	default:
+		return volumes
 	}
 }
 

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo/workflow/common"
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
@@ -191,4 +192,77 @@ func TestWorkflowControllerArchiveConfigUnresolvable(t *testing.T) {
 	podName := getPodName(woc.wf)
 	_, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 	assert.Error(t, err)
+}
+
+// TestVolumeAndVolumeMounts verifies the ability to carry forward volumes and volumeMounts from workflow.spec
+func TestVolumeAndVolumeMounts(t *testing.T) {
+	volumes := []apiv1.Volume{
+		{
+			Name: "volume-name",
+			VolumeSource: apiv1.VolumeSource{
+				EmptyDir: &apiv1.EmptyDirVolumeSource{},
+			},
+		},
+	}
+	volumeMounts := []apiv1.VolumeMount{
+		{
+			Name:      "volume-name",
+			MountPath: "/test",
+		},
+	}
+
+	// For Docker executor
+	{
+		woc := newWoc()
+		woc.wf.Spec.Volumes = volumes
+		woc.wf.Spec.Templates[0].Container.VolumeMounts = volumeMounts
+		woc.controller.Config.ContainerRuntimeExecutor = common.ContainerRuntimeExecutorDocker
+
+		woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], "")
+		podName := getPodName(woc.wf)
+		pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
+		assert.Nil(t, err)
+		assert.Equal(t, 3, len(pod.Spec.Volumes))
+		assert.Equal(t, "podmetadata", pod.Spec.Volumes[0].Name)
+		assert.Equal(t, "docker-sock", pod.Spec.Volumes[1].Name)
+		assert.Equal(t, "volume-name", pod.Spec.Volumes[2].Name)
+		assert.Equal(t, 1, len(pod.Spec.Containers[0].VolumeMounts))
+		assert.Equal(t, "volume-name", pod.Spec.Containers[0].VolumeMounts[0].Name)
+	}
+
+	// For Kubelet executor
+	{
+		woc := newWoc()
+		woc.wf.Spec.Volumes = volumes
+		woc.wf.Spec.Templates[0].Container.VolumeMounts = volumeMounts
+		woc.controller.Config.ContainerRuntimeExecutor = common.ContainerRuntimeExecutorKubelet
+
+		woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], "")
+		podName := getPodName(woc.wf)
+		pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
+		assert.Nil(t, err)
+		assert.Equal(t, 2, len(pod.Spec.Volumes))
+		assert.Equal(t, "podmetadata", pod.Spec.Volumes[0].Name)
+		assert.Equal(t, "volume-name", pod.Spec.Volumes[1].Name)
+		assert.Equal(t, 1, len(pod.Spec.Containers[0].VolumeMounts))
+		assert.Equal(t, "volume-name", pod.Spec.Containers[0].VolumeMounts[0].Name)
+	}
+
+	// For K8sAPI executor
+	{
+		woc := newWoc()
+		woc.wf.Spec.Volumes = volumes
+		woc.wf.Spec.Templates[0].Container.VolumeMounts = volumeMounts
+		woc.controller.Config.ContainerRuntimeExecutor = common.ContainerRuntimeExecutorK8sAPI
+
+		woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], "")
+		podName := getPodName(woc.wf)
+		pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
+		assert.Nil(t, err)
+		assert.Equal(t, 2, len(pod.Spec.Volumes))
+		assert.Equal(t, "podmetadata", pod.Spec.Volumes[0].Name)
+		assert.Equal(t, "volume-name", pod.Spec.Volumes[1].Name)
+		assert.Equal(t, 1, len(pod.Spec.Containers[0].VolumeMounts))
+		assert.Equal(t, "volume-name", pod.Spec.Containers[0].VolumeMounts[0].Name)
+	}
 }


### PR DESCRIPTION
I got the following error when I submitted a workflow with the K8sAPI executor in my production environment which uses PSP.

```
pods "argo-chainer-mnist-vmtwz-139714430" is forbidden: unable to validate against any pod security policy: [spec.volumes[1].hostPath.pathPrefix: Invalid value: "/var/lib/docker": is not allowed to be used spec.volumes[2].hostPath.pathPrefix: Invalid value: "/var/run/docker.sock": is not allowed to be used spec.volumes[1].hostPath.pathPrefix: Invalid value: "/var/lib/docker": is not allowed to be used spec.volumes[2].hostPath.pathPrefix: Invalid value: "/var/run/docker.sock": is not allowed to be used]
```

I fixed the condition of added volumes and volumeMounts to workflow pods and wrote a simple test.