### PR TITLE
Fischerjulian adds ruby to rest docs

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -32,6 +32,7 @@ https://github.com/kubernetes-client/java/blob/master/kubernetes/docs/CustomObje
 ### Ruby
 The Ruby kubernetes client has libraries for interacting with custom objects. See:
 https://github.com/kubernetes-client/ruby/tree/master/kubernetes
+See this [external Ruby example](https://github.com/fischerjulian/argo_workflows_ruby_example) on how to make use of this client.
 
 ## OpenAPI
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -29,6 +29,10 @@ The python kubernetes client has libraries for interacting with custom objects. 
 The Java kubernetes client has libraries for interacting with custom objects. See:
 https://github.com/kubernetes-client/java/blob/master/kubernetes/docs/CustomObjectsApi.md
 
+### Ruby
+The Ruby kubernetes client has libraries for interacting with custom objects. See:
+https://github.com/kubernetes-client/ruby/tree/master/kubernetes
+
 ## OpenAPI
 
 An OpenAPI Spec is generated under [argoproj/argo/api/openapi-spec](https://github.com/argoproj/argo/blob/master/api/openapi-spec/swagger.json). This spec may be


### PR DESCRIPTION
Two commits: 

* add the link to the Ruby kubernetes gem
* add a link to a Ruby example on how to start an Argo workflow from a remote Ruby app.