### PR TITLE
Fix argo logs empty content when workflow run in virtual kubelet env

### DIFF
--- a/cmd/argo/commands/logs.go
+++ b/cmd/argo/commands/logs.go
@@ -346,6 +346,12 @@ func (p *logPrinter) getPodLogs(
 						})
 					}
 				}
+			} else {
+				callback(logEntry{
+					pod:         podName,
+					displayName: displayName,
+					line:        line,
+				})
 			}
 		}
 	}


### PR DESCRIPTION
VirtualKubelet is [here](https://github.com/virtual-kubelet/virtual-kubelet).   

When argo run workflow in virtual kubelet env,   the virtual kubelet return not standard log entry. It will cause empty content when `argo logs`.    