### PR TITLE
Issue #1190 - Fix incorrect retry node handling

### DIFF
--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -106,6 +106,10 @@ func (d *dagContext) assessDAGPhase(targetTasks []string, nodes map[string]wfv1.
 }
 
 func hasMoreRetries(node *wfv1.NodeStatus, wf *wfv1.Workflow) bool {
+	if node.Phase == wfv1.NodeSucceeded {
+		return false
+	}
+
 	if len(node.Children) == 0 {
 		return true
 	}


### PR DESCRIPTION
Fixes issue described at https://github.com/argoproj/argo/issues/1190#issuecomment-459898488

Workflow stuck in running state forever if it has dag step with depends on a successfully completed node with retries and this dag step is a dependency for something else.