### PR TITLE
Dockerfile: argoexec base image correction (fixes #1209)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN make $MAKE_TARGET
 ####################################################################################################
 # argoexec
 ####################################################################################################
-FROM debian:9.6-slim as argoexec
+FROM argoexec-base as argoexec
 COPY --from=argo-build /go/src/github.com/argoproj/argo/dist/argoexec /usr/local/bin/
 
 


### PR DESCRIPTION
Correcting the base image of `argoexec` in the Dockerfile.

Closes #1209.