### PR TITLE
Remove extra quotes around output parameter value

### DIFF
--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -245,7 +245,7 @@ func (we *WorkflowExecutor) SaveResourceParameters(resourceNamespace string, res
 		}
 		var cmd *exec.Cmd
 		if param.ValueFrom.JSONPath != "" {
-			args := []string{"get", resourceName, "-o", fmt.Sprintf("jsonpath='%s'", param.ValueFrom.JSONPath)}
+			args := []string{"get", resourceName, "-o", fmt.Sprintf("jsonpath=%s", param.ValueFrom.JSONPath)}
 			if resourceNamespace != "" {
 				args = append(args, "-n", resourceNamespace)
 			}


### PR DESCRIPTION
It seems that using `valueFrom: jsonPath: ...` when definining the value of an output parameter for a `resource` template leads to the value being enclosed in single quotes.
For example, here is the output of the Argo pod that creates the resource:
```
time="2019-02-22T21:42:02Z" level=info msg="Saving resource output parameters"
time="2019-02-22T21:42:02Z" level=info msg="[kubectl get PersistentVolumeClaim./example-1-5qkgt-mypvc -o jsonpath='{.metadata.name}' -n kubeflow]"
time="2019-02-22T21:42:03Z" level=info msg="Saved output parameter: mypvc-name, value: 'example-1-5qkgt-mypvc'"
time="2019-02-22T21:42:03Z" level=info msg="Annotating pod with output"
```
I would expect the value to be without quotes, so it can be used as is to refer to the newly-created resource in other parts of the workflow.

I looked deeper, and it seems that the Go code [here](https://github.com/argoproj/argo/blob/master/workflow/executor/resource.go#L248), includes these quotes in error. Removing the extra quotes fixes the problem.

Similarly, when playing with `jqFilter`, it seems the return value begins with double quotes and ends in double quotes, also followed by a newline: i.e., `"parameter value"\n`
Is this expected, or is it an undesired side-effect?
If this is undesired, I can amend this PR, or create a new one, to also fix this behavior.

Looking forward to your comments,
Ilias. 
