### PR TITLE
Fix the Prometheus address references

### DIFF
--- a/workflow/metrics/server.go
+++ b/workflow/metrics/server.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -20,7 +21,7 @@ type PrometheusConfig struct {
 func RunServer(ctx context.Context, config PrometheusConfig, registry *prometheus.Registry) {
 	mux := http.NewServeMux()
 	mux.Handle(config.Path, promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
-	srv := &http.Server{Addr: config.Port, Handler: mux}
+	srv := &http.Server{Addr: fmt.Sprintf(":%s", config.Port), Handler: mux}
 
 	defer func() {
 		if cerr := srv.Close(); cerr != nil {
@@ -28,7 +29,7 @@ func RunServer(ctx context.Context, config PrometheusConfig, registry *prometheu
 		}
 	}()
 
-	log.Infof("Starting prometheus metrics server at 0.0.0.0%s%s", config.Port, config.Path)
+	log.Infof("Starting prometheus metrics server at 0.0.0.0:%s%s", config.Port, config.Path)
 	if err := srv.ListenAndServe(); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
If you follow the configmap reference here: https://github.com/Path-AI/argo/blob/master/docs/workflow-controller-configmap.yaml#L99 and try to start the Prometheus metrics listener, you get logs like this:

```
time="2019-02-25T20:55:10Z" level=info msg="workflow controller configuration from workflow-controller-configmap:\n# metricsConfig controls the path and port for prometheus metrics\nmetricsConfig:\n  enabled: true\n  path: /metrics\n  port: 8080\n"                                                                                                                                                                             
time="2019-02-25T20:55:10Z" level=info msg="Starting workflow TTL controller (resync 20m0s)"
time="2019-02-25T20:55:10Z" level=info msg="Starting prometheus metrics server at 0.0.0.08080/metrics"
panic: listen tcp: address 8080: missing port in address                   

goroutine 38 [running]:                   
github.com/argoproj/argo/workflow/metrics.RunServer(0x135b100, 0xc4203870c0, 0x1, 0xc42041ef30, 0x8, 0xc42041ef38, 0x4, 0xc4202da340)
        /root/go/src/github.com/argoproj/argo/workflow/metrics/server.go:33 +0x2b1
github.com/argoproj/argo/workflow/controller.(*WorkflowController).MetricsServer(0xc4200c7ce0, 0x135b100, 0xc4203870c0)
        /root/go/src/github.com/argoproj/argo/workflow/controller/controller.go:93 +0x16d
created by main.NewRootCommand.func1
        /root/go/src/github.com/argoproj/argo/cmd/workflow-controller/main.go:80 +0x42b
```

The problem is that `net/http` expects a colon before the provided port number.

Tested this locally and it works as expected.