### PR TITLE
Fixed Issue#1223 Kubernetes Resource action: patch is not supported

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1163,7 +1163,8 @@ spec:
   templates:
   - name: pi-tmpl
     resource:                   # indicates that this is a resource template
-      action: create            # can be any kubectl action (e.g. create, delete, apply, patch)
+      action: create            # can be any kubectl action (e.g. create, delete, apply, patch) 
+                                # Patch action will support only **json merge strategic**
       # The successCondition and failureCondition are optional expressions.
       # If failureCondition is true, the step is considered failed.
       # If successCondition is true, the step is considered successful.

--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -31,10 +31,11 @@ func (we *WorkflowExecutor) ExecResource(action string, manifestPath string, isD
 	}
 
 	if action == "patch" {
-		args = append(args, "-p")
-		buff, err :=ioutil.ReadFile(manifestPath)
 
-		if(err != nil) {
+		args = append(args, "-p")
+		buff, err := ioutil.ReadFile(manifestPath)
+
+		if err != nil {
 			return "", "", errors.New(errors.CodeBadRequest, err.Error())
 		}
 

--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os/exec"
 	"strings"
 	"time"
@@ -28,6 +29,18 @@ func (we *WorkflowExecutor) ExecResource(action string, manifestPath string, isD
 		args = append(args, "--ignore-not-found")
 		output = "name"
 	}
+
+	if action == "patch" {
+		args = append(args, "-p")
+		buff, err :=ioutil.ReadFile(manifestPath)
+
+		if(err != nil) {
+			return "", "", errors.New(errors.CodeBadRequest, err.Error())
+		}
+
+		args = append(args, string(buff))
+	}
+
 	args = append(args, "-f")
 	args = append(args, manifestPath)
 	args = append(args, "-o")


### PR DESCRIPTION
This PR is fixed the Issue#1223 reported by @shanesiebken. Argo kubernetes resource workflow failed on patch action because argoexec is not passing -p/--patch option to kubectl command. --patch or -p option is required for kubectl patch action.
This PR is including the manifest content as patch argument in kubectl command. 
This Fix will support the Patch action in Argo kubernetes resource workflow.

This Fix will support only **JSON merge strategic** in patch action

