### PR TITLE
Issue#1165 fake outputs don't notify and task completes successfully

### DIFF
--- a/workflow/executor/docker/docker.go
+++ b/workflow/executor/docker/docker.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/argoproj/argo/workflow/util/file"
+
 	"github.com/argoproj/argo/util"
 
 	"github.com/argoproj/argo/errors"
@@ -50,6 +52,11 @@ func (d *DockerExecutor) CopyFile(containerID string, sourcePath string, destPat
 	err := common.RunCommand("sh", "-c", dockerCpCmd)
 	if err != nil {
 		return err
+	}
+	if !file.IsFileOrDirExistInGZip(sourcePath, destPath) {
+		errMsg := fmt.Sprintf("File or Artifact does not exist. %s", sourcePath)
+		log.Warn(errMsg)
+		return errors.InternalError(errMsg)
 	}
 	log.Infof("Archiving completed")
 	return nil

--- a/workflow/util/file/fileutil.go
+++ b/workflow/util/file/fileutil.go
@@ -1,0 +1,43 @@
+package file
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"os"
+	"strings"
+)
+
+//IsFileOrDirExistInGZip return true if file or directory exists in GZip file
+func IsFileOrDirExistInGZip(sourcePath string, gzipFilePath string) bool {
+
+	fi, err := os.Open(gzipFilePath)
+
+	if os.IsNotExist(err) {
+		return false
+	}
+	defer fi.Close()
+
+	fz, err := gzip.NewReader(fi)
+	if err != nil {
+		return false
+	}
+	defer fz.Close()
+	tr := tar.NewReader(fz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return false
+		}
+		if hdr.FileInfo().IsDir() && strings.Contains(strings.Trim(hdr.Name, "/"), strings.Trim(sourcePath, "/")) {
+			return true
+		}
+		if strings.Contains(sourcePath, hdr.Name) && hdr.Size > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/workflow/util/file/fileutil.go
+++ b/workflow/util/file/fileutil.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 )
 
 //IsFileOrDirExistInGZip return true if file or directory exists in GZip file
@@ -16,13 +18,12 @@ func IsFileOrDirExistInGZip(sourcePath string, gzipFilePath string) bool {
 	if os.IsNotExist(err) {
 		return false
 	}
-	defer fi.Close()
+	defer closeFile(fi)
 
 	fz, err := gzip.NewReader(fi)
 	if err != nil {
 		return false
 	}
-	defer fz.Close()
 	tr := tar.NewReader(fz)
 	for {
 		hdr, err := tr.Next()
@@ -30,6 +31,7 @@ func IsFileOrDirExistInGZip(sourcePath string, gzipFilePath string) bool {
 			break
 		}
 		if err != nil {
+
 			return false
 		}
 		if hdr.FileInfo().IsDir() && strings.Contains(strings.Trim(hdr.Name, "/"), strings.Trim(sourcePath, "/")) {
@@ -40,4 +42,11 @@ func IsFileOrDirExistInGZip(sourcePath string, gzipFilePath string) bool {
 		}
 	}
 	return false
+}
+
+func closeFile(f *os.File) {
+	err := f.Close()
+	if err != nil {
+		log.Warn("Failed to close the file. v%", err)
+	}
 }


### PR DESCRIPTION
This PR is addressing the Issue#1165 reported by @alexfrieden.

Issue/Bug: Argo workflow is finishing the step successfully even artifact does exist.

Fix: Validate the created gzip contains artifact. if artifact doesn't exist, Current step/stage/task will be failed with the log message.

Sample Log:
'''
INFO[0029] Updating node artifact-passing-lkvj8[0].generate-artifact (artifact-passing-lkvj8-1949982165) message: failed to save outputs: **File or Artifact does not exist. /tmp/hello_world.txt**


'''