### PR TITLE
Add a config to allow user config main container resource

### DIFF
--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -95,6 +95,17 @@ data:
         cpu: 0.5
         memory: 512Mi
 
+    # mainContainerResources specifies the default resource requirement that will be used for
+    # the main container when running a kubectl command against a manifest. This is useful in 
+    # clusters which require resources to be specified as part of admission control.
+    mainContainerResources:
+      requests:
+        cpu: 0.1
+        memory: 64Mi
+      limits:
+        cpu: 0.5
+        memory: 512Mi
+
     # metricsConfig controls the path and port for prometheus metrics
     metricsConfig:
       enabled: true

--- a/workflow/controller/config.go
+++ b/workflow/controller/config.go
@@ -30,6 +30,9 @@ type WorkflowControllerConfig struct {
 	// ExecutorResources specifies the resource requirements that will be used for the executor sidecar
 	ExecutorResources *apiv1.ResourceRequirements `json:"executorResources,omitempty"`
 
+	// MainContainerResources specifies the default resource requirements that will be used for the main container
+	MainContainerResources *apiv1.ResourceRequirements `json:"mainContainerResources,omitempty"`
+
 	// KubeConfig specifies a kube config file for the wait & init containers
 	KubeConfig *KubeConfig `json:"kubeConfig,omitempty"`
 

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -38,6 +38,31 @@ spec:
       command: [cowsay]
       args: ["hello world"]
 `
+var helloWorldWf2 = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: hello-world
+spec:
+  entrypoint: whalesay
+  templates:
+  - name: whalesay
+    resource:
+      action: create
+      manifests: |
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          generateName: job-
+        spec:
+          template:
+          spec:
+            containers:
+            - name: c1
+              image: docker/whalesay:latest
+              command: [cowsay]
+              args: ["hello world"]
+`
 
 func newController() *WorkflowController {
 	return &WorkflowController{

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1487,6 +1487,9 @@ func (woc *wfOperationCtx) executeResource(nodeName string, tmpl *wfv1.Template,
 		},
 		Env: execEnvVars,
 	}
+	if woc.controller.Config.MainContainerResources != nil {
+		mainCtr.Resources = *woc.controller.Config.MainContainerResources
+	}
 	_, err := woc.createWorkflowPod(nodeName, mainCtr, tmpl)
 	if err != nil {
 		return woc.initializeNode(nodeName, wfv1.NodeTypePod, tmpl.Name, boundaryID, wfv1.NodeError, err.Error())


### PR DESCRIPTION
Adding the MainContainerResources config, to make executeResource can work if resource is required. We may export the config also for executeContainer and executeScript funcs.