### PR TITLE
[Fix #1242] Failed DAG nodes are now kept and set to running on Retry…

### DIFF
--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -462,6 +462,14 @@ func RetryWorkflow(kubeClient kubernetes.Interface, wfClient v1alpha1.WorkflowIn
 				continue
 			}
 		case wfv1.NodeError, wfv1.NodeFailed:
+			if !strings.HasPrefix(node.Name, onExitNodeName) && node.Type == wfv1.NodeTypeDAG {
+				newNode := node.DeepCopy()
+				newNode.Phase = wfv1.NodeRunning
+				newNode.Message = ""
+				newNode.FinishedAt = metav1.Time{}
+				newWF.Status.Nodes[newNode.ID] = *newNode
+				continue
+			}
 			// do not add this status to the node. pretend as if this node never existed.
 		default:
 			// Do not allow retry of workflows with pods in Running/Pending phase


### PR DESCRIPTION
Failed DAG nodes are now kept on RetryWorkflow with their status set to running and their finished timestamps and messagse set to null. As a result, the node dependents are kept and the workflow no longer ends up having multiple disconnected graphs (fix for #1242).

