### PR TITLE
Fix the arguments being passed to `kubectl patch`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1164,7 +1164,7 @@ spec:
   - name: pi-tmpl
     resource:                   # indicates that this is a resource template
       action: create            # can be any kubectl action (e.g. create, delete, apply, patch) 
-                                # Patch action will support only **json merge strategic**
+                                # Patch action will perform a merge patch
       # The successCondition and failureCondition are optional expressions.
       # If failureCondition is true, the step is considered failed.
       # If successCondition is true, the step is considered successful.

--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -31,7 +31,8 @@ func (we *WorkflowExecutor) ExecResource(action string, manifestPath string, isD
 	}
 
 	if action == "patch" {
-
+		args = append(args, "--type")
+		args = append(args, "merge")
 		args = append(args, "-p")
 		buff, err := ioutil.ReadFile(manifestPath)
 
@@ -39,7 +40,7 @@ func (we *WorkflowExecutor) ExecResource(action string, manifestPath string, isD
 			return "", "", errors.New(errors.CodeBadRequest, err.Error())
 		}
 
-		args = append(args, string(buff))
+		args = append(args, "'"+string(buff)+"'")
 	}
 
 	args = append(args, "-f")


### PR DESCRIPTION
* The `kubectl patch` will fail if the `--type merge` argument is not
  passed. It also requires for the patch manifest to be enclosed in single
  quotes.

* This also updates the k8s resource example

Resolves https://github.com/argoproj/argo/issues/1223