### PR TITLE
Add the `mergeStrategy` option to resource patching

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -538,6 +538,10 @@
           "description": "Manifest contains the kubernetes manifest",
           "type": "string"
         },
+        "mergeStrategy": {
+          "description": "MergeStrategy is the strategy used to merge a patch. It defaults to \"strategic\" Must be one of: strategic, merge, json",
+          "type": "string"
+        },
         "successCondition": {
           "description": "SuccessCondition is a label selector expression which describes the conditions of the k8s resource in which it is acceptable to proceed to the following step",
           "type": "string"

--- a/pkg/apis/workflow/v1alpha1/openapi_generated.go
+++ b/pkg/apis/workflow/v1alpha1/openapi_generated.go
@@ -1005,6 +1005,13 @@ func schema_pkg_apis_workflow_v1alpha1_ResourceTemplate(ref common.ReferenceCall
 							Format:      "",
 						},
 					},
+					"mergeStrategy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MergeStrategy is the strategy used to merge a patch. It defaults to \"strategic\" Must be one of: strategic, merge, json",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"manifest": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Manifest contains the kubernetes manifest",

--- a/pkg/apis/workflow/v1alpha1/types.go
+++ b/pkg/apis/workflow/v1alpha1/types.go
@@ -781,6 +781,10 @@ type ResourceTemplate struct {
 	// Must be one of: get, create, apply, delete, replace
 	Action string `json:"action"`
 
+	// MergeStrategy is the strategy used to merge a patch. It defaults to "strategic"
+	// Must be one of: strategic, merge, json
+	MergeStrategy string `json:"mergeStrategy,omitempty"`
+
 	// Manifest contains the kubernetes manifest
 	Manifest string `json:"manifest"`
 

--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -31,6 +31,13 @@ func (we *WorkflowExecutor) ExecResource(action string, manifestPath string, isD
 	}
 
 	if action == "patch" {
+		mergeStrategy := "strategic"
+		if we.Template.Resource.MergeStrategy != "" {
+			mergeStrategy = we.Template.Resource.MergeStrategy
+		}
+
+		args = append(args, "--type")
+		args = append(args, mergeStrategy)
 
 		args = append(args, "-p")
 		buff, err := ioutil.ReadFile(manifestPath)


### PR DESCRIPTION
* This adds the ability to pass a mergeStrategy to a patch resource.
  this is valuable because the default merge strategy for kubernetes is
  'strategic', which does not work with Custom Resources.

* This also updates the resource example to demonstrate how it is used