### PR TITLE
Reduce redundancy pod label action

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -456,6 +456,11 @@ func (woc *wfOperationCtx) podReconciliation() error {
 			}
 			node := woc.wf.Status.Nodes[pod.ObjectMeta.Name]
 			if node.Completed() && !node.IsDaemoned() {
+				if tmpVal, tmpOk := pod.Labels[common.LabelKeyCompleted]; tmpOk {
+					if tmpVal == "true" {
+						return
+					}
+				}
 				woc.completedPods[pod.ObjectMeta.Name] = true
 			}
 		}


### PR DESCRIPTION
For that pod which has already been tag `workflows.argoproj.io/completed: "true"`. It shouldn't be tag again and again.

In some large workflow,  these redundant tag action will cause much press to apiServer and cost much time. 

![image](https://user-images.githubusercontent.com/6504718/54670387-8268dd00-4b2e-11e9-83f9-478a25f88d35.png)

@jessesuen @alexmt WDYT ?