### PR TITLE
Speed up podReconciliation using parallel goroutine

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	argokubeerr "github.com/argoproj/pkg/kube/errors"
@@ -449,11 +450,21 @@ func (woc *wfOperationCtx) podReconciliation() error {
 		return err
 	}
 	seenPods := make(map[string]bool)
+	seenPodLock := &sync.Mutex{}
+	wfNodesLock := &sync.RWMutex{}
 
 	performAssessment := func(pod *apiv1.Pod) {
+		if pod == nil {
+			return
+		}
 		nodeNameForPod := pod.Annotations[common.AnnotationKeyNodeName]
 		nodeID := woc.wf.NodeID(nodeNameForPod)
+		seenPodLock.Lock()
 		seenPods[nodeID] = true
+		seenPodLock.Unlock()
+
+		wfNodesLock.Lock()
+		defer wfNodesLock.Unlock()
 		if node, ok := woc.wf.Status.Nodes[nodeID]; ok {
 			if newState := assessNodeStatus(pod, &node); newState != nil {
 				woc.wf.Status.Nodes[nodeID] = *newState
@@ -472,27 +483,23 @@ func (woc *wfOperationCtx) podReconciliation() error {
 		}
 	}
 
+	parallelPodNum := make(chan string, 500)
+	var wg sync.WaitGroup
 	for _, pod := range podList.Items {
-		origNodeStatus := *woc.wf.Status.DeepCopy()
-		performAssessment(&pod)
-		err = woc.applyExecutionControl(&pod)
-		if err != nil {
-			woc.log.Warnf("Failed to apply execution control to pod %s", pod.Name)
-		}
-		err = woc.checkAndCompress()
-		if err != nil {
-			woc.wf.Status = origNodeStatus
-			nodeNameForPod := pod.Annotations[common.AnnotationKeyNodeName]
-			woc.log.Warnf("%v", err)
-			woc.markNodeErrorClearOuput(nodeNameForPod, err)
-			err = woc.checkAndCompress()
+		parallelPodNum <- pod.Name
+		wg.Add(1)
+		go func(tmpPod apiv1.Pod) {
+			defer wg.Done()
+			performAssessment(&tmpPod)
+			err = woc.applyExecutionControl(&tmpPod, wfNodesLock)
 			if err != nil {
-				woc.markWorkflowError(err, true)
+				woc.log.Warnf("Failed to apply execution control to pod %s", pod.Name)
 			}
-		}
-
+			<- parallelPodNum
+		}(pod)
 	}
 
+	wg.Wait()
 	// Now check for deleted pods. Iterate our nodes. If any one of our nodes does not show up in
 	// the seen list it implies that the pod was deleted without the controller seeing the event.
 	// It is now impossible to infer pod status. The only thing we can do at this point is to mark

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -493,9 +493,9 @@ func (woc *wfOperationCtx) podReconciliation() error {
 			performAssessment(&tmpPod)
 			err = woc.applyExecutionControl(&tmpPod, wfNodesLock)
 			if err != nil {
-				woc.log.Warnf("Failed to apply execution control to pod %s", pod.Name)
+				woc.log.Warnf("Failed to apply execution control to pod %s", tmpPod.Name)
 			}
-			<- parallelPodNum
+			<-parallelPodNum
 		}(pod)
 	}
 


### PR DESCRIPTION
I test many situations on every size workflow, found that there's a problem on large or medium workflow. As the workflow grows larger, the state sync of the pod is slower and slower. In the end, there will even be a situation where the state of the pod in the workflow differs from the state of the actual apiServer storage by more than 20 minutes. I use the test case below.
<details>
  <summary>test case</summary>

```
 apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: pod-limits-
spec:
  entrypoint: pod-limits
  arguments:
    parameters:
    - name: limit
      value: 300

  templates:
  - name: pod-limits
    steps:
    - - name: run-pod
        template: run-pod
        withSequence:
          count: "{{workflow.parameters.limit}}"
    - - name: run-pod-2
        template: run-pod
        withSequence:
          count: "{{workflow.parameters.limit}}"
    - - name: run-pod-3
        template: run-pod
        withSequence:
          count: "{{workflow.parameters.limit}}"
    - - name: run-pod-4
        template: run-pod
        withSequence:
          count: "{{workflow.parameters.limit}}"
    - - name: run-pod-5
        template: run-pod
        withSequence:
          count: "{{workflow.parameters.limit}}"
    - - name: run-pod-6
        template: run-pod
        withSequence:
          count: "{{workflow.parameters.limit}}"
    - - name: run-pod-7
        template: run-pod
        withSequence:
          count: "{{workflow.parameters.limit}}"
    - - name: run-pod-8
        template: run-pod
        withSequence:
          count: "{{workflow.parameters.limit}}"
    - - name: run-pod-9
        template: run-pod
        withSequence:
          count: "{{workflow.parameters.limit}}"
    - - name: run-pod-10
        template: run-pod
        withSequence:
          count: "{{workflow.parameters.limit}}"

  - name: run-pod
    container:
      image: "alpine:3.7"
      command: [sh, -c]
      args: ["echo sleeping 1s; sleep 1"]
```

</details>

I finally found that the ultimate cause of this phenomenon is because of this code https://github.com/argoproj/argo/blob/master/workflow/controller/operator.go#L475.

Every pod it will cost about 0.07s. For a workflow with 5000+ pod , it will become 350s(5.83min). Each workflow operate will cost 5.83min,  it will cause all the workflow failed.  I log some info here

```
time="2019-03-25T11:02:55Z" level=info msg="woc.operate() begin 2019-03-25 11:02:55.79355082 +0000 UTC m=+2065.114054885"
time="2019-03-25T11:02:55Z" level=info msg="podReconciliation beigin 2019-03-25 11:02:55.793568393 +0000 UTC m=+2065.114072444" nam    espace=default workflow=pod-limits-lpx8s

time="2019-03-25T11:02:56Z" level=info msg="podList.Items begin 2019-03-25 11:02:56.440491326 +0000 UTC m=+2065.760995371"
time="2019-03-25T11:06:31Z" level=info msg="podList.Items finish 2019-03-25 11:06:31.042339976 +0000 UTC m=+2280.362844058"

time="2019-03-25T11:06:31Z" level=info msg="podReconciliation finish 2019-03-25 11:06:31.042647034 +0000 UTC m=+2280.363151118"
time="2019-03-25T11:06:32Z" level=info msg="woc.operate() finish 2019-03-25 11:06:32.19709539 +0000 UTC m=+2281.517599462"
```

We can see that, much time cost on pod list line about 5min.   

So I raise this PR, using goroutine to parallel processing pod change.  The data will be show on log info

```
time="2019-03-26T03:34:06Z" level=info msg="woc.operate() begin 2019-03-26 03:34:06.756379813 +0000 UTC m=+1087.223992692"

time="2019-03-26T03:34:06Z" level=info msg="podReconciliation beigin 2019-03-26 03:34:06.756395722 +0000 UTC m=+1087.224008733"        

time="2019-03-26T03:34:07Z" level=info msg="podReconciliation finish 2019-03-26 03:34:07.891711473 +0000 UTC m=+1088.359324424"        

time="2019-03-26T03:34:09Z" level=info msg="woc.operate() finish 2019-03-26 03:34:09.015838715 +0000 UTC m=+1089.483451712"
```

You can see that,  after using this PR, the cost time reduce to 1s.  From 5min to 1s. 
It's very useful on medium or large workflow and for normal workflow, it will also accelerate processing.

@jessesuen pls help review.   Thanks.
