### PR TITLE
Added support for artifact path references

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -28,6 +28,8 @@ The following variables are made available to reference various metadata of a wo
 | Variable | Description|
 |----------|------------|
 | `pod.name` | Pod name of the container/script |
+| `inputs.artifacts.<NAME>.path` | Local path of the input artifact |
+| `outputs.artifacts.<NAME>.path` | Local path of the output artifact |
 
 ## Loops (withItems / withParam)
 | Variable | Description|

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -30,6 +30,7 @@ The following variables are made available to reference various metadata of a wo
 | `pod.name` | Pod name of the container/script |
 | `inputs.artifacts.<NAME>.path` | Local path of the input artifact |
 | `outputs.artifacts.<NAME>.path` | Local path of the output artifact |
+| `outputs.parameters.<NAME>.path` | Local path of the output parameter |
 
 ## Loops (withItems / withParam)
 | Variable | Description|

--- a/examples/artifact-path-placeholders.yaml
+++ b/examples/artifact-path-placeholders.yaml
@@ -1,0 +1,36 @@
+# This example demonstrates the how to refer to input and output artifact paths.
+# Referring to the path instead of copy/pasting it prevents errors when paths change.
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: artifact-path-placeholders-
+spec:
+  entrypoint: grep
+  arguments:
+    parameters:
+    - name: regex
+      value: Argo
+    artifacts:
+    - name: text
+      raw:
+        data: |
+          Beginning with thee, O Phoebus,
+          I will recount the famous deeds of men of old,
+          who, at the behest of King Pelias,
+          down through the mouth of Pontus and between the Cyanean rocks,
+          sped well-benched Argo in quest of the golden fleece
+  templates:
+  - name: grep
+    inputs:
+      parameters:
+      - name: regex
+      artifacts:
+      - name: text
+        path: /inputs/text/data
+    outputs:
+      artifacts:
+      - name: text
+        path: /outputs/text/data
+    container:
+      image: busybox
+      command: [sh, -c, 'grep "{{inputs.parameters.regex}}" <"{{inputs.artifacts.text.path}}" | tee "{{outputs.artifacts.text.path}}"']

--- a/examples/artifact-path-placeholders.yaml
+++ b/examples/artifact-path-placeholders.yaml
@@ -5,32 +5,36 @@ kind: Workflow
 metadata:
   generateName: artifact-path-placeholders-
 spec:
-  entrypoint: grep
+  entrypoint: head-lines
   arguments:
     parameters:
-    - name: regex
-      value: Argo
+    - name: lines-count
+      value: 3
     artifacts:
     - name: text
       raw:
         data: |
-          Beginning with thee, O Phoebus,
-          I will recount the famous deeds of men of old,
-          who, at the behest of King Pelias,
-          down through the mouth of Pontus and between the Cyanean rocks,
-          sped well-benched Argo in quest of the golden fleece
+          1
+          2
+          3
+          4
+          5
   templates:
-  - name: grep
+  - name: head-lines
     inputs:
       parameters:
-      - name: regex
+      - name: lines-count
       artifacts:
       - name: text
         path: /inputs/text/data
     outputs:
+      parameters:
+      - name: actual-lines-count
+        valueFrom:
+          path: /outputs/actual-lines-count/data
       artifacts:
       - name: text
         path: /outputs/text/data
     container:
       image: busybox
-      command: [sh, -c, 'grep "{{inputs.parameters.regex}}" <"{{inputs.artifacts.text.path}}" | tee "{{outputs.artifacts.text.path}}"']
+      command: [sh, -c, 'head -n {{inputs.parameters.lines-count}} <"{{inputs.artifacts.text.path}}" | tee "{{outputs.artifacts.text.path}}" | wc -l > "{{outputs.parameters.actual-lines-count.path}}"']

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -116,7 +116,7 @@ const (
 )
 
 // GlobalVarWorkflowRootTags is a list of root tags in workflow which could be used for variable reference
-var GlobalVarValidWorkflowVariablePrefix = []string{"item.", "steps.", "inputs.", "pod.", "workflow.", "tasks."}
+var GlobalVarValidWorkflowVariablePrefix = []string{"item.", "steps.", "inputs.", "outputs.", "pod.", "workflow.", "tasks."}
 
 // ExecutionControl contains execution control parameters for executor to decide how to execute the container
 type ExecutionControl struct {

--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -195,6 +195,16 @@ func substituteParams(tmpl *wfv1.Template, globalParams, localParams map[string]
 		}
 		replaceMap["inputs.parameters."+inParam.Name] = *inParam.Value
 	}
+	for _, inArt := range globalReplacedTmpl.Inputs.Artifacts {
+		if inArt.Path != "" {
+			replaceMap["inputs.artifacts."+inArt.Name+".path"] = inArt.Path
+		}
+	}
+	for _, outArt := range globalReplacedTmpl.Outputs.Artifacts {
+		if outArt.Path != "" {
+			replaceMap["outputs.artifacts."+outArt.Name+".path"] = outArt.Path
+		}
+	}
 	fstTmpl = fasttemplate.New(globalReplacedTmplStr, "{{", "}}")
 	s, err := Replace(fstTmpl, replaceMap, true)
 	if err != nil {

--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -205,6 +205,12 @@ func substituteParams(tmpl *wfv1.Template, globalParams, localParams map[string]
 			replaceMap["outputs.artifacts."+outArt.Name+".path"] = outArt.Path
 		}
 	}
+	for _, param := range globalReplacedTmpl.Outputs.Parameters {
+		if param.ValueFrom != nil && param.ValueFrom.Path != "" {
+			replaceMap["outputs.parameters."+param.Name+".path"] = param.ValueFrom.Path
+		}
+	}
+
 	fstTmpl = fasttemplate.New(globalReplacedTmplStr, "{{", "}}")
 	s, err := Replace(fstTmpl, replaceMap, true)
 	if err != nil {

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -119,6 +119,13 @@ func (ctx *wfValidationCtx) validateTemplate(tmpl *wfv1.Template, args wfv1.Argu
 		localParams[common.LocalVarPodName] = placeholderValue
 		scope[common.LocalVarPodName] = placeholderValue
 	}
+	if tmpl.IsLeaf() {
+		for _, art := range tmpl.Outputs.Artifacts {
+			if art.Path != "" {
+				scope[fmt.Sprintf("outputs.artifacts.%s.path", art.Name)] = true
+			}
+		}
+	}
 
 	_, err = common.ProcessArgs(tmpl, args, ctx.globalParams, localParams, true)
 	if err != nil {
@@ -190,6 +197,7 @@ func validateInputs(tmpl *wfv1.Template) (map[string]interface{}, error) {
 			if art.Path == "" {
 				return nil, errors.Errorf(errors.CodeBadRequest, "templates.%s.%s.path not specified", tmpl.Name, artRef)
 			}
+			scope[fmt.Sprintf("inputs.artifacts.%s.path", art.Name)] = true
 		} else {
 			if art.Path != "" {
 				return nil, errors.Errorf(errors.CodeBadRequest, "templates.%s.%s.path only valid in container/script templates", tmpl.Name, artRef)

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -125,6 +125,11 @@ func (ctx *wfValidationCtx) validateTemplate(tmpl *wfv1.Template, args wfv1.Argu
 				scope[fmt.Sprintf("outputs.artifacts.%s.path", art.Name)] = true
 			}
 		}
+		for _, param := range tmpl.Outputs.Parameters {
+			if param.ValueFrom != nil && param.ValueFrom.Path != "" {
+				scope[fmt.Sprintf("outputs.parameters.%s.path", param.Name)] = true
+			}
+		}
 	}
 
 	_, err = common.ProcessArgs(tmpl, args, ctx.globalParams, localParams, true)

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -167,27 +167,41 @@ var ioArtifactPaths = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  generateName: passthrough-
+  generateName: artifact-path-placeholders-
 spec:
-  entrypoint: passthrough
+  entrypoint: head-lines
   arguments:
+    parameters:
+    - name: lines-count
+      value: 3
     artifacts:
-    - name: art
+    - name: text
       raw:
-        data: Hello World
+        data: |
+          1
+          2
+          3
+          4
+          5
   templates:
-  - name: passthrough
+  - name: head-lines
     inputs:
+      parameters:
+      - name: lines-count
       artifacts:
-      - name: art
-        path: /inputs/art/data
+      - name: text
+        path: /inputs/text/data
     outputs:
+      parameters:
+      - name: actual-lines-count
+        valueFrom:
+          path: /outputs/actual-lines-count/data
       artifacts:
-      - name: art
-        path: /outputs/art/data
+      - name: text
+        path: /outputs/text/data
     container:
       image: busybox
-      command: [cp, "{{inputs.artifacts.art.path}}", "{{outputs.artifacts.art.path}}"]
+      command: [sh, -c, 'head -n {{inputs.parameters.lines-count}} <"{{inputs.artifacts.text.path}}" | tee "{{outputs.artifacts.text.path}}" | wc -l > "{{outputs.parameters.actual-lines-count.path}}"']
 `
 
 func TestResolveIOArtifactPathPlaceholders(t *testing.T) {

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -163,6 +163,38 @@ func TestUnresolved(t *testing.T) {
 	}
 }
 
+var ioArtifactPaths = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: passthrough-
+spec:
+  entrypoint: passthrough
+  arguments:
+    artifacts:
+    - name: art
+      raw:
+        data: Hello World
+  templates:
+  - name: passthrough
+    inputs:
+      artifacts:
+      - name: art
+        path: /inputs/art/data
+    outputs:
+      artifacts:
+      - name: art
+        path: /outputs/art/data
+    container:
+      image: busybox
+      command: [cp, "{{inputs.artifacts.art.path}}", "{{outputs.artifacts.art.path}}"]
+`
+
+func TestResolveIOArtifactPathPlaceholders(t *testing.T) {
+	err := validate(ioArtifactPaths)
+	assert.Nil(t, err)
+}
+
 var stepOutputReferences = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -195,6 +195,30 @@ func TestResolveIOArtifactPathPlaceholders(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+var outputParameterPath = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: get-current-date-
+spec:
+  entrypoint: get-current-date
+  templates:
+  - name: get-current-date
+    outputs:
+      parameters:
+      - name: current-date
+        valueFrom:
+          path: /tmp/current-date
+    container:
+      image: busybox
+      command: [sh, -c, 'date > {{outputs.parameters.current-date.path}}']
+`
+
+func TestResolveOutputParameterPathPlaceholder(t *testing.T) {
+	err := validate(outputParameterPath)
+	assert.Nil(t, err)
+}
+
 var stepOutputReferences = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow


### PR DESCRIPTION
Adds the following placeholders that resolve to local file paths specified in the `inputs` /`outputs` sections:
* `{{inputs.artifacts.<NAME>.path}}`
* `{{outputs.artifacts.<NAME>.path}}`
* `{{outputs.parameters.<NAME>.path}}`

Fixes https://github.com/argoproj/argo/issues/1257