### PR TITLE
WIP: Add Task names to Pod names

### DIFF
--- a/cmd/argo/commands/get.go
+++ b/cmd/argo/commands/get.go
@@ -429,7 +429,7 @@ func printNode(w *tabwriter.Writer, wf *wfv1.Workflow, node wfv1.NodeStatus, dep
 	var args []interface{}
 	duration := humanize.RelativeDurationShort(node.StartedAt.Time, node.FinishedAt.Time)
 	if node.Type == wfv1.NodeTypePod {
-		args = []interface{}{nodePrefix, nodeName, node.ID, duration, node.Message}
+		args = []interface{}{nodePrefix, nodeName, wf.PodName(node.Name, node.ID), duration, node.Message}
 	} else {
 		args = []interface{}{nodePrefix, nodeName, "", "", node.Message}
 	}

--- a/cmd/argo/commands/logs.go
+++ b/cmd/argo/commands/logs.go
@@ -156,7 +156,7 @@ func (p *logPrinter) printRecentWorkflowLogs(wf *v1alpha1.Workflow) map[string]*
 		go func() {
 			defer wg.Done()
 			var podLogs []logEntry
-			err := p.getPodLogs(context.Background(), getDisplayName(node), node.ID, wf.Namespace, false, p.tail, p.sinceSeconds, p.sinceTime, func(entry logEntry) {
+			err := p.getPodLogs(context.Background(), getDisplayName(node), wf.PodName(node.Name, node.ID), wf.Namespace, false, p.tail, p.sinceSeconds, p.sinceTime, func(entry logEntry) {
 				podLogs = append(podLogs, entry)
 			})
 

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -94,7 +94,7 @@ func (woc *wfOperationCtx) createWorkflowPod(nodeName string, mainCtr apiv1.Cont
 	mainCtr.Name = common.MainContainerName
 	pod := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      nodeID,
+			Name:      woc.wf.PodName(nodeName, nodeID),
 			Namespace: woc.wf.ObjectMeta.Namespace,
 			Labels: map[string]string{
 				common.LabelKeyWorkflow:  woc.wf.ObjectMeta.Name, // Allows filtering by pods related to specific workflow

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -81,7 +81,7 @@ func TestScriptTemplateWithVolume(t *testing.T) {
 func TestWFLevelServiceAccount(t *testing.T) {
 	woc := newWoc()
 	woc.wf.Spec.ServiceAccountName = "foo"
-	woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+	woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 	podName := getPodName(woc.wf)
 	pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 	assert.Nil(t, err)
@@ -94,7 +94,7 @@ func TestTmplServiceAccount(t *testing.T) {
 	woc := newWoc()
 	woc.wf.Spec.ServiceAccountName = "foo"
 	woc.wf.Spec.Templates[0].ServiceAccountName = "tmpl"
-	woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+	woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 	podName := getPodName(woc.wf)
 	pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 	assert.Nil(t, err)
@@ -110,7 +110,7 @@ func TestWFLevelAutomountServiceAccountToken(t *testing.T) {
 	falseValue := false
 	woc.wf.Spec.AutomountServiceAccountToken = &falseValue
 	woc.wf.Spec.Executor = &wfv1.ExecutorConfig{ServiceAccountName: "foo"}
-	woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+	woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 	podName := getPodName(woc.wf)
 	pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 	assert.Nil(t, err)
@@ -128,7 +128,7 @@ func TestTmplLevelAutomountServiceAccountToken(t *testing.T) {
 	woc.wf.Spec.AutomountServiceAccountToken = &trueValue
 	woc.wf.Spec.Executor = &wfv1.ExecutorConfig{ServiceAccountName: "foo"}
 	woc.wf.Spec.Templates[0].AutomountServiceAccountToken = &falseValue
-	woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+	woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 	podName := getPodName(woc.wf)
 	pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 	assert.Nil(t, err)
@@ -152,7 +152,7 @@ func TestWFLevelExecutorServiceAccountName(t *testing.T) {
 	assert.NoError(t, err)
 
 	woc.wf.Spec.Executor = &wfv1.ExecutorConfig{ServiceAccountName: "foo"}
-	woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+	woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 	podName := getPodName(woc.wf)
 	pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 
@@ -174,7 +174,7 @@ func TestTmplLevelExecutorServiceAccountName(t *testing.T) {
 
 	woc.wf.Spec.Executor = &wfv1.ExecutorConfig{ServiceAccountName: "foo"}
 	woc.wf.Spec.Templates[0].Executor = &wfv1.ExecutorConfig{ServiceAccountName: "tmpl"}
-	woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+	woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 	podName := getPodName(woc.wf)
 	pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 
@@ -194,7 +194,7 @@ func TestImagePullSecrets(t *testing.T) {
 			Name: "secret-name",
 		},
 	}
-	woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+	woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 	podName := getPodName(woc.wf)
 	pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 	assert.Nil(t, err)
@@ -224,7 +224,7 @@ func TestAffinity(t *testing.T) {
 			},
 		},
 	}
-	woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+	woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 	podName := getPodName(woc.wf)
 	pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 	assert.Nil(t, err)
@@ -239,7 +239,7 @@ func TestTolerations(t *testing.T) {
 		Operator: "Exists",
 		Effect:   "NoSchedule",
 	}}
-	woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+	woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 	podName := getPodName(woc.wf)
 	pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 	assert.Nil(t, err)
@@ -250,7 +250,7 @@ func TestTolerations(t *testing.T) {
 // TestMetadata verifies ability to carry forward annotations and labels
 func TestMetadata(t *testing.T) {
 	woc := newWoc()
-	woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+	woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 	podName := getPodName(woc.wf)
 	pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 
@@ -377,7 +377,7 @@ func TestVolumeAndVolumeMounts(t *testing.T) {
 		woc.wf.Spec.Templates[0].Container.VolumeMounts = volumeMounts
 		woc.controller.Config.ContainerRuntimeExecutor = common.ContainerRuntimeExecutorDocker
 
-		woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+		woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 		podName := getPodName(woc.wf)
 		pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 		assert.Nil(t, err)
@@ -396,7 +396,7 @@ func TestVolumeAndVolumeMounts(t *testing.T) {
 		woc.wf.Spec.Templates[0].Container.VolumeMounts = volumeMounts
 		woc.controller.Config.ContainerRuntimeExecutor = common.ContainerRuntimeExecutorKubelet
 
-		woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+		woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 		podName := getPodName(woc.wf)
 		pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 		assert.Nil(t, err)
@@ -414,7 +414,7 @@ func TestVolumeAndVolumeMounts(t *testing.T) {
 		woc.wf.Spec.Templates[0].Container.VolumeMounts = volumeMounts
 		woc.controller.Config.ContainerRuntimeExecutor = common.ContainerRuntimeExecutorK8sAPI
 
-		woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+		woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 		podName := getPodName(woc.wf)
 		pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 		assert.Nil(t, err)
@@ -457,7 +457,7 @@ func TestVolumesPodSubstitution(t *testing.T) {
 	woc.wf.Spec.Templates[0].Inputs.Parameters = inputParameters
 	woc.controller.Config.ContainerRuntimeExecutor = common.ContainerRuntimeExecutorDocker
 
-	woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+	woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 	podName := getPodName(woc.wf)
 	pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 	assert.Nil(t, err)
@@ -491,7 +491,7 @@ func TestOutOfCluster(t *testing.T) {
 			SecretKey:  "bar",
 		}
 
-		woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+		woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 		podName := getPodName(woc.wf)
 		pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 
@@ -513,7 +513,7 @@ func TestOutOfCluster(t *testing.T) {
 			VolumeName: "kube-config-secret",
 		}
 
-		woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+		woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 		podName := getPodName(woc.wf)
 		pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 
@@ -533,7 +533,7 @@ func TestPriority(t *testing.T) {
 	woc := newWoc()
 	woc.wf.Spec.Templates[0].PriorityClassName = "foo"
 	woc.wf.Spec.Templates[0].Priority = &priority
-	woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+	woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 	podName := getPodName(woc.wf)
 	pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 	assert.Nil(t, err)
@@ -545,7 +545,7 @@ func TestPriority(t *testing.T) {
 func TestSchedulerName(t *testing.T) {
 	woc := newWoc()
 	woc.wf.Spec.Templates[0].SchedulerName = "foo"
-	woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+	woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 	podName := getPodName(woc.wf)
 	pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 	assert.Nil(t, err)
@@ -595,7 +595,7 @@ func TestInitContainers(t *testing.T) {
 		},
 	}
 
-	woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+	woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 	podName := getPodName(woc.wf)
 	pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 	assert.Nil(t, err)
@@ -652,7 +652,7 @@ func TestSidecars(t *testing.T) {
 		},
 	}
 
-	woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+	woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 	podName := getPodName(woc.wf)
 	pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 	assert.Nil(t, err)
@@ -702,7 +702,7 @@ func TestTemplateLocalVolumes(t *testing.T) {
 	woc.wf.Spec.Templates[0].Container.VolumeMounts = volumeMounts
 	woc.wf.Spec.Templates[0].Volumes = localVolumes
 
-	woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+	woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 	podName := getPodName(woc.wf)
 	pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 	assert.Nil(t, err)
@@ -721,7 +721,7 @@ func TestWFLevelHostAliases(t *testing.T) {
 		{IP: "127.0.0.1"},
 		{IP: "127.0.0.1"},
 	}
-	woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+	woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 	podName := getPodName(woc.wf)
 	pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 	assert.Nil(t, err)
@@ -736,7 +736,7 @@ func TestTmplLevelHostAliases(t *testing.T) {
 		{IP: "127.0.0.1"},
 		{IP: "127.0.0.1"},
 	}
-	woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+	woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 	podName := getPodName(woc.wf)
 	pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 	assert.Nil(t, err)
@@ -751,7 +751,7 @@ func TestWFLevelSecurityContext(t *testing.T) {
 	woc.wf.Spec.SecurityContext = &apiv1.PodSecurityContext{
 		RunAsUser: &runAsUser,
 	}
-	woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+	woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 	podName := getPodName(woc.wf)
 	pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 	assert.Nil(t, err)
@@ -766,7 +766,7 @@ func TestTmplLevelSecurityContext(t *testing.T) {
 	woc.wf.Spec.Templates[0].SecurityContext = &apiv1.PodSecurityContext{
 		RunAsUser: &runAsUser,
 	}
-	woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
+	woc.executeContainer(woc.wf.ObjectMeta.Name, &woc.wf.Spec.Templates[0], &wfv1.Template{}, "")
 	podName := getPodName(woc.wf)
 	pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
 	assert.Nil(t, err)


### PR DESCRIPTION
* This proposal adds the name of each task to the name of the pod it is
  associated with. This makes it easier to keep track of which pod is
  performing which task.

Still a work in progress - unit tests are failing, and there's probably a better way to deal with parentheses.

This would close https://github.com/argoproj/argo/issues/1319 if it is accepted.

Let me know what you think :)