### PR TITLE
fix multiple ssh key

### DIFF
--- a/workflow/artifacts/git/git.go
+++ b/workflow/artifacts/git/git.go
@@ -58,20 +58,9 @@ func writePrivateKey(key string, insecureIgnoreHostKey bool) error {
 		return errors.InternalWrapError(err)
 	}
 	sshDir := fmt.Sprintf("%s/.ssh", usr.HomeDir)
-
-	if _, err = os.Stat(sshDir); err != nil {
-
-		if os.IsNotExist(err) {
-
-			err = os.Mkdir(sshDir, 0700)
-			if err != nil {
-				return errors.InternalWrapError(err)
-			}
-
-		} else {
-			return errors.InternalWrapError(err)
-		}
-
+	err = os.MkdirAll(sshDir, 0700)
+	if err != nil {
+		return errors.InternalWrapError(err)
 	}
 
 	if insecureIgnoreHostKey {

--- a/workflow/artifacts/git/git.go
+++ b/workflow/artifacts/git/git.go
@@ -58,9 +58,20 @@ func writePrivateKey(key string, insecureIgnoreHostKey bool) error {
 		return errors.InternalWrapError(err)
 	}
 	sshDir := fmt.Sprintf("%s/.ssh", usr.HomeDir)
-	err = os.Mkdir(sshDir, 0700)
-	if err != nil {
-		return errors.InternalWrapError(err)
+
+	if _, err = os.Stat(sshDir); err != nil {
+
+		if os.IsNotExist(err) {
+
+			err = os.Mkdir(sshDir, 0700)
+			if err != nil {
+				return errors.InternalWrapError(err)
+			}
+
+		} else {
+			return errors.InternalWrapError(err)
+		}
+
 	}
 
 	if insecureIgnoreHostKey {


### PR DESCRIPTION
The current implementation for git (using ssh key) does't works fine with multiples `git` artifacts are defined:
```
  - name: code
     path: /workdir/src
     git:
         ...
   - name: plywood
      path: /workdir/src/plywood
      git:
          repo: ....
```
It returns error `failed to load artifacts: mkdir /root/.ssh: file exists`

The reason fo that is the creation of `~/.ssh` many times which is failing at the second key in the list even if it is the same key.

This PR simply check if the directory exists or not before trying to create it. 