### PR TITLE
Make locating kubeconfig in example os independent

### DIFF
--- a/docs/example-golang/main.go
+++ b/docs/example-golang/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"os"
+	"os/user"
 	"path/filepath"
 
 	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
@@ -36,8 +36,12 @@ var (
 )
 
 func main() {
-	// use the current context in kubeconfig
-	kubeconfig := flag.String("kubeconfig", filepath.Join(os.Getenv("HOME"), ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+	// get current user to determine home directory
+	usr, err := user.Current()
+	checkErr(err)
+
+	// get kubeconfig file location
+	kubeconfig := flag.String("kubeconfig", filepath.Join(usr.HomeDir, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
 	flag.Parse()
 
 	// use the current context in kubeconfig


### PR DESCRIPTION
Make locating kubeconfig in example os independent. This addresses issue #1392.