### PR TITLE
PNS executor intermitently failed to capture entire log of script templates

### DIFF
--- a/workflow/executor/pns/pns.go
+++ b/workflow/executor/pns/pns.go
@@ -224,6 +224,7 @@ func (p *PNSExecutor) GetOutputStream(containerID string, combinedOutput bool) (
 	}
 	opts := v1.PodLogOptions{
 		Container: common.MainContainerName,
+		Follow:    true,
 	}
 	return p.clientset.CoreV1().Pods(p.namespace).GetLogs(p.podName, &opts).Stream()
 }


### PR DESCRIPTION
Due to timing issues, PNS would intermittently fail to capture the logs of a script container, instead returning an empty string. Adding the follow option resolved the issue.