### PR TITLE
Add paging function for list command

### DIFF
--- a/cmd/argo/commands/list.go
+++ b/cmd/argo/commands/list.go
@@ -30,7 +30,7 @@ type listFlags struct {
 	running       bool   // --running
 	output        string // --output
 	since         string // --since
-	limit         int64  // --limit
+	chunkSize     int64  // --chunk-size
 }
 
 func NewListCommand() *cobra.Command {
@@ -62,7 +62,9 @@ func NewListCommand() *cobra.Command {
 				labelSelector = labelSelector.Add(*req)
 			}
 			listOpts.LabelSelector = labelSelector.String()
-			listOpts.Limit = listArgs.limit
+			if listArgs.chunkSize != 0 {
+				listOpts.Limit = listArgs.chunkSize
+			}
 			wfList, err := wfClient.List(listOpts)
 			if err != nil {
 				log.Fatal(err)
@@ -114,7 +116,7 @@ func NewListCommand() *cobra.Command {
 	command.Flags().BoolVar(&listArgs.running, "running", false, "Show only running workflows")
 	command.Flags().StringVarP(&listArgs.output, "output", "o", "", "Output format. One of: wide|name")
 	command.Flags().StringVar(&listArgs.since, "since", "", "Show only workflows newer than a relative duration")
-	command.Flags().Int64VarP(&listArgs.limit, "limit", "", 100, "Limit per num in one request")
+	command.Flags().Int64VarP(&listArgs.chunkSize, "chunk-size", "", 500, "Return large lists in chunks rather than all at once. Pass 0 to disable.")
 	return command
 }
 

--- a/cmd/argo/commands/list.go
+++ b/cmd/argo/commands/list.go
@@ -30,6 +30,7 @@ type listFlags struct {
 	running       bool   // --running
 	output        string // --output
 	since         string // --since
+	limit         int64  // --limit
 }
 
 func NewListCommand() *cobra.Command {
@@ -61,20 +62,33 @@ func NewListCommand() *cobra.Command {
 				labelSelector = labelSelector.Add(*req)
 			}
 			listOpts.LabelSelector = labelSelector.String()
+			listOpts.Limit = listArgs.limit
 			wfList, err := wfClient.List(listOpts)
 			if err != nil {
 				log.Fatal(err)
 			}
+
+			var tmpWorkFlows []wfv1.Workflow
+			tmpWorkFlows = wfList.Items
+			for wfList.ListMeta.Continue != "" {
+				listOpts.Continue = wfList.ListMeta.Continue
+				wfList, err = wfClient.List(listOpts)
+				if err != nil {
+					log.Fatal(err)
+				}
+				tmpWorkFlows = append(tmpWorkFlows, wfList.Items...)
+			}
+
 			var workflows []wfv1.Workflow
 			if listArgs.since == "" {
-				workflows = wfList.Items
+				workflows = tmpWorkFlows
 			} else {
 				workflows = make([]wfv1.Workflow, 0)
 				minTime, err := argotime.ParseSince(listArgs.since)
 				if err != nil {
 					log.Fatal(err)
 				}
-				for _, wf := range wfList.Items {
+				for _, wf := range tmpWorkFlows {
 					if wf.Status.FinishedAt.IsZero() || wf.ObjectMeta.CreationTimestamp.After(*minTime) {
 						workflows = append(workflows, wf)
 					}
@@ -100,6 +114,7 @@ func NewListCommand() *cobra.Command {
 	command.Flags().BoolVar(&listArgs.running, "running", false, "Show only running workflows")
 	command.Flags().StringVarP(&listArgs.output, "output", "o", "", "Output format. One of: wide|name")
 	command.Flags().StringVar(&listArgs.since, "since", "", "Show only workflows newer than a relative duration")
+	command.Flags().Int64VarP(&listArgs.limit, "limit", "", 100, "Limit per num in one request")
 	return command
 }
 


### PR DESCRIPTION
For some k8s cluster which already run many workflows.   The argo list command will return about 1-2k+ workflows.  In this situation, argo list will output error message like this 

```
stream error http2.streamerror{streamid:0x1, code:0x2, cause:error(nil)} w
```

To avoid this situation, we should set the limit for argo list command,  this will increase argo list command usability and robustness.

@jessesuen @sarabala1979   Pls take a look. 