### PR TITLE
Typo fix in ARTIFACT_REPO.md

### DIFF
--- a/ARTIFACT_REPO.md
+++ b/ARTIFACT_REPO.md
@@ -154,7 +154,7 @@ The `endpoint`, `accessKeySecret` and `secretKeySecret` are the same as for conf
         path: /my-ouput-artifact
         s3:
           endpoint: storage.googleapis.com
-          bucket: my-aws-bucket-name
+          bucket: my-gcs-bucket-name
           # NOTE that all output artifacts are automatically tarred and
           # gzipped before saving. So as a best practice, .tgz or .tar.gz
           # should be incorporated into the key name so the resulting file


### PR DESCRIPTION
In the non-default artifact repo section, when showing the gcs example the bucket name said 'my-aws-bucket-name'. I've updated this to say 'my-gcs-bucket-name'.

Super minor change but I've been banging my head against artifact repo outputs all day and this was bothering me.

See issue #1424 