### PR TITLE
Improve bash completion

### DIFF
--- a/cmd/argo/commands/completion.go
+++ b/cmd/argo/commands/completion.go
@@ -36,7 +36,7 @@ __argo_get_logs() {
 
 	# Otherwise, complete the list of pods
 	local -a kubectl_out
-	if kubectl_out=($(kubectl get pods --no-headers --label-columns=workflows.argoproj.io/workflow | awk '{if ($6!="") print $1}')); then
+	if kubectl_out=($(kubectl get pods --no-headers --label-columns=workflows.argoproj.io/workflow 2>/dev/null | awk '{if ($6!="") print $1}' 2>/dev/null)); then
 		COMPREPLY+=( $( compgen -W "${kubectl_out[*]}" -- "$cur" ) )
 	fi
 }

--- a/cmd/argo/commands/completion.go
+++ b/cmd/argo/commands/completion.go
@@ -40,6 +40,10 @@ __argo_get_logs() {
 	fi
 }
 
+__argo_list_manifest_files() {
+	COMPREPLY+=( $( compgen -f -o plusdirs -X '!*.@(yaml|yml|json)' -- "$cur" ) )
+}
+
 __argo_custom_func() {
 	case ${last_command} in
 		argo_delete | argo_get |\
@@ -50,6 +54,9 @@ __argo_custom_func() {
 			;;
 		argo_logs)
 			__argo_get_logs
+			;;
+		argo_submit)
+			__argo_list_manifest_files
 			;;
 		*)
 			;;

--- a/cmd/argo/commands/completion.go
+++ b/cmd/argo/commands/completion.go
@@ -13,8 +13,8 @@ const (
 	bashCompletionFunc = `
 __argo_get_workflow() {
 	local status="$1"
-	local argo_out
-	if argo_out=$(argo list --status="$status" --output name 2>/dev/null); then
+	local -a argo_out
+	if argo_out=($(argo list --status="$status" --output name 2>/dev/null)); then
 		COMPREPLY+=( $( compgen -W "${argo_out[*]}" -- "$cur" ) )
 	fi
 }
@@ -35,8 +35,8 @@ __argo_get_logs() {
 	fi
 
 	# Otherwise, complete the list of pods
-	local kubectl_out
-	if kubectl_out=$(kubectl get pods --no-headers --label-columns=workflows.argoproj.io/workflow | awk '{if ($6!="") print $1}'); then
+	local -a kubectl_out
+	if kubectl_out=($(kubectl get pods --no-headers --label-columns=workflows.argoproj.io/workflow | awk '{if ($6!="") print $1}')); then
 		COMPREPLY+=( $( compgen -W "${kubectl_out[*]}" -- "$cur" ) )
 	fi
 }

--- a/cmd/argo/commands/completion.go
+++ b/cmd/argo/commands/completion.go
@@ -12,8 +12,9 @@ import (
 const (
 	bashCompletionFunc = `
 __argo_get_workflow() {
+	local status="$1"
 	local argo_out
-	if argo_out=$(argo list --output name 2>/dev/null); then
+	if argo_out=$(argo list --status="$status" --output name 2>/dev/null); then
 		COMPREPLY+=( $( compgen -W "${argo_out[*]}" -- "$cur" ) )
 	fi
 }
@@ -46,17 +47,29 @@ __argo_list_manifest_files() {
 
 __argo_custom_func() {
 	case ${last_command} in
-		argo_delete | argo_get |\
-		argo_resubmit | argo_resume | argo_retry | argo_suspend |\
-		argo_terminate | argo_wait | argo_watch)
+		argo_delete | argo_get | argo_resubmit)
 			__argo_get_workflow
+			return
+			;;
+		argo_suspend | argo_terminate | argo_wait | argo_watch)
+			__argo_get_workflow "Running,Pending"
+			return
+			;;
+		argo_resume)
+			__argo_get_workflow "Running"
+			return
+			;;
+		argo_retry)
+			__argo_get_workflow "Failed"
 			return
 			;;
 		argo_logs)
 			__argo_get_logs
+			return
 			;;
 		argo_submit)
 			__argo_list_manifest_files
+			return
 			;;
 		*)
 			;;

--- a/cmd/argo/commands/completion.go
+++ b/cmd/argo/commands/completion.go
@@ -41,7 +41,7 @@ __argo_get_logs() {
 	fi
 }
 
-__argo_list_manifest_files() {
+__argo_list_files() {
 	COMPREPLY+=( $( compgen -f -o plusdirs -X '!*.@(yaml|yml|json)' -- "$cur" ) )
 }
 
@@ -68,7 +68,11 @@ __argo_custom_func() {
 			return
 			;;
 		argo_submit)
-			__argo_list_manifest_files
+			__argo_list_files
+			return
+			;;
+		argo_lint)
+			__argo_list_files
 			return
 			;;
 		*)

--- a/cmd/argo/commands/list.go
+++ b/cmd/argo/commands/list.go
@@ -24,13 +24,13 @@ import (
 )
 
 type listFlags struct {
-	allNamespaces bool   // --all-namespaces
-	status        string // --status
-	completed     bool   // --completed
-	running       bool   // --running
-	output        string // --output
-	since         string // --since
-	chunkSize     int64  // --chunk-size
+	allNamespaces bool     // --all-namespaces
+	status        []string // --status
+	completed     bool     // --completed
+	running       bool     // --running
+	output        string   // --output
+	since         string   // --since
+	chunkSize     int64    // --chunk-size
 }
 
 func NewListCommand() *cobra.Command {
@@ -49,8 +49,8 @@ func NewListCommand() *cobra.Command {
 			}
 			listOpts := metav1.ListOptions{}
 			labelSelector := labels.NewSelector()
-			if listArgs.status != "" {
-				req, _ := labels.NewRequirement(common.LabelKeyPhase, selection.In, strings.Split(listArgs.status, ","))
+			if len(listArgs.status) != 0 {
+				req, _ := labels.NewRequirement(common.LabelKeyPhase, selection.In, listArgs.status)
 				labelSelector = labelSelector.Add(*req)
 			}
 			if listArgs.completed {
@@ -111,7 +111,7 @@ func NewListCommand() *cobra.Command {
 		},
 	}
 	command.Flags().BoolVar(&listArgs.allNamespaces, "all-namespaces", false, "Show workflows from all namespaces")
-	command.Flags().StringVar(&listArgs.status, "status", "", "Filter by status (comma separated)")
+	command.Flags().StringSliceVar(&listArgs.status, "status", []string{}, "Filter by status (comma separated)")
 	command.Flags().BoolVar(&listArgs.completed, "completed", false, "Show only completed workflows")
 	command.Flags().BoolVar(&listArgs.running, "running", false, "Show only running workflows")
 	command.Flags().StringVarP(&listArgs.output, "output", "o", "", "Output format. One of: wide|name")

--- a/cmd/argo/commands/list.go
+++ b/cmd/argo/commands/list.go
@@ -51,7 +51,9 @@ func NewListCommand() *cobra.Command {
 			labelSelector := labels.NewSelector()
 			if len(listArgs.status) != 0 {
 				req, _ := labels.NewRequirement(common.LabelKeyPhase, selection.In, listArgs.status)
-				labelSelector = labelSelector.Add(*req)
+				if req != nil {
+					labelSelector = labelSelector.Add(*req)
+				}
 			}
 			if listArgs.completed {
 				req, _ := labels.NewRequirement(common.LabelKeyCompleted, selection.Equals, []string{"true"})

--- a/cmd/argo/commands/submit.go
+++ b/cmd/argo/commands/submit.go
@@ -59,7 +59,10 @@ func NewSubmitCommand() *cobra.Command {
 	command.Flags().Int32Var(&priority, "priority", 0, "workflow priority")
 	command.Flags().StringVarP(&submitOpts.ParameterFile, "parameter-file", "f", "", "pass a file containing all input parameters")
 	// Only complete files with appropriate extension.
-	command.Flags().SetAnnotation("parameter-file", cobra.BashCompFilenameExt, []string{"json", "yaml", "yml"})
+	err := command.Flags().SetAnnotation("parameter-file", cobra.BashCompFilenameExt, []string{"json", "yaml", "yml"})
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	return command
 }

--- a/cmd/argo/commands/submit.go
+++ b/cmd/argo/commands/submit.go
@@ -50,7 +50,6 @@ func NewSubmitCommand() *cobra.Command {
 	command.Flags().StringVar(&submitOpts.GenerateName, "generate-name", "", "override metadata.generateName")
 	command.Flags().StringVar(&submitOpts.Entrypoint, "entrypoint", "", "override entrypoint")
 	command.Flags().StringArrayVarP(&submitOpts.Parameters, "parameter", "p", []string{}, "pass an input parameter")
-	command.Flags().StringVarP(&submitOpts.ParameterFile, "parameter-file", "f", "", "pass a file containing all input parameters")
 	command.Flags().StringVar(&submitOpts.ServiceAccount, "serviceaccount", "", "run all pods in the workflow using specified serviceaccount")
 	command.Flags().StringVar(&submitOpts.InstanceID, "instanceid", "", "submit with a specific controller's instance id label")
 	command.Flags().StringVarP(&cliSubmitOpts.output, "output", "o", "", "Output format. One of: name|json|yaml|wide")
@@ -58,6 +57,10 @@ func NewSubmitCommand() *cobra.Command {
 	command.Flags().BoolVar(&cliSubmitOpts.watch, "watch", false, "watch the workflow until it completes")
 	command.Flags().BoolVar(&cliSubmitOpts.strict, "strict", true, "perform strict workflow validation")
 	command.Flags().Int32Var(&priority, "priority", 0, "workflow priority")
+	command.Flags().StringVarP(&submitOpts.ParameterFile, "parameter-file", "f", "", "pass a file containing all input parameters")
+	// Only complete files with appropriate extension.
+	command.Flags().SetAnnotation("parameter-file", cobra.BashCompFilenameExt, []string{"json", "yaml", "yml"})
+
 	return command
 }
 


### PR DESCRIPTION
# bash completion improvements

Resolve Issue #1436 and #1440, to improve user experience for command-line completion with bash.

## Installation

This is what I'm doing on my Mac.  You just need to write the completion script to a file so you can source it.

```
make cli
sudo cp -R dist/argo `which argo`
argo completion bash > /usr/local/etc/bash_completion.d/argo
. /usr/local/etc/bash_completion.d/argo
```

## Improvements
#### Complete "logs" command with either pods or workflows as appropriate

```
Edwins-MacBook-Pro:argo edwin$ argo logs 
artifact-passing-br72f-4272859315  coinflip-5ktdk-666293366           coinflip-qvqbl-630379513           steps-ptdtq-1129304726
artifact-passing-br72f-570194761   coinflip-jg4g6-2175945733          coinflip-rd6v4-1951658687          steps-ptdtq-126479429
artifact-passing-mldqq-3331757295  coinflip-jmvx7-2288525212          coinflip-rd6v4-2832038430          steps-sp22h-1028943132
artifact-passing-zg55d-1757963829  coinflip-jmvx7-830609345           coinflip-s9xdk-1282470043          steps-sp22h-1079275989
artifact-passing-zg55d-3501659643  coinflip-m587w-2484450197          coinflip-s9xdk-3902802574          steps-sp22h-3280091627
coinflip-5ktdk-3334567571          coinflip-qvqbl-1757769684          steps-ptdtq-1112527107             
Edwins-MacBook-Pro:argo edwin$ argo logs coinflip-qvqbl-1757769684
it was heads
Edwins-MacBook-Pro:argo edwin$ argo logs --workflow 
artifact-passing-br72f  coinflip-5ktdk          coinflip-m587w          coinflip-s9xdk          steps-sp22h             
artifact-passing-mldqq  coinflip-jg4g6          coinflip-qvqbl          conditional-ntp9c       
artifact-passing-zg55d  coinflip-jmvx7          coinflip-rd6v4          steps-ptdtq             
Edwins-MacBook-Pro:argo edwin$ argo logs --workflow coinflip-qvqbl
flip-coin:      heads
heads:  it was heads
```

#### "submit" command completes only yaml/yml or json files

```
Edwins-MacBook-Pro:argo edwin$ argo submit 
.argo-ci           assets             docs               gometalinter.json  pkg                vendor             
.git               cmd                errors             hack               test               workflow           
.github            community          examples           hooks              ui                 
api                dist               golangci.yml       manifests          util               
```

#### "list --status=' '" should return the same thing as naked "list" rather than SIGSEGV

```
ejacques-mbp:argo ejacques$ argo list --status=" "
NAME                     STATUS      AGE   DURATION   PRIORITY
artifact-passing-2dw47   Succeeded   41m   55s        0
artifact-passing-dbsb7   Succeeded   42m   10s        0
artifact-passing-zz549   Succeeded   48m   11s        0
resubmit-znlpk           Error       3h    0s         0
artifact-passing-2nrvn   Succeeded   3h    1m         0
artifact-passing-mr9vg   Succeeded   3h    11s        0
artifact-passing-gtz8d   Succeeded   3h    10s        0
artifact-passing-dvzsl   Succeeded   3h    10s        0
```
#### "suspend/resume/terminate/wait/watch" should complete only Running,Pending workflows
```

ejacques-mbp:argo ejacques$ argo submit examples/artifact-passing.yaml 
Name:                artifact-passing-b8s6q
Namespace:           argo
ServiceAccount:      default
Status:              Pending
Created:             Wed Jun 19 15:40:28 -0400 (1 second ago)
ejacques-mbp:argo ejacques$ argo watch artifact-passing-b8s6q 
ejacques-mbp:argo ejacques$ argo submit examples/artifact-passing.yaml 
Name:                artifact-passing-6bkj7
Namespace:           argo
ServiceAccount:      default
Status:              Pending
Created:             Wed Jun 19 15:41:03 -0400 (1 second ago)
ejacques-mbp:argo ejacques$ argo suspend artifact-passing-6bkj7 
workflow artifact-passing-6bkj7 suspended
ejacques-mbp:argo ejacques$ argo resume artifact-passing-6bkj7
workflow artifact-passing-6bkj7 resumed

ejacques-mbp:argo ejacques$ argo submit examples/artifact-passing.yaml 
Name:                artifact-passing-44qcn
Namespace:           argo
ServiceAccount:      default
Status:              Pending
Created:             Wed Jun 19 15:42:00 -0400 (now)
ejacques-mbp:argo ejacques$ argo terminate artifact-passing-44qcn 
Workflow 'artifact-passing-44qcn' terminated

ejacques-mbp:argo ejacques$ argo submit examples/artifact-passing.yaml 
Name:                artifact-passing-9b9nm
Namespace:           argo
ServiceAccount:      default
Status:              Pending
Created:             Wed Jun 19 15:43:38 -0400 (1 second ago)
ejacques-mbp:argo ejacques$ argo wait artifact-passing-9b9nm 
artifact-passing-9b9nm completed at 2019-06-19 15:43:49 -0400 EDT
ejacques-mbp:argo ejacques$ 
```

#### "retry" should only complete failed workflows

```
ejacques-mbp:argo ejacques$ argo retry artifact-passing-44qcn 
INFO[0000] Deleting pod: artifact-passing-44qcn-3047876622 
Name:                artifact-passing-44qcn
Namespace:           argo
ServiceAccount:      default
Status:              Running
Created:             Wed Jun 19 15:42:00 -0400 (5 minutes ago)
Started:             Wed Jun 19 15:42:00 -0400 (5 minutes ago)
Duration:            5 minutes 38 seconds
```