### PR TITLE
docs: Fix demo's doc issue of install minio chart

### DIFF
--- a/demo.md
+++ b/demo.md
@@ -77,7 +77,8 @@ helm install stable/minio \
   --set service.type=LoadBalancer \
   --set defaultBucket.enabled=true \
   --set defaultBucket.name=my-bucket \
-  --set persistence.enabled=false
+  --set persistence.enabled=false \
+  --set fullnameOverride=argo-artifacts
 ```
 
 Login to the Minio UI using a web browser (port 9000) after exposing obtaining the external IP using `kubectl`.


### PR DESCRIPTION
Signed-off-by: Aisuko <urakiny@gmail.com>

Follow the demo's doc,  there may have some misunderstanding，please see link below

https://github.com/helm/charts/blob/62b33b47d8ffd8c9fa2c727a2a962f1754a0eb5d/stable/minio/templates/_helpers.tpl#L15

So, If you would like to install `minio chart` as name `argo-artifacts`, the `fullnameOverride ` is more helpful then `--name`, it's a release name for `helm`.

