### PR TITLE
Allow overriding workflow labels in 'argo submit'

### DIFF
--- a/cmd/argo/commands/submit.go
+++ b/cmd/argo/commands/submit.go
@@ -58,6 +58,7 @@ func NewSubmitCommand() *cobra.Command {
 	command.Flags().BoolVar(&cliSubmitOpts.strict, "strict", true, "perform strict workflow validation")
 	command.Flags().Int32Var(&priority, "priority", 0, "workflow priority")
 	command.Flags().StringVarP(&submitOpts.ParameterFile, "parameter-file", "f", "", "pass a file containing all input parameters")
+	command.Flags().StringVarP(&submitOpts.Labels, "labels", "l", "", "Comma separated labels to apply to the workflow. Will override previous values.")
 	// Only complete files with appropriate extension.
 	err := command.Flags().SetAnnotation("parameter-file", cobra.BashCompFilenameExt, []string{"json", "yaml", "yml"})
 	if err != nil {

--- a/util/cmd/cmd.go
+++ b/util/cmd/cmd.go
@@ -88,3 +88,27 @@ func SetLogLevel(level string) {
 		log.Fatalf("Unknown level: %s", level)
 	}
 }
+
+// ParseLabels turns a string representation of a label set into a map[string]string
+func ParseLabels(labelSpec interface{}) (map[string]string, error) {
+	labelString, isString := labelSpec.(string)
+	if !isString {
+		return nil, fmt.Errorf("expected string, found %v", labelSpec)
+	}
+	if len(labelString) == 0 {
+		return nil, fmt.Errorf("no label spec passed")
+	}
+	labels := map[string]string{}
+	labelSpecs := strings.Split(labelString, ",")
+	for ix := range labelSpecs {
+		labelSpec := strings.Split(labelSpecs[ix], "=")
+		if len(labelSpec) != 2 {
+			return nil, fmt.Errorf("unexpected label spec: %s", labelSpecs[ix])
+		}
+		if len(labelSpec[0]) == 0 {
+			return nil, fmt.Errorf("unexpected empty label key")
+		}
+		labels[labelSpec[0]] = labelSpec[1]
+	}
+	return labels, nil
+}

--- a/util/cmd/cmd_test.go
+++ b/util/cmd/cmd_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMakeParseLabels(t *testing.T) {
+	successCases := []struct {
+		name     string
+		labels   string
+		expected map[string]string
+	}{
+		{
+			name:   "test1",
+			labels: "foo=false",
+			expected: map[string]string{
+				"foo": "false",
+			},
+		},
+		{
+			name:   "test2",
+			labels: "foo=true,bar=123",
+			expected: map[string]string{
+				"foo": "true",
+				"bar": "123",
+			},
+		},
+	}
+	for _, test := range successCases {
+		got, err := ParseLabels(test.labels)
+		if err != nil {
+			t.Errorf("unexpected error :%v", err)
+		}
+		if !reflect.DeepEqual(test.expected, got) {
+			t.Errorf("\nexpected:\n%v\ngot:\n%v", test.expected, got)
+		}
+	}
+
+	errorCases := []struct {
+		name   string
+		labels interface{}
+	}{
+		{
+			name:   "non-string",
+			labels: 123,
+		},
+		{
+			name:   "empty string",
+			labels: "",
+		},
+		{
+			name:   "error format",
+			labels: "abc=456;bcd=789",
+		},
+		{
+			name:   "error format",
+			labels: "abc=456.bcd=789",
+		},
+		{
+			name:   "error format",
+			labels: "abc,789",
+		},
+		{
+			name:   "error format",
+			labels: "abc",
+		},
+		{
+			name:   "error format",
+			labels: "=abc",
+		},
+	}
+	for _, test := range errorCases {
+		_, err := ParseLabels(test.labels)
+		if err == nil {
+			t.Errorf("labels %s expect error, reason: %s, got nil", test.labels, test.name)
+		}
+	}
+}

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -141,6 +141,7 @@ type SubmitOpts struct {
 	Parameters     []string               // --parameter
 	ParameterFile  string                 // --parameter-file
 	ServiceAccount string                 // --serviceaccount
+	Labels         string                 // --labels
 	OwnerReference *metav1.OwnerReference // useful if your custom controller creates argo workflow resources
 }
 
@@ -155,14 +156,17 @@ func SubmitWorkflow(wfIf v1alpha1.WorkflowInterface, wf *wfv1.Workflow, opts *Su
 	if opts.ServiceAccount != "" {
 		wf.Spec.ServiceAccountName = opts.ServiceAccount
 	}
-	if opts.InstanceID != "" {
-		labels := wf.GetLabels()
-		if labels == nil {
-			labels = make(map[string]string)
-		}
-		labels[common.LabelKeyControllerInstanceID] = opts.InstanceID
-		wf.SetLabels(labels)
+	labels := wf.GetLabels()
+	if opts.Labels != "" {
+		labels, _ = cmdutil.ParseLabels(opts.Labels)
 	}
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	if opts.InstanceID != "" {
+		labels[common.LabelKeyControllerInstanceID] = opts.InstanceID
+	}
+	wf.SetLabels(labels)
 	if len(opts.Parameters) > 0 || opts.ParameterFile != "" {
 		newParams := make([]wfv1.Parameter, 0)
 		passedParams := make(map[string]bool)

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -157,11 +157,17 @@ func SubmitWorkflow(wfIf v1alpha1.WorkflowInterface, wf *wfv1.Workflow, opts *Su
 		wf.Spec.ServiceAccountName = opts.ServiceAccount
 	}
 	labels := wf.GetLabels()
-	if opts.Labels != "" {
-		labels, _ = cmdutil.ParseLabels(opts.Labels)
-	}
 	if labels == nil {
 		labels = make(map[string]string)
+	}
+	if opts.Labels != "" {
+		passedLabels, err := cmdutil.ParseLabels(opts.Labels)
+		if err != nil {
+			return nil, fmt.Errorf("Expected labels of the form: NAME1=VALUE2,NAME2=VALUE2. Received: %s", opts.Labels)
+		}
+		for k, v := range passedLabels {
+			labels[k] = v
+		}
 	}
 	if opts.InstanceID != "" {
 		labels[common.LabelKeyControllerInstanceID] = opts.InstanceID


### PR DESCRIPTION
This PR allows overriding workflow labels in 'argo submit', the same way they can be overridden in 'kubectl run'