### PR TITLE
Expose all input parameters to template as JSON

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -6,6 +6,7 @@ The following variables are made available to reference various metadata of a wo
 | Variable | Description|
 |----------|------------|
 | `inputs.parameters.<NAME>`| Input parameter to a template |
+| `inputs.parameters`| All input parameters to a template as a JSON string |
 | `inputs.artifacts.<NAME>` | Input artifact to a template |
 
 ## Steps Templates:

--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -325,6 +325,12 @@ func substituteParams(tmpl *wfv1.Template, globalParams, localParams map[string]
 		}
 		replaceMap["inputs.parameters."+inParam.Name] = *inParam.Value
 	}
+	//allow {{inputs.parameters}} to fetch the entire input parameters list as JSON
+	jsonInputParametersBytes, err := json.Marshal(globalReplacedTmpl.Inputs.Parameters)
+	if err != nil {
+		return nil, errors.InternalWrapError(err)
+	}
+	replaceMap["inputs.parameters"] = string(jsonInputParametersBytes)
 	for _, inArt := range globalReplacedTmpl.Inputs.Artifacts {
 		if inArt.Path != "" {
 			replaceMap["inputs.artifacts."+inArt.Name+".path"] = inArt.Path
@@ -356,8 +362,7 @@ func substituteParams(tmpl *wfv1.Template, globalParams, localParams map[string]
 
 // Replace executes basic string substitution of a template with replacement values.
 // allowUnresolved indicates whether or not it is acceptable to have unresolved variables
-// remaining in the substituted template. prefixFilter will apply the replacements only
-// to variables with the specified prefix
+// remaining in the substituted template.
 func Replace(fstTmpl *fasttemplate.Template, replaceMap map[string]string, allowUnresolved bool) (string, error) {
 	var unresolvedErr error
 	replacedTmpl := fstTmpl.ExecuteFuncString(func(w io.Writer, tag string) (int, error) {

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -213,6 +213,9 @@ func validateInputs(tmpl *wfv1.Template) (map[string]interface{}, error) {
 	for _, param := range tmpl.Inputs.Parameters {
 		scope[fmt.Sprintf("inputs.parameters.%s", param.Name)] = true
 	}
+	if (len(tmpl.Inputs.Parameters) > 0) {
+		scope["inputs.parameters"] = true
+	}
 
 	for _, art := range tmpl.Inputs.Artifacts {
 		artRef := fmt.Sprintf("inputs.artifacts.%s", art.Name)

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -213,7 +213,7 @@ func validateInputs(tmpl *wfv1.Template) (map[string]interface{}, error) {
 	for _, param := range tmpl.Inputs.Parameters {
 		scope[fmt.Sprintf("inputs.parameters.%s", param.Name)] = true
 	}
-	if (len(tmpl.Inputs.Parameters) > 0) {
+	if len(tmpl.Inputs.Parameters) > 0 {
 		scope["inputs.parameters"] = true
 	}
 


### PR DESCRIPTION
This change allows you to use {{input.parameters}} to fetch the full parameters list as a JSON string.