### PR TITLE
Wildcard parameters and arguments

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -669,6 +669,14 @@
           "description": "Name is the parameter name",
           "type": "string"
         },
+        "passthroughRegexp": {
+          "description": "PassthroughRegexp matches argument multiple parameter names using a regexp and passes through their values",
+          "type": "string"
+        },
+        "regexp": {
+          "description": "Regexp matches multiple input parameter names using a regexp",
+          "type": "string"
+        },
         "value": {
           "description": "Value is the literal value to use for the parameter. If specified in the context of an input parameter, the value takes precedence over any passed values",
           "type": "string"

--- a/examples/passthrough-parameters.yaml
+++ b/examples/passthrough-parameters.yaml
@@ -1,0 +1,36 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: passthrough-parameters-
+spec:
+  entrypoint: passthrough-parameters-steps
+  arguments:
+    parameters:
+      - name: message
+        value: test1
+  templates:
+    - name: passthrough-parameters-steps
+      inputs:
+        parameters:
+          - regexp: ".*"
+      steps:
+        - - name: display-parameters
+            template: display-parameters
+            arguments:
+              parameters:
+                - passthroughRegexp: ".*"
+                - name: extra-parameter
+                  value: extra-value
+
+    - name: display-parameters
+      inputs:
+        parameters:
+          - name: message
+          - name: extra-parameter
+      script:
+        image: alpine:latest
+        command: [sh, -x]
+        source: |
+          #!/bin/sh
+          echo {{inputs.parameters.message}}
+          echo {{inputs.parameters.extra-parameter}}

--- a/pkg/apis/workflow/v1alpha1/openapi_generated.go
+++ b/pkg/apis/workflow/v1alpha1/openapi_generated.go
@@ -1245,6 +1245,20 @@ func schema_pkg_apis_workflow_v1alpha1_Parameter(ref common.ReferenceCallback) c
 							Format:      "",
 						},
 					},
+					"passthroughRegexp": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PassthroughRegexp matches argument multiple parameter names using a regexp and passes through their values",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"regexp": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Regexp matches multiple input parameter names using a regexp",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"default": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Default is the default value to use for an input parameter if a value was not supplied",

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -402,8 +402,16 @@ func (woc *wfOperationCtx) executeDAGTask(dagCtx *dagContext, taskName string) {
 			}
 		}
 
+		args := t.Arguments.DeepCopy()
+		updatedParameters, err := dagCtx.tmpl.Inputs.GetPassthroughParameters(args.Parameters)
+		if err != nil {
+			woc.initializeNode(nodeName, wfv1.NodeTypeSkipped, task, dagCtx.boundaryID, wfv1.NodeError, err.Error())
+			return
+		}
+		args.Parameters = updatedParameters
+
 		// Finally execute the template
-		_, _ = woc.executeTemplate(taskNodeName, &t, dagCtx.tmplCtx, t.Arguments, dagCtx.boundaryID)
+		_, _ = woc.executeTemplate(taskNodeName, &t, dagCtx.tmplCtx, args, dagCtx.boundaryID)
 	}
 
 	if taskGroupNode != nil {

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1128,8 +1128,7 @@ func (woc *wfOperationCtx) executeTemplate(nodeName string, orgTmpl wfv1.Templat
 		return node, ErrDeadlineExceeded
 	}
 
-	newTmplCtx, basedTmpl, err := woc.getResolvedTemplate(node, orgTmpl, tmplCtx, args)
-
+	newTmplCtx, basedTmpl, err := woc.getResolvedTemplate(node, orgTmpl, tmplCtx, *args)
 	if err != nil {
 		return woc.initializeNodeOrMarkError(node, nodeName, wfv1.NodeTypeSkipped, orgTmpl, boundaryID, err), err
 	}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -209,7 +209,7 @@ func (woc *wfOperationCtx) operate() {
 
 	var workflowStatus wfv1.NodePhase
 	var workflowMessage string
-	node, err := woc.executeTemplate(woc.wf.ObjectMeta.Name, &wfv1.Template{Template: woc.wf.Spec.Entrypoint}, woc.tmplCtx, woc.wf.Spec.Arguments, "")
+	node, err := woc.executeTemplate(woc.wf.ObjectMeta.Name, &wfv1.Template{Template: woc.wf.Spec.Entrypoint}, woc.tmplCtx, &woc.wf.Spec.Arguments, "")
 	if err != nil {
 		// the error are handled in the callee so just log it.
 		woc.log.Errorf("%s error in entry template execution: %+v", woc.wf.Name, err)
@@ -237,7 +237,7 @@ func (woc *wfOperationCtx) operate() {
 		}
 		woc.log.Infof("Running OnExit handler: %s", woc.wf.Spec.OnExit)
 		onExitNodeName := woc.wf.ObjectMeta.Name + ".onExit"
-		onExitNode, err = woc.executeTemplate(onExitNodeName, &wfv1.Template{Template: woc.wf.Spec.OnExit}, woc.tmplCtx, woc.wf.Spec.Arguments, "")
+		onExitNode, err = woc.executeTemplate(onExitNodeName, &wfv1.Template{Template: woc.wf.Spec.OnExit}, woc.tmplCtx, &woc.wf.Spec.Arguments, "")
 		if err != nil {
 			// the error are handled in the callee so just log it.
 			woc.log.Errorf("%s error in exit template execution: %+v", woc.wf.Name, err)
@@ -1103,7 +1103,7 @@ func (woc *wfOperationCtx) getLastChildNode(node *wfv1.NodeStatus) (*wfv1.NodeSt
 // for the created node (if created). Nodes may not be created if parallelism or deadline exceeded.
 // nodeName is the name to be used as the name of the node, and boundaryID indicates which template
 // boundary this node belongs to.
-func (woc *wfOperationCtx) executeTemplate(nodeName string, orgTmpl wfv1.TemplateHolder, tmplCtx *templateresolution.Context, args wfv1.Arguments, boundaryID string) (*wfv1.NodeStatus, error) {
+func (woc *wfOperationCtx) executeTemplate(nodeName string, orgTmpl wfv1.TemplateHolder, tmplCtx *templateresolution.Context, args *wfv1.Arguments, boundaryID string) (*wfv1.NodeStatus, error) {
 	woc.log.Debugf("Evaluating node %s: template: %s, boundaryID: %s", nodeName, common.GetTemplateHolderString(orgTmpl), boundaryID)
 
 	node := woc.getNodeByName(nodeName)

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -208,7 +208,15 @@ func (woc *wfOperationCtx) executeStepGroup(stepGroup []wfv1.WorkflowStep, sgNod
 			}
 			continue
 		}
-		childNode, err := woc.executeTemplate(childNodeName, &step, stepsCtx.tmplCtx, step.Arguments, stepsCtx.boundaryID)
+		args := step.Arguments.DeepCopy()
+		updatedParameters, err := stepsCtx.scope.tmpl.Inputs.GetPassthroughParameters(args.Parameters)
+		if err != nil {
+			return woc.markNodeError(sgNodeName, err)
+		}
+		args.Parameters = updatedParameters
+
+		childNode, err := woc.executeTemplate(childNodeName, &step, stepsCtx.tmplCtx, args, stepsCtx.boundaryID)
+
 		if err != nil {
 			switch err {
 			case ErrDeadlineExceeded:

--- a/workflow/templateresolution/context_test.go
+++ b/workflow/templateresolution/context_test.go
@@ -393,7 +393,8 @@ func TestResolveTemplate(t *testing.T) {
 	}
 	assert.Equal(t, "another-workflow-template", wftmpl.Name)
 	assert.Equal(t, "whalesay-with-passthrough-arguments", tmpl.Name)
-	assert.Equal(t, []string{"hello world"}, tmpl.Container.Args)
+	assert.Equal(t, []string{"{{inputs.parameters.message}}"}, tmpl.Container.Args)
+	assert.Equal(t, "hello world", *tmpl.Inputs.Parameters[0].Value)
 
 	// Get the template of nested template reference with arguments.
 	tmplHolder = wfv1.Template{

--- a/workflow/templateresolution/context_test.go
+++ b/workflow/templateresolution/context_test.go
@@ -383,7 +383,7 @@ func TestResolveTemplate(t *testing.T) {
 	tmplHolder = wfv1.Template{
 		TemplateRef: &wfv1.TemplateRef{Name: "some-workflow-template", Template: "whalesay-with-passthrough-arguments"},
 	}
-	ctx, tmpl, err = ctx.ResolveTemplate(&tmplHolder)
+	ctx, tmpl, err = ctx.ResolveTemplate(&tmplHolder, &wfv1.Arguments{Parameters: []wfv1.Parameter{{Name: "message", Value: &msgValue}}}, emptymap, emptymap, false)
 	if !assert.NoError(t, err) {
 		t.Fatal(err)
 	}

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -467,9 +467,9 @@ func FormulateResubmitWorkflow(wf *wfv1.Workflow, memoized bool) (*wfv1.Workflow
 }
 
 // convertNodeID converts an old nodeID to a new nodeID
-func convertNodeID(newWf *wfv1.Workflow, regex *regexp.Regexp, oldNodeID string, oldNodes map[string]wfv1.NodeStatus) string {
+func convertNodeID(newWf *wfv1.Workflow, regexp *regexp.Regexp, oldNodeID string, oldNodes map[string]wfv1.NodeStatus) string {
 	node := oldNodes[oldNodeID]
-	newNodeName := regex.ReplaceAllString(node.Name, newWf.ObjectMeta.Name)
+	newNodeName := regexp.ReplaceAllString(node.Name, newWf.ObjectMeta.Name)
 	return newWf.NodeID(newNodeName)
 }
 

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -880,14 +880,18 @@ func validateWorkflowArgumentParameterField(parameters []wfv1.Parameter) error {
 }
 
 // validateInputParameterField takes a set of input parameters and verifies
-// * Either Name or PassthroughRegexp is provided
-// * PassthroughRegexp is a valid regex if provided
+// * Either Name or Regexp is provided
+// * Regexp is a valid regex if provided
 // * Name validations
 func validateInputParameterField(parameters []wfv1.Parameter) error {
 
 	for i, parameter := range parameters {
 		if parameter.Name == "" && (parameter.Regexp == "") {
 			return errors.Errorf(errors.CodeBadRequest, "[%d].name or .regexp is required", i)
+		}
+
+		if parameter.PassthroughRegexp != "" {
+			return errors.Errorf(errors.CodeBadRequest, "[%d].passthroughRegexp is not permitted for arguments", i)
 		}
 
 		if parameter.Regexp != "" {
@@ -912,6 +916,9 @@ func validateArgumentParameterField(parameters []wfv1.Parameter) error {
 	for i, parameter := range parameters {
 		if parameter.Name == "" && (parameter.PassthroughRegexp == "") {
 			return errors.Errorf(errors.CodeBadRequest, "[%d].name or .passthroughRegexp is required", i)
+		}
+		if parameter.Regexp != "" {
+			return errors.Errorf(errors.CodeBadRequest, "[%d].regexp is not permitted for arguments", i)
 		}
 
 		if parameter.PassthroughRegexp != "" {

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -590,12 +590,6 @@ func (ctx *templateValidationCtx) validateSteps(scope map[string]interface{}, tm
 			if err != nil {
 				return err
 			}
-			//args := step.Arguments.DeepCopy()
-			//updatedParameters, err := tmpl.Inputs.GetPassthroughParameters(args.Parameters)
-			//if err != nil {
-			//	return err
-			//}
-			//args.Parameters = updatedParameters
 
 			resolvedTmpl, err := ctx.validateTemplateHolder(&step, tmplCtx, &FakeArguments{}, scope)
 			if err != nil {
@@ -608,8 +602,16 @@ func (ctx *templateValidationCtx) validateSteps(scope map[string]interface{}, tm
 			resolvedTmpl := resolvedTemplates[step.Name]
 			ctx.addOutputsToScope(resolvedTmpl, fmt.Sprintf("steps.%s", step.Name), scope, aggregate, false)
 
+			//include passthrough arguments in step arguments
+			stepArgs := step.Arguments.DeepCopy()
+			updatedParameters, err := tmpl.Inputs.GetPassthroughParameters(stepArgs.Parameters)
+			if err != nil {
+				return err
+			}
+			stepArgs.Parameters = updatedParameters
+
 			// Validate the template again with actual arguments.
-			_, err = ctx.validateTemplateHolder(&step, tmplCtx, &step.Arguments, scope)
+			_, err = ctx.validateTemplateHolder(&step, tmplCtx, stepArgs, scope)
 			if err != nil {
 				return errors.Errorf(errors.CodeBadRequest, "templates.%s.steps[%d].%s %s", tmpl.Name, i, step.Name, err.Error())
 			}

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -294,7 +294,7 @@ func TestPassthrough(t *testing.T) {
 
 	err = validate(badArgsRegex)
 	if assert.NotNil(t, err) {
-		assert.Contains(t, err.Error(), "regexp ( could not be processed")
+		assert.Contains(t, err.Error(), "error parsing regexp: missing closing ): `(`")
 	}
 
 	err = validate(badInputRegex)


### PR DESCRIPTION
This enables input parameters and arguments to be passed through using regexes, from suggestion by @dtaniwaki. It needs some further tidying and tests. Background scenario:

Using the WorkflowTemplate I’m creating a generic template that invokes a job (for example ‘SparkWorkflowTemplate’ that invokes a Spark job. This would take in a set of parameters that get passed onto Spark.

I don’t want to need to hardcode all the possible parameters that any Spark job may need into this ‘SparkWorkflowTemplate’, but at the moment it’s only possible to pass on explicitly declared parameters.