### PR TITLE
Change 'continue-on-fail' example to better reflect its description

### DIFF
--- a/examples/continue-on-fail.yaml
+++ b/examples/continue-on-fail.yaml
@@ -1,5 +1,5 @@
 # Example on specifying parallelism on the outer workflow and limiting the number of its
-# children workflowss to be run at the same time.
+# children workflows to be run at the same time.
 #
 # If the parallelism of A is 1, the four steps of seq-step will run sequentially.
 
@@ -9,6 +9,7 @@ metadata:
   generateName: continue-on-fail-
 spec:
   entrypoint: workflow-ignore
+  parallelism: 1
   templates:
   - name: workflow-ignore
     steps:


### PR DESCRIPTION
Researching how this `parallelism` config feature functions and came across this example that I think wasn't accurately reflecting the description it had at the top of the file. 

PS. Great work on Argo!