### PR TITLE
Fix the lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ STATIC_BUILD=true
 # build development images
 DEV_IMAGE=false
 
+GOLANGCI_EXISTS := $(shell command -v golangci-lint 2> /dev/null)
+
 override LDFLAGS += \
   -X ${PACKAGE}.version=${VERSION} \
   -X ${PACKAGE}.buildDate=${BUILD_DATE} \
@@ -127,9 +129,12 @@ endif
 
 .PHONY: lint
 lint:
+ifdef GOLANGCI_EXISTS
+	golangci-lint run --config golangci.yml
+else
 	# Remove gometalinter after a migration time.
-	(command -v golangci-lint >/dev/null 2>&1 && golangci-lint run --config golangci.yml) || \
 	gometalinter --config gometalinter.json ./...
+endif
 
 .PHONY: test
 test:

--- a/cmd/argo/commands/list.go
+++ b/cmd/argo/commands/list.go
@@ -72,8 +72,7 @@ func NewListCommand() *cobra.Command {
 				log.Fatal(err)
 			}
 
-			var tmpWorkFlows []wfv1.Workflow
-			tmpWorkFlows = wfList.Items
+			tmpWorkFlows := wfList.Items
 			for wfList.ListMeta.Continue != "" {
 				listOpts.Continue = wfList.ListMeta.Continue
 				wfList, err = wfClient.List(listOpts)

--- a/cmd/argoexec/commands/root.go
+++ b/cmd/argoexec/commands/root.go
@@ -2,8 +2,9 @@ package commands
 
 import (
 	"encoding/json"
-	"github.com/argoproj/argo/util"
 	"os"
+
+	"github.com/argoproj/argo/util"
 
 	"github.com/argoproj/pkg/cli"
 	kubecli "github.com/argoproj/pkg/kube/cli"

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -3,11 +3,12 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	"github.com/argoproj/argo/errors"
 	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo/workflow/common"
 	"github.com/valyala/fasttemplate"
-	"strings"
 )
 
 // dagContext holds context information about this context's DAG

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/argoproj/argo/util"
 	"io"
 	"io/ioutil"
 	"net/url"
@@ -19,6 +18,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/argoproj/argo/util"
 
 	argofile "github.com/argoproj/pkg/file"
 	log "github.com/sirupsen/logrus"


### PR DESCRIPTION
This fixes an issue with the `make lint` target, where if a developer
has golangci-lint installed and also has linter errors, the linter fails
with an error, causing the next case to fall through (and the old linter
is run).

This also fixes all of the linter errors that had somehow cropped up in
the repo.

This should be the resolve all the issues preventing `make precheckin` from passing.