### PR TITLE
Fix validation

### DIFF
--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -244,8 +244,8 @@ func ProcessArgs(tmpl *wfv1.Template, args wfv1.Arguments, globalParams, localPa
 	// 1) check if was supplied as argument. if so use the supplied value from arg
 	// 2) if not, use default value.
 	// 3) if no default value, it is an error
-	tmpl = tmpl.DeepCopy()
-	for i, inParam := range tmpl.Inputs.Parameters {
+	newTmpl := tmpl.DeepCopy()
+	for i, inParam := range newTmpl.Inputs.Parameters {
 		if inParam.Default != nil {
 			// first set to default value
 			inParam.Value = inParam.Default
@@ -259,12 +259,12 @@ func ProcessArgs(tmpl *wfv1.Template, args wfv1.Arguments, globalParams, localPa
 		if inParam.Value == nil {
 			return nil, errors.Errorf(errors.CodeBadRequest, "inputs.parameters.%s was not supplied", inParam.Name)
 		}
-		tmpl.Inputs.Parameters[i] = inParam
+		newTmpl.Inputs.Parameters[i] = inParam
 	}
 
 	// Performs substitutions of input artifacts
-	newInputArtifacts := make([]wfv1.Artifact, len(tmpl.Inputs.Artifacts))
-	for i, inArt := range tmpl.Inputs.Artifacts {
+	newInputArtifacts := make([]wfv1.Artifact, len(newTmpl.Inputs.Artifacts))
+	for i, inArt := range newTmpl.Inputs.Artifacts {
 		// if artifact has hard-wired location, we prefer that
 		if inArt.HasLocation() {
 			newInputArtifacts[i] = inArt
@@ -288,9 +288,10 @@ func ProcessArgs(tmpl *wfv1.Template, args wfv1.Arguments, globalParams, localPa
 			newInputArtifacts[i] = inArt
 		}
 	}
-	tmpl.Inputs.Artifacts = newInputArtifacts
+	newTmpl.Inputs.Artifacts = newInputArtifacts
 
-	return substituteParams(tmpl, globalParams, localParams)
+	return substituteParams(newTmpl, globalParams, localParams)
+
 }
 
 // substituteParams returns a new copy of the template with global, pod, and input parameters substituted

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -79,7 +79,13 @@ func ValidateWorkflow(wf *wfv1.Workflow, opts ValidateOpts) error {
 	ctx.globalParams[common.GlobalVarWorkflowNamespace] = placeholderValue
 	ctx.globalParams[common.GlobalVarWorkflowUID] = placeholderValue
 	for _, param := range ctx.wf.Spec.Arguments.Parameters {
-		ctx.globalParams["workflow.parameters."+param.Name] = placeholderValue
+		if param.Name != "" {
+			if param.Value != nil {
+				ctx.globalParams["workflow.parameters."+param.Name] = *param.Value
+			} else {
+				ctx.globalParams["workflow.parameters."+param.Name] = placeholderValue
+			}
+		}
 	}
 
 	for k := range ctx.wf.ObjectMeta.Annotations {

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -147,34 +147,34 @@ func (ctx *wfValidationCtx) validateTemplate(tmpl *wfv1.Template, args wfv1.Argu
 		}
 	}
 
-	_, err = common.ProcessArgs(tmpl, args, ctx.globalParams, localParams, true)
+	newTmpl, err := common.ProcessArgs(tmpl, args, ctx.globalParams, localParams, true)
 	if err != nil {
 		return errors.Errorf(errors.CodeBadRequest, "templates.%s %s", tmpl.Name, err)
 	}
 	for globalVar, val := range ctx.globalParams {
 		scope[globalVar] = val
 	}
-	switch tmpl.GetType() {
+	switch newTmpl.GetType() {
 	case wfv1.TemplateTypeSteps:
-		err = ctx.validateSteps(scope, tmpl)
+		err = ctx.validateSteps(scope, newTmpl)
 	case wfv1.TemplateTypeDAG:
-		err = ctx.validateDAG(scope, tmpl)
+		err = ctx.validateDAG(scope, newTmpl)
 	default:
-		err = validateLeaf(scope, tmpl)
+		err = validateLeaf(scope, newTmpl)
 	}
 	if err != nil {
 		return err
 	}
-	err = validateOutputs(scope, tmpl)
+	err = validateOutputs(scope, newTmpl)
 	if err != nil {
 		return err
 	}
-	err = ctx.validateBaseImageOutputs(tmpl)
+	err = ctx.validateBaseImageOutputs(newTmpl)
 	if err != nil {
 		return err
 	}
-	if tmpl.ArchiveLocation != nil {
-		err = validateArtifactLocation("templates.archiveLocation", *tmpl.ArchiveLocation)
+	if newTmpl.ArchiveLocation != nil {
+		err = validateArtifactLocation("templates.archiveLocation", *newTmpl.ArchiveLocation)
 		if err != nil {
 			return err
 		}

--- a/workflow/validate/validate_dag_test.go
+++ b/workflow/validate/validate_dag_test.go
@@ -116,7 +116,7 @@ spec:
       - name: A
         template: echo
         arguments:
-          parameters: 
+          parameters:
           - name: message
             value: val
       - name: B
@@ -154,14 +154,14 @@ spec:
       - name: A
         template: echo
         arguments:
-          parameters: 
+          parameters:
           - name: message
             value: val
       - name: B
         dependencies: [A]
         template: echo
         arguments:
-          parameters: 
+          parameters:
           - name: message
             value: "{{tasks.A.outputs.parameters.hosts}}"
       - name: C
@@ -199,14 +199,14 @@ spec:
       - name: A
         template: echo
         arguments:
-          parameters: 
+          parameters:
           - name: message
             value: val
       - name: B
         dependencies: [A]
         template: echo
         arguments:
-          parameters: 
+          parameters:
           - name: message
             value: "{{tasks.A.outputs.parameters.hosts}}"
       - name: C
@@ -246,7 +246,7 @@ spec:
       command: [echo, generate]
     outputs:
       artifacts:
-      - name: hosts
+      - name: generated_hosts
         path: /etc/hosts
 
   - name: echo
@@ -282,7 +282,7 @@ spec:
             value: val
           artifacts:
           - name: passthrough
-            from: "{{tasks.A.outputs.artifacts.hosts}}"
+            from: "{{tasks.A.outputs.artifacts.generated_hosts}}"
 `
 
 func TestDAGArtifactResolution(t *testing.T) {

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -239,7 +239,7 @@ var stepOutputReferences = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  generateName: hello-world-
+  generateName: step-output-ref-
 spec:
   entrypoint: whalesay
   templates:
@@ -267,8 +267,64 @@ spec:
             value: "{{steps.one.outparam}}"
 `
 
-func TestStepReference(t *testing.T) {
+func TestStepOutputReference(t *testing.T) {
 	err := validate(stepOutputReferences)
+	assert.Nil(t, err)
+}
+
+var stepArtReferences = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: step-art-ref-
+spec:
+  entrypoint: stepref
+  templates:
+  - name: generate
+    container:
+      image: alpine:3.7
+      command: [echo, generate]
+    outputs:
+      artifacts:
+      - name: generated_hosts
+        path: /etc/hosts
+
+  - name: echo
+    inputs:
+      parameters:
+      - name: message
+      artifacts:
+      - name: passthrough
+        path: /tmp/passthrough
+    container:
+      image: alpine:3.7
+      command: [echo, "{{inputs.parameters.message}}"]
+    outputs:
+      parameters:
+      - name: hosts
+        valueFrom:
+          path: /etc/hosts
+      artifacts:
+      - name: someoutput
+        path: /tmp/passthrough
+
+  - name: stepref
+    steps:
+    - - name: one
+        template: generate
+    - - name: two
+        template: echo
+        arguments:
+          parameters:
+          - name: message
+            value: val
+          artifacts:
+          - name: passthrough
+            from: "{{steps.one.outputs.artifacts.generated_hosts}}"
+`
+
+func TestStepArtReference(t *testing.T) {
+	err := validate(stepArtReferences)
 	assert.Nil(t, err)
 }
 


### PR DESCRIPTION
The function `ProcessArgs` returns an updated template, but using it in validation causes unit test errors. It confuses developers when they implement something around input/output parameters and arguments like #1490. I fixed it so it won't confuse them in the future.