### PR TITLE
Fix a compiler error in a unit test

### DIFF
--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -1029,7 +1029,7 @@ spec:
 func TestResolvePlaceholdersInOutputValues(t *testing.T) {
 	wf := unmarshalWF(outputValuePlaceholders)
 	woc := newWoc(*wf)
-	woc.controller.Config.ArtifactRepository.S3 = new(S3ArtifactRepository)
+	woc.controller.Config.ArtifactRepository.S3 = new(config.S3ArtifactRepository)
 	woc.operate()
 	assert.Equal(t, wfv1.NodeRunning, woc.wf.Status.Phase)
 	pods, err := woc.controller.kubeclientset.CoreV1().Pods(wf.ObjectMeta.Namespace).List(metav1.ListOptions{})


### PR DESCRIPTION
I'm not sure how to ask this without sounding rude - Is there a reason that code is being merged into master without passing the CI gates? There have been several of these over the past few weeks, for example https://github.com/argoproj/argo/pull/1505, https://github.com/argoproj/argo/pull/1500