### PR TITLE
Fix uninitialized wfClientset in the Lint command

### DIFF
--- a/cmd/argo/commands/lint.go
+++ b/cmd/argo/commands/lint.go
@@ -29,6 +29,7 @@ func NewLintCommand() *cobra.Command {
 				log.Fatal(err)
 			}
 
+			_ = InitWorkflowClient()
 			validateDir := cmdutil.MustIsDir(args[0])
 			if validateDir {
 				if len(args) > 1 {


### PR DESCRIPTION
This PR resolves #1547

It adds a missing call to ```InitWorkflowClient()``` which initializes the wfClientset object used for validation.