### PR TITLE
Add entrypoint label to workflow default labels

### DIFF
--- a/workflow/metrics/collector.go
+++ b/workflow/metrics/collector.go
@@ -12,12 +12,12 @@ import (
 )
 
 var (
-	descWorkflowDefaultLabels = []string{"namespace", "name"}
+	descWorkflowDefaultLabels = []string{"namespace", "name", "entrypoint"}
 
 	descWorkflowInfo = prometheus.NewDesc(
 		"argo_workflow_info",
 		"Information about workflow.",
-		append(descWorkflowDefaultLabels, "entrypoint", "service_account_name", "templates"),
+		append(descWorkflowDefaultLabels, "service_account_name", "templates"),
 		nil,
 	)
 	descWorkflowStartedAt = prometheus.NewDesc(


### PR DESCRIPTION
I'm monitoring workflow-controller metrics with Datadog.

I want to group a specific metric (e.g. `argo_workflow_completion_time`) and display it in the graph, but I can't do this because there is no common tag(label) set in Workflow Resource.

I want to add `entrypoint`  to workflow default labels for each metric.

rel. https://github.com/argoproj/argo/issues/1384