### PR TITLE
Allow defining k8s resource manifest from path or url

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -603,6 +603,10 @@
           "description": "Manifest contains the kubernetes manifest",
           "type": "string"
         },
+        "manifestPath": {
+          "description": "ManifestPath contains the path to a kubernetes manifest",
+          "type": "string"
+        },
         "mergeStrategy": {
           "description": "MergeStrategy is the strategy used to merge a patch. It defaults to \"strategic\" Must be one of: strategic, merge, json",
           "type": "string"

--- a/examples/k8s-jobs-manifestpath.yaml
+++ b/examples/k8s-jobs-manifestpath.yaml
@@ -1,0 +1,24 @@
+# This example demonstrates the usage of the 'manifestPath' field of the 'resource' template type, 
+# which provides a convenient way to define a kubernetes resources from manifest file from a path or url
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: k8s-jobs-
+spec:
+  entrypoint: pi-tmpl
+  templates:
+  - name: pi-tmpl
+    resource:
+      action: create
+      successCondition: status.succeeded > 0
+      failureCondition: status.failed > 3
+      # manifestPath can be either a path (relative to the workflow manifest or absolute) or a url
+      manifestPath: k8s-manifest.yaml
+    outputs:
+      parameters:
+      - name: job-name
+        valueFrom:
+          jsonPath: '{.metadata.name}'
+      - name: job-obj
+        valueFrom:
+          jqFilter: '.'

--- a/examples/k8s-manifest.yaml
+++ b/examples/k8s-manifest.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: pi-job-
+spec:
+  template:
+    metadata:
+      name: pi
+    spec:
+      containers:
+      - name: pi
+        image: perl
+        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+      restartPolicy: Never
+  backoffLimit: 4

--- a/pkg/apis/workflow/v1alpha1/openapi_generated.go
+++ b/pkg/apis/workflow/v1alpha1/openapi_generated.go
@@ -1126,6 +1126,13 @@ func schema_pkg_apis_workflow_v1alpha1_ResourceTemplate(ref common.ReferenceCall
 							Format:      "",
 						},
 					},
+					"manifestPath": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ManifestPath contains the path to a kubernetes manifest",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"setOwnerReference": {
 						SchemaProps: spec.SchemaProps{
 							Description: "SetOwnerReference sets the reference to the workflow on the OwnerReference of generated resource.",

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -968,6 +968,9 @@ type ResourceTemplate struct {
 	// Manifest contains the kubernetes manifest
 	Manifest string `json:"manifest"`
 
+	// ManifestPath contains the path to a kubernetes manifest
+	ManifestPath string `json:"manifestPath,omitempty"`
+
 	// SetOwnerReference sets the reference to the workflow on the OwnerReference of generated resource.
 	SetOwnerReference bool `json:"setOwnerReference,omitempty"`
 

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -243,7 +243,7 @@ func SubmitWorkflow(wfIf v1alpha1.WorkflowInterface, wfClientset wfclientset.Int
 	for _, template := range wf.Spec.Templates {
 		if template.Resource != nil {
 			if template.Resource.Manifest == "" && template.Resource.ManifestPath != "" {
-				body, err := readFromUrlOrPath(template.Resource.ManifestPath)
+				body, err := ReadFromUrlOrPath(template.Resource.ManifestPath)
 				if err != nil {
 					return nil, err
 				}
@@ -271,7 +271,7 @@ func SubmitWorkflow(wfIf v1alpha1.WorkflowInterface, wfClientset wfclientset.Int
 }
 
 // Reads the content of a url or a file path
-func readFromUrlOrPath(urlOrFilePath string) ([]byte, error) {
+func ReadFromUrlOrPath(urlOrFilePath string) ([]byte, error) {
 	var body []byte
 	var err error
 	if cmdutil.IsURL(urlOrFilePath) {

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -194,7 +194,7 @@ func SubmitWorkflow(wfIf v1alpha1.WorkflowInterface, wfClientset wfclientset.Int
 
 		// Add parameters from a parameter-file, if one was provided
 		if opts.ParameterFile != "" {
-			body, err := readFromUrlOrPath(opts.ParameterFile)
+			body, err := ReadFromUrlOrPath(opts.ParameterFile)
 			if err != nil {
 				return nil, err
 			}

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -4,7 +4,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/ghodss/yaml"
 
 	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	"github.com/stretchr/testify/assert"
@@ -54,4 +57,123 @@ func TestReadFromPath(t *testing.T) {
 	body, err := ReadFromUrlOrPath(tmpfn)
 	assert.Nil(t, err)
 	assert.Equal(t, body, content)
+}
+
+var workflowManifestWithoutManifest = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: hello-world-
+spec:
+  entrypoint: whalesay
+  templates:
+    - name: whalesay
+      resource:
+        manifestPath: <PathToResourceManifest>
+`
+
+var workflowManifestWithManifest = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: hello-world-
+spec:
+  entrypoint: whalesay
+  templates:
+    - name: whalesay
+      resource:
+        manifest: |- 
+            apiVersion: batch/v1
+            kind: Job
+            metadata:
+                generateName: different-whalesay-
+            spec:
+                template:
+                    metadata:
+                        name: different-whalesay
+                    spec:
+                     containers:
+                        - name: different-whalesay
+                          image: docker/whalesay:latest
+`
+
+var k8sResourceManifest = `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: whalesay-
+spec:
+  template:
+  metadata:
+   name: whalesay
+  spec:
+    containers:
+      - name: whalesay
+        image: docker/whalesay:latest
+`
+
+// TestWritingManifestUsingManifestPath ensures that manifest is filled with the content of the file at manifestPath
+func TestWritingManifestUsingManifestPath(t *testing.T) {
+	dir, err := ioutil.TempDir("", "testWritingManifestUsingManifestPath")
+	if err != nil {
+		t.Error("Could not create temporary directory")
+	}
+
+	defer os.RemoveAll(dir)
+
+	tmpfn := filepath.Join(dir, "test-resource.yaml")
+	if err := ioutil.WriteFile(tmpfn, []byte(k8sResourceManifest), 0666); err != nil {
+		t.Error("Could not write to test resource file")
+	}
+
+	workflowManifestWithoutManifest = strings.Replace(workflowManifestWithoutManifest, "<PathToResourceManifest>", tmpfn, 1)
+
+	wf := unmarshalWF(workflowManifestWithoutManifest)
+
+	assert.True(t, wf.Spec.Templates[0].Resource.Manifest == "")
+
+	err = MaybeWriteManifestFromManifestPath(wf)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, wf.Spec.Templates[0].Resource.Manifest, k8sResourceManifest)
+}
+
+// TestNotOverwritingManifestWithManifestPathWhenNotEmpty ensures that manifest's content is not overwritten
+// with the content of the file at manifestPath when it is not empty
+func TestNotOverwritingManifestWithManifestPathWhenNotEmpty(t *testing.T) {
+	dir, err := ioutil.TempDir("", "testNotOverwritingManifestWithManifestPathWhenNotEmpty")
+	if err != nil {
+		t.Error("Could not create temporary directory")
+	}
+
+	defer os.RemoveAll(dir)
+
+	tmpfn := filepath.Join(dir, "test-resource.yaml")
+	if err := ioutil.WriteFile(tmpfn, []byte(k8sResourceManifest), 0666); err != nil {
+		t.Error("Could not write to test resource file")
+	}
+
+	workflowManifestWithManifest = strings.Replace(workflowManifestWithManifest, "<PathToResourceManifest>", tmpfn, 1)
+
+	wf := unmarshalWF(workflowManifestWithManifest)
+
+	assert.True(t, wf.Spec.Templates[0].Resource.Manifest != "")
+
+	err = MaybeWriteManifestFromManifestPath(wf)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.NotEqual(t, wf.Spec.Templates[0].Resource.Manifest, k8sResourceManifest)
+}
+
+func unmarshalWF(yamlStr string) *wfv1.Workflow {
+	var wf wfv1.Workflow
+	err := yaml.Unmarshal([]byte(yamlStr), &wf)
+	if err != nil {
+		panic(err)
+	}
+	return &wf
 }

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -37,7 +37,7 @@ func TestResubmitWorkflowWithOnExit(t *testing.T) {
 	assert.False(t, ok)
 }
 
-// TestReadFromPath ensures we can read the content of a file correctly using the readFromUrlOrPath
+// TestReadFromPath ensures we can read the content of a file correctly using the ReadFromUrlOrPath function
 func TestReadFromPath(t *testing.T) {
 	content := []byte("test file's content")
 	dir, err := ioutil.TempDir("", "testReadFromUrlOrPath")
@@ -51,7 +51,7 @@ func TestReadFromPath(t *testing.T) {
 	if err := ioutil.WriteFile(tmpfn, content, 0666); err != nil {
 		t.Error("Could not write to temporary file")
 	}
-	body, err := readFromUrlOrPath(tmpfn)
+	body, err := ReadFromUrlOrPath(tmpfn)
 	assert.Nil(t, err)
 	assert.Equal(t, body, content)
 }

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -1,6 +1,9 @@
 package util
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
@@ -32,4 +35,23 @@ func TestResubmitWorkflowWithOnExit(t *testing.T) {
 	newWFOneExitID := newWF.NodeID(newWFOnExitName)
 	_, ok := newWF.Status.Nodes[newWFOneExitID]
 	assert.False(t, ok)
+}
+
+// TestReadFromPath ensures we can read the content of a file correctly using the readFromUrlOrPath
+func TestReadFromPath(t *testing.T) {
+	content := []byte("test file's content")
+	dir, err := ioutil.TempDir("", "testReadFromUrlOrPath")
+	if err != nil {
+		t.Error("Could not create temporary directory")
+	}
+
+	defer os.RemoveAll(dir)
+
+	tmpfn := filepath.Join(dir, "test_file.yaml")
+	if err := ioutil.WriteFile(tmpfn, content, 0666); err != nil {
+		t.Error("Could not write to temporary file")
+	}
+	body, err := readFromUrlOrPath(tmpfn)
+	assert.Nil(t, err)
+	assert.Equal(t, body, content)
 }


### PR DESCRIPTION
This PR adds a new ```manifestPath``` field to the ```ResourceTemplate```

With the addition of this field we can keep the k8s resource manifest in a separate file and give a path to it in the workflow manifest. This can make it easier to template the resource before submitting it with argo and to reduce the clutter in the workflow manifest thus making it more readable.

For example, we can define a workflow manifest that uses a k8s resource as follows:

```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: k8s-jobs-
spec:
  entrypoint: pi-tmpl
  templates:
  - name: pi-tmpl
    resource:
      action: create
      successCondition: status.succeeded > 0
      failureCondition: status.failed > 3
      manifestPath: test-manifest.yaml
    outputs:
      parameters:
      - name: job-name
        valueFrom:
          jsonPath: '{.metadata.name}'
      - name: job-obj
        valueFrom:
          jqFilter: '.'
```

With a ```test-manifest.yaml``` defined in the same folder as follows:

```yaml
apiVersion: batch/v1
kind: Job
metadata:
  generateName: pi-job-
spec:
  template:
    metadata:
      name: pi
    spec:
      containers:
      - name: pi
        image: perl
        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
      restartPolicy: Never
  backoffLimit: 4
```

manifestPath can also be a url, in which case the content will be downloaded.

Internally it works by checking if the ```manifest``` is empty and if so reads the content of the given file or url and puts it into that field.
