### PR TITLE
Add coverage make target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ cmd/**/debug
 hack/**/debug
 debug.test
 *.iml
+coverage.out
+.envrc

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,11 @@ endif
 
 .PHONY: test
 test:
-	go test ./...
+	go test -covermode=count -coverprofile=coverage.out ./...
+
+.PHONY: cover
+cover:
+	go tool cover -html=coverage.out
 
 .PHONY: codegen
 codegen:


### PR DESCRIPTION
I think we should track test coverage and write more tests so we can easily modify the code in the future.

I wanted to set up codecov for the coverage tracking. Could some one set up the ci with `CODECOV_TOKEN` in https://codecov.io/gh/argoproj/argo?