### PR TITLE
Small code cleanup and add tests

### DIFF
--- a/cmd/argo/commands/submit.go
+++ b/cmd/argo/commands/submit.go
@@ -80,15 +80,17 @@ func SubmitWorkflows(filePaths []string, submitOpts *util.SubmitOpts, cliOpts *c
 	}
 	defaultWFClient := InitWorkflowClient()
 
+	var fileContents [][]byte
 	if len(filePaths) == 1 && filePaths[0] == "-" {
 		reader := bufio.NewReader(os.Stdin)
 		body, err := ioutil.ReadAll(reader)
 		if err != nil {
 			log.Fatal(err)
 		}
-		fileContents := [][]byte{body}
+		fileContents = append(fileContents, body)
 	} else {
-		fileContents, err := util.ReadFromFilePathsOrUrls(filePaths)
+		var err error
+		fileContents, err = util.ReadFromFilePathsOrUrls(filePaths...)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/argo/commands/submit.go
+++ b/cmd/argo/commands/submit.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"bufio"
-	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
@@ -82,8 +80,7 @@ func SubmitWorkflows(filePaths []string, submitOpts *util.SubmitOpts, cliOpts *c
 
 	var fileContents [][]byte
 	if len(filePaths) == 1 && filePaths[0] == "-" {
-		reader := bufio.NewReader(os.Stdin)
-		body, err := ioutil.ReadAll(reader)
+		body, err := util.ReadFromStdin()
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/argo/commands/submit.go
+++ b/cmd/argo/commands/submit.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"bufio"
+	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
@@ -78,9 +80,18 @@ func SubmitWorkflows(filePaths []string, submitOpts *util.SubmitOpts, cliOpts *c
 	}
 	defaultWFClient := InitWorkflowClient()
 
-	fileContents, err := util.ReadFromFilePathsOrUrls(filePaths)
-	if err != nil {
-		log.Fatal(err)
+	if len(filePaths) == 1 && filePaths[0] == "-" {
+		reader := bufio.NewReader(os.Stdin)
+		body, err := ioutil.ReadAll(reader)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fileContents := [][]byte{body}
+	} else {
+		fileContents, err := util.ReadFromFilePathsOrUrls(filePaths)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 	var workflows []wfv1.Workflow
 	for _, body := range fileContents {

--- a/cmd/argo/commands/submit.go
+++ b/cmd/argo/commands/submit.go
@@ -78,20 +78,11 @@ func SubmitWorkflows(filePaths []string, submitOpts *util.SubmitOpts, cliOpts *c
 	}
 	defaultWFClient := InitWorkflowClient()
 
-	var fileContents [][]byte
-	if len(filePaths) == 1 && filePaths[0] == "-" {
-		body, err := util.ReadFromStdin()
-		if err != nil {
-			log.Fatal(err)
-		}
-		fileContents = append(fileContents, body)
-	} else {
-		var err error
-		fileContents, err = util.ReadFromFilePathsOrUrls(filePaths...)
-		if err != nil {
-			log.Fatal(err)
-		}
+	fileContents, err := util.ReadManifest(filePaths...)
+	if err != nil {
+		log.Fatal(err)
 	}
+
 	var workflows []wfv1.Workflow
 	for _, body := range fileContents {
 		wfs := unmarshalWorkflows(body, cliOpts.strict)

--- a/cmd/argo/commands/template/create.go
+++ b/cmd/argo/commands/template/create.go
@@ -47,15 +47,17 @@ func CreateWorkflowTemplates(filePaths []string, cliOpts *cliCreateOpts) {
 	}
 	defaultWFTmplClient := InitWorkflowTemplateClient()
 
+	var fileContents [][]byte
 	if len(filePaths) == 1 && filePaths[0] == "-" {
 		reader := bufio.NewReader(os.Stdin)
 		body, err := ioutil.ReadAll(reader)
 		if err != nil {
 			log.Fatal(err)
 		}
-		fileContents := [][]byte{body}
+		fileContents = append(fileContents, body)
 	} else {
-		fileContents, err := util.ReadFromFilePathsOrUrls(filePaths)
+		var err error
+		fileContents, err = util.ReadFromFilePathsOrUrls(filePaths...)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/argo/commands/template/create.go
+++ b/cmd/argo/commands/template/create.go
@@ -1,8 +1,6 @@
 package template
 
 import (
-	"bufio"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -49,8 +47,7 @@ func CreateWorkflowTemplates(filePaths []string, cliOpts *cliCreateOpts) {
 
 	var fileContents [][]byte
 	if len(filePaths) == 1 && filePaths[0] == "-" {
-		reader := bufio.NewReader(os.Stdin)
-		body, err := ioutil.ReadAll(reader)
+		body, err := util.ReadFromStdin()
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/argo/commands/template/create.go
+++ b/cmd/argo/commands/template/create.go
@@ -1,6 +1,8 @@
 package template
 
 import (
+	"bufio"
+	"io/ioutil"
 	"log"
 	"os"
 
@@ -45,9 +47,18 @@ func CreateWorkflowTemplates(filePaths []string, cliOpts *cliCreateOpts) {
 	}
 	defaultWFTmplClient := InitWorkflowTemplateClient()
 
-	fileContents, err := util.ReadFromFilePathsOrUrls(filePaths)
-	if err != nil {
-		log.Fatal(err)
+	if len(filePaths) == 1 && filePaths[0] == "-" {
+		reader := bufio.NewReader(os.Stdin)
+		body, err := ioutil.ReadAll(reader)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fileContents := [][]byte{body}
+	} else {
+		fileContents, err := util.ReadFromFilePathsOrUrls(filePaths)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	var workflowTemplates []wfv1.WorkflowTemplate

--- a/cmd/argo/commands/template/create.go
+++ b/cmd/argo/commands/template/create.go
@@ -45,19 +45,9 @@ func CreateWorkflowTemplates(filePaths []string, cliOpts *cliCreateOpts) {
 	}
 	defaultWFTmplClient := InitWorkflowTemplateClient()
 
-	var fileContents [][]byte
-	if len(filePaths) == 1 && filePaths[0] == "-" {
-		body, err := util.ReadFromStdin()
-		if err != nil {
-			log.Fatal(err)
-		}
-		fileContents = append(fileContents, body)
-	} else {
-		var err error
-		fileContents, err = util.ReadFromFilePathsOrUrls(filePaths...)
-		if err != nil {
-			log.Fatal(err)
-		}
+	fileContents, err := util.ReadManifest(filePaths...)
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	var workflowTemplates []wfv1.WorkflowTemplate

--- a/util/file/fileutil_test.go
+++ b/util/file/fileutil_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/argoproj/argo/util/file"
 )
 
-// TestResubmitWorkflowWithOnExit ensures we do not carry over the onExit node even if successful
+// TestCompressContentString ensures compressing then decompressing a content string works as expected
 func TestCompressContentString(t *testing.T) {
 	content := "{\"pod-limits-rrdm8-591645159\":{\"id\":\"pod-limits-rrdm8-591645159\",\"name\":\"pod-limits-rrdm8[0]." +
 		"run-pod(0:0)\",\"displayName\":\"run-pod(0:0)\",\"type\":\"Pod\",\"templateName\":\"run-pod\",\"phase\":" +

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -1,13 +1,11 @@
 package util
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
-	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -283,35 +281,25 @@ func ReadFromUrl(url string) ([]byte, error) {
 }
 
 // ReadFromFilePathsOrUrls reads the content of a single or a list of file paths and/or urls
-func ReadFromFilePathsOrUrls(filePathsOrUrls []string) ([][]byte, error) {
+func ReadFromFilePathsOrUrls(filePathsOrUrls ...string) ([][]byte, error) {
 	var contents [][]byte
 	var body []byte
 	var err error
-	if len(filePathsOrUrls) == 1 && filePathsOrUrls[0] == "-" {
-		reader := bufio.NewReader(os.Stdin)
-		body, err = ioutil.ReadAll(reader)
-		if err != nil {
-			return [][]byte{}, err
+	for _, filePathOrUrl := range filePathsOrUrls {
+		if cmdutil.IsURL(filePathOrUrl) {
+			body, err = ReadFromUrl(filePathOrUrl)
+			if err != nil {
+				return [][]byte{}, err
+			}
+		} else {
+			body, err = ioutil.ReadFile(filePathOrUrl)
+			if err != nil {
+				return [][]byte{}, err
+			}
 		}
 		contents = append(contents, body)
-		return contents, err
-	} else {
-		for _, filePathOrUrl := range filePathsOrUrls {
-			if cmdutil.IsURL(filePathOrUrl) {
-				body, err = ReadFromUrl(filePathOrUrl)
-				if err != nil {
-					return [][]byte{}, err
-				}
-			} else {
-				body, err = ioutil.ReadFile(filePathOrUrl)
-				if err != nil {
-					return [][]byte{}, err
-				}
-			}
-			contents = append(contents, body)
-		}
-		return contents, err
 	}
+	return contents, err
 }
 
 // CreateServerDryRun fills the workflow struct with the server's representation without creating it and returns an error, if there is any

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -1,11 +1,13 @@
 package util
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -264,6 +266,16 @@ func SubmitWorkflow(wfIf v1alpha1.WorkflowInterface, wfClientset wfclientset.Int
 	} else {
 		return wfIf.Create(wf)
 	}
+}
+
+// Reads from stdin
+func ReadFromStdin() ([]byte, error) {
+	reader := bufio.NewReader(os.Stdin)
+	body, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return []byte{}, err
+	}
+	return body, err
 }
 
 // Reads the content of a url

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -614,7 +614,7 @@ func ReadFromUrl(url string) ([]byte, error) {
 
 // ReadFromFilePathsOrUrls reads the content of a single or a list of file paths and/or urls
 func ReadFromFilePathsOrUrls(filePathsOrUrls ...string) ([][]byte, error) {
-	var contents [][]byte
+	var fileContents [][]byte
 	var body []byte
 	var err error
 	for _, filePathOrUrl := range filePathsOrUrls {
@@ -629,7 +629,27 @@ func ReadFromFilePathsOrUrls(filePathsOrUrls ...string) ([][]byte, error) {
 				return [][]byte{}, err
 			}
 		}
-		contents = append(contents, body)
+		fileContents = append(fileContents, body)
 	}
-	return contents, err
+	return fileContents, err
+}
+
+// ReadManifest reads from stdin, a single file/url, or a list of files and/or urls
+func ReadManifest(manifestPaths ...string) ([][]byte, error) {
+	var manifestContents [][]byte
+	var err error
+	if len(manifestPaths) == 1 && manifestPaths[0] == "-" {
+		body, err := ReadFromStdin()
+		if err != nil {
+			return [][]byte{}, err
+		}
+		manifestContents = append(manifestContents, body)
+	} else {
+		var err error
+		manifestContents, err = ReadFromFilePathsOrUrls(manifestPaths...)
+		if err != nil {
+			return [][]byte{}, err
+		}
+	}
+	return manifestContents, err
 }

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -268,52 +268,6 @@ func SubmitWorkflow(wfIf v1alpha1.WorkflowInterface, wfClientset wfclientset.Int
 	}
 }
 
-// Reads from stdin
-func ReadFromStdin() ([]byte, error) {
-	reader := bufio.NewReader(os.Stdin)
-	body, err := ioutil.ReadAll(reader)
-	if err != nil {
-		return []byte{}, err
-	}
-	return body, err
-}
-
-// Reads the content of a url
-func ReadFromUrl(url string) ([]byte, error) {
-	response, err := http.Get(url)
-	if err != nil {
-		return nil, err
-	}
-	body, err := ioutil.ReadAll(response.Body)
-	_ = response.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-	return body, err
-}
-
-// ReadFromFilePathsOrUrls reads the content of a single or a list of file paths and/or urls
-func ReadFromFilePathsOrUrls(filePathsOrUrls ...string) ([][]byte, error) {
-	var contents [][]byte
-	var body []byte
-	var err error
-	for _, filePathOrUrl := range filePathsOrUrls {
-		if cmdutil.IsURL(filePathOrUrl) {
-			body, err = ReadFromUrl(filePathOrUrl)
-			if err != nil {
-				return [][]byte{}, err
-			}
-		} else {
-			body, err = ioutil.ReadFile(filePathOrUrl)
-			if err != nil {
-				return [][]byte{}, err
-			}
-		}
-		contents = append(contents, body)
-	}
-	return contents, err
-}
-
 // CreateServerDryRun fills the workflow struct with the server's representation without creating it and returns an error, if there is any
 func CreateServerDryRun(wf *wfv1.Workflow, wfClientset wfclientset.Interface) (*wfv1.Workflow, error) {
 	// Keep the workflow metadata because it will be overwritten by the Post request
@@ -584,6 +538,7 @@ func IsWorkflowSuspended(wf *wfv1.Workflow) bool {
 	return false
 }
 
+// IsWorkflowTerminated returns whether or not a workflow is considered terminated
 func IsWorkflowTerminated(wf *wfv1.Workflow) bool {
 	if wf.Spec.ActiveDeadlineSeconds != nil && *wf.Spec.ActiveDeadlineSeconds == 0 {
 		return true
@@ -631,4 +586,50 @@ func DecompressWorkflow(wf *wfv1.Workflow) error {
 		wf.Status.CompressedNodes = ""
 	}
 	return nil
+}
+
+// Reads from stdin
+func ReadFromStdin() ([]byte, error) {
+	reader := bufio.NewReader(os.Stdin)
+	body, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return []byte{}, err
+	}
+	return body, err
+}
+
+// Reads the content of a url
+func ReadFromUrl(url string) ([]byte, error) {
+	response, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	body, err := ioutil.ReadAll(response.Body)
+	_ = response.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	return body, err
+}
+
+// ReadFromFilePathsOrUrls reads the content of a single or a list of file paths and/or urls
+func ReadFromFilePathsOrUrls(filePathsOrUrls ...string) ([][]byte, error) {
+	var contents [][]byte
+	var body []byte
+	var err error
+	for _, filePathOrUrl := range filePathsOrUrls {
+		if cmdutil.IsURL(filePathOrUrl) {
+			body, err = ReadFromUrl(filePathOrUrl)
+			if err != nil {
+				return [][]byte{}, err
+			}
+		} else {
+			body, err = ioutil.ReadFile(filePathOrUrl)
+			if err != nil {
+				return [][]byte{}, err
+			}
+		}
+		contents = append(contents, body)
+	}
+	return contents, err
 }

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -253,14 +253,14 @@ func SubmitWorkflow(wfIf v1alpha1.WorkflowInterface, wfClientset wfclientset.Int
 		return nil, err
 	}
 
-	if opts.ServerDryRun {
+	if opts.DryRun {
+		return wf, nil
+	} else if opts.ServerDryRun {
 		wf, err := CreateServerDryRun(wf, wfClientset)
 		if err != nil {
 			return nil, err
 		}
 		return wf, err
-	} else if opts.DryRun {
-		return wf, nil
 	} else {
 		return wfIf.Create(wf)
 	}

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -645,7 +645,6 @@ func ReadManifest(manifestPaths ...string) ([][]byte, error) {
 		}
 		manifestContents = append(manifestContents, body)
 	} else {
-		var err error
 		manifestContents, err = ReadFromFilePathsOrUrls(manifestPaths...)
 		if err != nil {
 			return [][]byte{}, err


### PR DESCRIPTION
This PR tries to reduce code duplication in the ```submit``` and ```template create``` code files.

It does so by factoring out the common code that was to read from a file or a url and adds tests for it.

It also adds a test for the dry-run option of the submit command.