### PR TITLE
[ENH] Add support for nested global parameters

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1896,11 +1896,18 @@ func (woc *wfOperationCtx) substituteNestedGlobalParams() error {
 			// to avoid unnecessarily creating a template
 			// the loop is needed to handle cases when there are multiple nesting levels
 			// i.e. when a nested parameter references another nested parameter
-			for startTagIndex := strings.Index(value, "{{"); startTagIndex > -1; startTagIndex = strings.Index(value, "{{") {
+			for {
+				startTagIndex := strings.Index(value, "{{")
+				if startTagIndex == -1 {
+					break
+				}
 				fstTmpl := fasttemplate.New(value, "{{", "}}")
 				newValue, err := common.Replace(fstTmpl, woc.globalParams, true)
 				if err != nil {
 					return err
+				}
+				if value == newValue {
+					break
 				}
 				newGlobalParams[name] = newValue
 				value = newValue

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -179,7 +179,12 @@ func (woc *wfOperationCtx) operate() {
 	woc.setGlobalParameters()
 
 	// Replace the nested global workflow parameters if there are any
-	woc.substituteNestedGlobalParams()
+	err := woc.substituteNestedGlobalParams()
+	if err != nil {
+		woc.log.Errorf("%s global nested params substitution error: %+v", woc.wf.ObjectMeta.Name, err)
+		woc.markWorkflowError(err, true)
+		return
+	}
 
 	if woc.wf.Spec.ArtifactRepositoryRef != nil {
 		repoReference := woc.wf.Spec.ArtifactRepositoryRef
@@ -192,7 +197,7 @@ func (woc *wfOperationCtx) operate() {
 		}
 	}
 
-	err := woc.substituteParamsInVolumes(woc.globalParams)
+	err = woc.substituteParamsInVolumes(woc.globalParams)
 	if err != nil {
 		woc.log.Errorf("%s volumes global param substitution error: %+v", woc.wf.ObjectMeta.Name, err)
 		woc.markWorkflowError(err, true)

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -882,15 +882,17 @@ func TestGlobalParamSubstitutionWithArtifact(t *testing.T) {
 }
 
 func TestGlobalNestedParamSubstitution(t *testing.T) {
-	wf := test.LoadTestWorkflow("testdata/workflow-nested-parameter-in-loop.yaml")
+	wf := test.LoadTestWorkflow("testdata/workflow-global-nested-parameter.yaml")
 	woc := newWoc(*wf)
 	// Call setGlobalParameters to fill the globalParams map
 	woc.setGlobalParameters()
 	assert.Equal(t, "{{workflow.parameters.adj}} {{workflow.parameters.recipient}}", woc.globalParams["workflow.parameters.target"])
+	assert.Equal(t, "{{workflow.parameters.target}}", woc.globalParams["workflow.parameters.nested-target"])
 	// Call substituteNestedGlobalParams to take care of nested global parameters
 	woc.substituteNestedGlobalParams()
 	// Make sure the nested parameters were substituted
 	assert.Equal(t, "cruel world", woc.globalParams["workflow.parameters.target"])
+	assert.Equal(t, "cruel world", woc.globalParams["workflow.parameters.nested-target"])
 	// Create a new workflow operation context and call its operate method
 	// to make sure the workflow runs correctly
 	woc = newWoc(*wf)

--- a/workflow/controller/testdata/workflow-global-nested-parameter.yaml
+++ b/workflow/controller/testdata/workflow-global-nested-parameter.yaml
@@ -1,9 +1,9 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  generateName: nested-loop-parameter-test-
+  generateName: global-nested-parameter-test-
 spec:
-  entrypoint: loop-with-nested-parameter
+  entrypoint: step-with-nested-parameter
 
   arguments:
     parameters:
@@ -13,6 +13,8 @@ spec:
       value: "world"
     - name: target
       value: "{{workflow.parameters.adj}} {{workflow.parameters.recipient}}"
+    - name: nested-target
+      value: "{{workflow.parameters.target}}"
 
   templates:
   - name: echo
@@ -24,12 +26,10 @@ spec:
       command: [/bin/sh, -c]
       args: ["echo {{inputs.parameters.message}}"]
 
-  - name: loop-with-nested-parameter
-    steps:
-    - - name: foreach-nest
-        template: echo
-        arguments:
-          parameters:
-            - name: message
-              value: "{{item}} {{workflow.parameters.target}}"
-        withItems: ["Hello", "Goodbye"]
+  - name: step-with-nested-parameter
+    template: echo
+    arguments:
+      parameters:
+        - name: message
+          value: "{{item}} {{workflow.parameters.nested-target}}"
+      withItems: ["Hello", "Goodbye"]

--- a/workflow/controller/testdata/workflow-nested-parameter-in-loop.yaml
+++ b/workflow/controller/testdata/workflow-nested-parameter-in-loop.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: nested-loop-parameter-test-
+spec:
+  entrypoint: loop-with-nested-parameter
+
+  arguments:
+    parameters:
+    - name: adj
+      value: "cruel"
+    - name: recipient
+      value: "world"
+    - name: target
+      value: "{{workflow.parameters.adj}} {{workflow.parameters.recipient}}"
+
+  templates:
+  - name: echo
+    inputs:
+      parameters:
+      - name: message
+    container:
+      image: alpine:3.7
+      command: [/bin/sh, -c]
+      args: ["echo {{inputs.parameters.message}}"]
+
+  - name: loop-with-nested-parameter
+    steps:
+    - - name: foreach-nest
+        template: echo
+        arguments:
+          parameters:
+            - name: message
+              value: "{{item}} {{workflow.parameters.target}}"
+        withItems: ["Hello", "Goodbye"]


### PR DESCRIPTION
This PR resolves issue #1535 by adding a new method to wfOperationCtx that takes care of substituting the values of nested global parameters ( workflow.parameters.* ) right after setting the globalParams map.

This is now possible:
```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: global-nested-parameter-test-
spec:
  entrypoint: step-with-nested-parameter

  arguments:
    parameters:
    - name: adj
      value: "cruel"
    - name: recipient
      value: "world"
    - name: target
      value: "{{workflow.parameters.adj}} {{workflow.parameters.recipient}}"
    - name: nested-target
      value: "{{workflow.parameters.target}}"

  templates:
  - name: echo
    inputs:
      parameters:
      - name: message
    container:
      image: alpine:3.7
      command: [/bin/sh, -c]
      args: ["echo {{inputs.parameters.message}}"]

  - name: step-with-nested-parameter
    template: echo
    arguments:
      parameters:
        - name: message
          value: "{{item}} {{workflow.parameters.nested-target}}"
      withItems: ["Hello", "Goodbye"]
```
It also handles the case when a variable references itself such as, by leaving them as is for now:

```yaml
  arguments:
    parameters:
    - name: adj
      value: "{{workflow.parameters.adj}}"
```

I am planning to add validation for that case