### PR TITLE
Regard resource templates as leaf nodes

### DIFF
--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -1035,7 +1035,7 @@ func (tmpl *Template) IsPodType() bool {
 // IsLeaf returns whether or not the template is a leaf
 func (tmpl *Template) IsLeaf() bool {
 	switch tmpl.GetType() {
-	case TemplateTypeContainer, TemplateTypeScript:
+	case TemplateTypeContainer, TemplateTypeScript, TemplateTypeResource:
 		return true
 	}
 	return false


### PR DESCRIPTION
This PR registers resource templates as leaf templates, enabling retryStrategy for resource templates.
This closes #1370