### PR TITLE
Add merge keys to Workflow objects to allow for StrategicMergePatches

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1393,7 +1393,9 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/io.argoproj.workflow.v1alpha1.Template"
-          }
+          },
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
         },
         "tolerations": {
           "description": "Tolerations to apply to workflow pods.",

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -27,14 +27,18 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/io.argoproj.workflow.v1alpha1.Artifact"
-          }
+          },
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
         },
         "parameters": {
           "description": "Parameters is the list of parameters to pass to the template or workflow",
           "type": "array",
           "items": {
             "$ref": "#/definitions/io.argoproj.workflow.v1alpha1.Parameter"
-          }
+          },
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
         }
       }
     },
@@ -272,7 +276,9 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/io.argoproj.workflow.v1alpha1.DAGTask"
-          }
+          },
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
         }
       }
     },
@@ -480,14 +486,18 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/io.argoproj.workflow.v1alpha1.Artifact"
-          }
+          },
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
         },
         "parameters": {
           "description": "Parameters are a list of parameters passed as inputs",
           "type": "array",
           "items": {
             "$ref": "#/definitions/io.argoproj.workflow.v1alpha1.Parameter"
-          }
+          },
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
         }
       }
     },
@@ -527,14 +537,18 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/io.argoproj.workflow.v1alpha1.Artifact"
-          }
+          },
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
         },
         "parameters": {
           "description": "Parameters holds the list of output parameters produced by a step",
           "type": "array",
           "items": {
             "$ref": "#/definitions/io.argoproj.workflow.v1alpha1.Parameter"
-          }
+          },
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
         },
         "result": {
           "description": "Result holds the result (stdout) of a script template",
@@ -934,14 +948,18 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.HostAlias"
-          }
+          },
+          "x-kubernetes-patch-merge-key": "ip",
+          "x-kubernetes-patch-strategy": "merge"
         },
         "initContainers": {
           "description": "InitContainers is a list of containers which run before the main container.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/io.argoproj.workflow.v1alpha1.UserContainer"
-          }
+          },
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
         },
         "inputs": {
           "description": "Inputs describe what inputs parameters and artifacts are supplied to this template",
@@ -1009,7 +1027,9 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/io.argoproj.workflow.v1alpha1.UserContainer"
-          }
+          },
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
         },
         "steps": {
           "description": "Steps define a series of sequential/parallel workflow steps",
@@ -1038,14 +1058,18 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
-          }
+          },
+          "x-kubernetes-patch-merge-key": "key",
+          "x-kubernetes-patch-strategy": "merge"
         },
         "volumes": {
           "description": "Volumes is a list of volumes that can be mounted by containers in a template.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.Volume"
-          }
+          },
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
         }
       }
     },
@@ -1325,7 +1349,9 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.HostAlias"
-          }
+          },
+          "x-kubernetes-patch-merge-key": "ip",
+          "x-kubernetes-patch-strategy": "merge"
         },
         "hostNetwork": {
           "description": "Host networking requested for this workflow pod. Default to false.",
@@ -1336,7 +1362,9 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
-          }
+          },
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
         },
         "nodeSelector": {
           "description": "NodeSelector is a selector which will result in all pods of the workflow to be scheduled on the selected node(s). This is able to be overridden by a nodeSelector specified in the template.",
@@ -1402,7 +1430,9 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
-          }
+          },
+          "x-kubernetes-patch-merge-key": "key",
+          "x-kubernetes-patch-strategy": "merge"
         },
         "ttlSecondsAfterFinished": {
           "description": "TTLSecondsAfterFinished limits the lifetime of a Workflow that has finished execution (Succeeded, Failed, Error). If this field is set, once the Workflow finishes, it will be deleted after ttlSecondsAfterFinished expires. If this field is unset, ttlSecondsAfterFinished will not expire. If this field is set to zero, ttlSecondsAfterFinished expires immediately after the Workflow finishes.",
@@ -1414,14 +1444,18 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaim"
-          }
+          },
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
         },
         "volumes": {
           "description": "Volumes is a list of volumes that can be mounted by containers in a workflow.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.Volume"
-          }
+          },
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
         }
       }
     },

--- a/pkg/apis/workflow/v1alpha1/openapi_generated.go
+++ b/pkg/apis/workflow/v1alpha1/openapi_generated.go
@@ -2318,6 +2318,12 @@ func schema_pkg_apis_workflow_v1alpha1_WorkflowSpec(ref common.ReferenceCallback
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"templates": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Templates is a list of workflow templates used in a workflow",
 							Type:        []string{"array"},

--- a/pkg/apis/workflow/v1alpha1/openapi_generated.go
+++ b/pkg/apis/workflow/v1alpha1/openapi_generated.go
@@ -92,6 +92,12 @@ func schema_pkg_apis_workflow_v1alpha1_Arguments(ref common.ReferenceCallback) c
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"parameters": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Parameters is the list of parameters to pass to the template or workflow",
 							Type:        []string{"array"},
@@ -105,6 +111,12 @@ func schema_pkg_apis_workflow_v1alpha1_Arguments(ref common.ReferenceCallback) c
 						},
 					},
 					"artifacts": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Artifacts is the list of artifacts to pass to the template or workflow",
 							Type:        []string{"array"},
@@ -511,6 +523,12 @@ func schema_pkg_apis_workflow_v1alpha1_DAGTemplate(ref common.ReferenceCallback)
 						},
 					},
 					"tasks": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Tasks are a list of DAG tasks",
 							Type:        []string{"array"},
@@ -884,6 +902,12 @@ func schema_pkg_apis_workflow_v1alpha1_Inputs(ref common.ReferenceCallback) comm
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"parameters": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Parameters are a list of parameters passed as inputs",
 							Type:        []string{"array"},
@@ -897,6 +921,12 @@ func schema_pkg_apis_workflow_v1alpha1_Inputs(ref common.ReferenceCallback) comm
 						},
 					},
 					"artifacts": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Artifact are a list of artifacts passed as inputs",
 							Type:        []string{"array"},
@@ -989,6 +1019,12 @@ func schema_pkg_apis_workflow_v1alpha1_Outputs(ref common.ReferenceCallback) com
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"parameters": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Parameters holds the list of output parameters produced by a step",
 							Type:        []string{"array"},
@@ -1002,6 +1038,12 @@ func schema_pkg_apis_workflow_v1alpha1_Outputs(ref common.ReferenceCallback) com
 						},
 					},
 					"artifacts": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Artifacts holds the list of output artifacts produced by a step",
 							Type:        []string{"array"},
@@ -1759,6 +1801,12 @@ func schema_pkg_apis_workflow_v1alpha1_Template(ref common.ReferenceCallback) co
 						},
 					},
 					"volumes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Volumes is a list of volumes that can be mounted by containers in a template.",
 							Type:        []string{"array"},
@@ -1772,6 +1820,12 @@ func schema_pkg_apis_workflow_v1alpha1_Template(ref common.ReferenceCallback) co
 						},
 					},
 					"initContainers": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "InitContainers is a list of containers which run before the main container.",
 							Type:        []string{"array"},
@@ -1785,6 +1839,12 @@ func schema_pkg_apis_workflow_v1alpha1_Template(ref common.ReferenceCallback) co
 						},
 					},
 					"sidecars": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Sidecars is a list of containers which run alongside the main container Sidecars are automatically killed when the main container completes",
 							Type:        []string{"array"},
@@ -1824,6 +1884,12 @@ func schema_pkg_apis_workflow_v1alpha1_Template(ref common.ReferenceCallback) co
 						},
 					},
 					"tolerations": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "key",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Tolerations to apply to workflow pods.",
 							Type:        []string{"array"},
@@ -1878,6 +1944,12 @@ func schema_pkg_apis_workflow_v1alpha1_Template(ref common.ReferenceCallback) co
 						},
 					},
 					"hostAliases": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "ip",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "HostAliases is an optional list of hosts and IPs that will be injected into the pod spec",
 							Type:        []string{"array"},
@@ -2370,6 +2442,12 @@ func schema_pkg_apis_workflow_v1alpha1_WorkflowSpec(ref common.ReferenceCallback
 						},
 					},
 					"volumes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Volumes is a list of volumes that can be mounted by containers in a workflow.",
 							Type:        []string{"array"},
@@ -2383,6 +2461,12 @@ func schema_pkg_apis_workflow_v1alpha1_WorkflowSpec(ref common.ReferenceCallback
 						},
 					},
 					"volumeClaimTemplates": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "VolumeClaimTemplates is a list of claims that containers are allowed to reference. The Workflow controller will create the claims at the beginning of the workflow and delete the claims upon completion of the workflow",
 							Type:        []string{"array"},
@@ -2437,6 +2521,12 @@ func schema_pkg_apis_workflow_v1alpha1_WorkflowSpec(ref common.ReferenceCallback
 						},
 					},
 					"tolerations": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "key",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Tolerations to apply to workflow pods.",
 							Type:        []string{"array"},
@@ -2450,6 +2540,12 @@ func schema_pkg_apis_workflow_v1alpha1_WorkflowSpec(ref common.ReferenceCallback
 						},
 					},
 					"imagePullSecrets": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod",
 							Type:        []string{"array"},
@@ -2538,6 +2634,12 @@ func schema_pkg_apis_workflow_v1alpha1_WorkflowSpec(ref common.ReferenceCallback
 						},
 					},
 					"hostAliases": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "ip",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "HostAliases is an optional list of hosts and IPs that will be injected into the pod spec",
 							Type:        []string{"array"},

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -100,7 +100,9 @@ var _ TemplateGetter = &Workflow{}
 // WorkflowSpec is the specification of a Workflow.
 type WorkflowSpec struct {
 	// Templates is a list of workflow templates used in a workflow
-	Templates []Template `json:"templates"`
+	// +patchStrategy=merge
+	// +patchMergeKey=name
+	Templates []Template `json:"templates" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// Entrypoint is a template reference to the starting point of the workflow
 	Entrypoint string `json:"entrypoint"`

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -123,12 +123,16 @@ type WorkflowSpec struct {
 	Executor *ExecutorConfig `json:"executor,omitempty"`
 
 	// Volumes is a list of volumes that can be mounted by containers in a workflow.
-	Volumes []apiv1.Volume `json:"volumes,omitempty"`
+	// +patchStrategy=merge
+	// +patchMergeKey=name
+	Volumes []apiv1.Volume `json:"volumes,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// VolumeClaimTemplates is a list of claims that containers are allowed to reference.
 	// The Workflow controller will create the claims at the beginning of the workflow
 	// and delete the claims upon completion of the workflow
-	VolumeClaimTemplates []apiv1.PersistentVolumeClaim `json:"volumeClaimTemplates,omitempty"`
+	// +patchStrategy=merge
+	// +patchMergeKey=name
+	VolumeClaimTemplates []apiv1.PersistentVolumeClaim `json:"volumeClaimTemplates,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// Parallelism limits the max total parallel pods that can execute at the same time in a workflow
 	Parallelism *int64 `json:"parallelism,omitempty"`
@@ -149,13 +153,17 @@ type WorkflowSpec struct {
 	Affinity *apiv1.Affinity `json:"affinity,omitempty"`
 
 	// Tolerations to apply to workflow pods.
-	Tolerations []apiv1.Toleration `json:"tolerations,omitempty"`
+	// +patchStrategy=merge
+	// +patchMergeKey=key
+	Tolerations []apiv1.Toleration `json:"tolerations,omitempty" patchStrategy:"merge" patchMergeKey:"key"`
 
 	// ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images
 	// in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets
 	// can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet.
 	// More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
-	ImagePullSecrets []apiv1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	// +patchStrategy=merge
+	// +patchMergeKey=name
+	ImagePullSecrets []apiv1.LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// Host networking requested for this workflow pod. Default to false.
 	HostNetwork *bool `json:"hostNetwork,omitempty"`
@@ -208,7 +216,9 @@ type WorkflowSpec struct {
 	PodPriority *int32 `json:"podPriority,omitempty"`
 
 	// HostAliases is an optional list of hosts and IPs that will be injected into the pod spec
-	HostAliases []apiv1.HostAlias `json:"hostAliases,omitempty"`
+	// +patchStrategy=merge
+	// +patchMergeKey=ip
+	HostAliases []apiv1.HostAlias `json:"hostAliases,omitempty" patchStrategy:"merge" patchMergeKey:"ip"`
 
 	// SecurityContext holds pod-level security attributes and common container settings.
 	// Optional: Defaults to empty.  See type description for default values of each field.
@@ -269,14 +279,20 @@ type Template struct {
 	Suspend *SuspendTemplate `json:"suspend,omitempty"`
 
 	// Volumes is a list of volumes that can be mounted by containers in a template.
-	Volumes []apiv1.Volume `json:"volumes,omitempty"`
+	// +patchStrategy=merge
+	// +patchMergeKey=name
+	Volumes []apiv1.Volume `json:"volumes,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// InitContainers is a list of containers which run before the main container.
-	InitContainers []UserContainer `json:"initContainers,omitempty"`
+	// +patchStrategy=merge
+	// +patchMergeKey=name
+	InitContainers []UserContainer `json:"initContainers,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// Sidecars is a list of containers which run alongside the main container
 	// Sidecars are automatically killed when the main container completes
-	Sidecars []UserContainer `json:"sidecars,omitempty"`
+	// +patchStrategy=merge
+	// +patchMergeKey=name
+	Sidecars []UserContainer `json:"sidecars,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// Location in which all files related to the step will be stored (logs, artifacts, etc...).
 	// Can be overridden by individual items in Outputs. If omitted, will use the default
@@ -298,7 +314,9 @@ type Template struct {
 	Parallelism *int64 `json:"parallelism,omitempty"`
 
 	// Tolerations to apply to workflow pods.
-	Tolerations []apiv1.Toleration `json:"tolerations,omitempty"`
+	// +patchStrategy=merge
+	// +patchMergeKey=key
+	Tolerations []apiv1.Toleration `json:"tolerations,omitempty"  patchStrategy:"merge" patchMergeKey:"key"`
 
 	// If specified, the pod will be dispatched by specified scheduler.
 	// Or it will be dispatched by workflow scope scheduler if specified.
@@ -323,7 +341,9 @@ type Template struct {
 	Executor *ExecutorConfig `json:"executor,omitempty"`
 
 	// HostAliases is an optional list of hosts and IPs that will be injected into the pod spec
-	HostAliases []apiv1.HostAlias `json:"hostAliases,omitempty"`
+	// +patchStrategy=merge
+	// +patchMergeKey=ip
+	HostAliases []apiv1.HostAlias `json:"hostAliases,omitempty"  patchStrategy:"merge" patchMergeKey:"ip"`
 
 	// SecurityContext holds pod-level security attributes and common container settings.
 	// Optional: Defaults to empty.  See type description for default values of each field.
@@ -348,10 +368,14 @@ func (tmpl *Template) GetTemplateRef() *TemplateRef {
 // Inputs are the mechanism for passing parameters, artifacts, volumes from one template to another
 type Inputs struct {
 	// Parameters are a list of parameters passed as inputs
-	Parameters []Parameter `json:"parameters,omitempty"`
+	// +patchStrategy=merge
+	// +patchMergeKey=name
+	Parameters []Parameter `json:"parameters,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// Artifact are a list of artifacts passed as inputs
-	Artifacts []Artifact `json:"artifacts,omitempty"`
+	// +patchStrategy=merge
+	// +patchMergeKey=name
+	Artifacts []Artifact `json:"artifacts,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // Pod metdata
@@ -479,10 +503,14 @@ type ArtifactRepositoryRef struct {
 // Outputs hold parameters, artifacts, and results from a step
 type Outputs struct {
 	// Parameters holds the list of output parameters produced by a step
-	Parameters []Parameter `json:"parameters,omitempty"`
+	// +patchStrategy=merge
+	// +patchMergeKey=name
+	Parameters []Parameter `json:"parameters,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// Artifacts holds the list of output artifacts produced by a step
-	Artifacts []Artifact `json:"artifacts,omitempty"`
+	// +patchStrategy=merge
+	// +patchMergeKey=name
+	Artifacts []Artifact `json:"artifacts,omitempty"  patchStrategy:"merge" patchMergeKey:"name"`
 
 	// Result holds the result (stdout) of a script template
 	Result *string `json:"result,omitempty"`
@@ -601,10 +629,14 @@ type ArgumentsProvider interface {
 // Arguments to a template
 type Arguments struct {
 	// Parameters is the list of parameters to pass to the template or workflow
-	Parameters []Parameter `json:"parameters,omitempty"`
+	// +patchStrategy=merge
+	// +patchMergeKey=name
+	Parameters []Parameter `json:"parameters,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// Artifacts is the list of artifacts to pass to the template or workflow
-	Artifacts []Artifact `json:"artifacts,omitempty"`
+	// +patchStrategy=merge
+	// +patchMergeKey=name
+	Artifacts []Artifact `json:"artifacts,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 var _ ArgumentsProvider = &Arguments{}
@@ -1052,7 +1084,9 @@ type DAGTemplate struct {
 	Target string `json:"target,omitempty"`
 
 	// Tasks are a list of DAG tasks
-	Tasks []DAGTask `json:"tasks"`
+	// +patchStrategy=merge
+	// +patchMergeKey=name
+	Tasks []DAGTask `json:"tasks" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// This flag is for DAG logic. The DAG logic has a built-in "fail fast" feature to stop scheduling new steps,
 	// as soon as it detects that one of the DAG nodes is failed. Then it waits until all DAG nodes are completed


### PR DESCRIPTION
This change adds merge keys to the types defined by Argo, allowing the types to be recognized for StrategicMergePatching, as opposed to the less powerful JSONMergePatch strategy.

We have an example of this in action using [our branch of Kustomize](https://github.com/keleustes/kustomize/tree/armadacrd):

```
# Clone the following branch of Kustomize.
# This branch imports the branch referenced in this PR
git clone --single-branch --branch armadacrd git@github.com:keleustes/kustomize.git

# Build and install kustomize and its plugins.
# Note that this will overwrite the current copy of kustomize,
# as well as any previously compiled plugins stored in $HOME/.config/kustomize
make install build-plugins

# Run through the example for argo. Further instructions are found in the README there.
cd examples/crds/argo-workflow
cat README.md
```

This feature will be much more important as Kubernetes moves forward. It will eventually have an effect on how a `kubectl patch` works on Argo resources, as Kubernetes continues to improve support for CRDs. See [this PR adding CRD validation field in server-side apply](https://github.com/kubernetes/kubernetes/pull/77354) for example.

