### PR TITLE
Fix/persistence deployment

### DIFF
--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -122,3 +122,36 @@ data:
       enabled: true
       path: /telemetry
       port: 8080
+
+    # enable persistence using postgres
+    persistence:
+      connectionPool:
+        maxIdleConns: 100
+        maxOpenConns: 0
+      # save the entire workflow into etcd and DB
+      nodeStatusOffLoad: false
+      postgresql:
+        host: localhost
+        port: 5432
+        database: postgres
+        tableName: argo_workflows
+        # the database secrets must be in the same namespace of the controller
+        userNameSecret:
+          name: argo-postgres-config
+          key: username
+        passwordSecret:
+          name: argo-postgres-config
+          key: password
+
+      # Optional config for mysql:
+      # mysql:
+      #   host: localhost
+      #   port: 3306
+      #   database: argo
+      #   tableName: argo_workflows
+      #   userNameSecret:
+      #     name: argo-mysql-config
+      #     key: username
+      #   passwordSecret:
+      #     name: argo-mysql-config
+      #     key: password

--- a/manifests/cluster-install/workflow-controller-rbac/kustomization.yaml
+++ b/manifests/cluster-install/workflow-controller-rbac/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
 - workflow-aggregate-roles.yaml
 - workflow-controller-clusterrole.yaml
 - workflow-controller-clusterrolebinding.yaml
+- workflow-controller-role.yaml
+- workflow-controller-rolebinding.yaml

--- a/manifests/cluster-install/workflow-controller-rbac/workflow-controller-clusterrole.yaml
+++ b/manifests/cluster-install/workflow-controller-rbac/workflow-controller-clusterrole.yaml
@@ -59,9 +59,3 @@ rules:
   verbs:
   - get
   - list
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get

--- a/manifests/cluster-install/workflow-controller-rbac/workflow-controller-clusterrole.yaml
+++ b/manifests/cluster-install/workflow-controller-rbac/workflow-controller-clusterrole.yaml
@@ -59,3 +59,9 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get

--- a/manifests/cluster-install/workflow-controller-rbac/workflow-controller-role.yaml
+++ b/manifests/cluster-install/workflow-controller-rbac/workflow-controller-role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argo-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get

--- a/manifests/cluster-install/workflow-controller-rbac/workflow-controller-rolebinding.yaml
+++ b/manifests/cluster-install/workflow-controller-rbac/workflow-controller-rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argo-role
+subjects:
+  - kind: ServiceAccount
+    name: argo

--- a/manifests/namespace-install/workflow-controller-rbac/workflow-controller-role.yaml
+++ b/manifests/namespace-install/workflow-controller-rbac/workflow-controller-role.yaml
@@ -59,3 +59,9 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get


### PR DESCRIPTION
Some minor changes I found useful for deploying argo connected to a database for persistence:

- Allow `argo-cluster-role` to get `secrets` (need for DB credentials)
- Add `configmap` example for persistence setup (nice to have)