### PR TITLE
Updated the API Rule Violations list

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -223,6 +223,14 @@
   version = "v4.5.0"
 
 [[projects]]
+  digest = "1:b13707423743d41665fd23f0c36b2f37bb49c30e94adb813319c44188a51ba22"
+  name = "github.com/ghodss/yaml"
+  packages = ["."]
+  pruneopts = ""
+  revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:21911d0d3cecc86a42fd1920583c34a33b91035d77d4929772938961d7814ffc"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
@@ -1420,6 +1428,7 @@
     "github.com/argoproj/pkg/time",
     "github.com/colinmarc/hdfs",
     "github.com/evanphx/json-patch",
+    "github.com/ghodss/yaml",
     "github.com/go-openapi/spec",
     "github.com/gorilla/websocket",
     "github.com/mitchellh/go-ps",

--- a/pkg/apis/api-rules/violation_exceptions.list
+++ b/pkg/apis/api-rules/violation_exceptions.list
@@ -7,6 +7,8 @@ API rule violation: list_type_missing,github.com/argoproj/argo/pkg/apis/workflow
 API rule violation: list_type_missing,github.com/argoproj/argo/pkg/apis/workflow/v1alpha1,HDFSConfig,Addresses
 API rule violation: list_type_missing,github.com/argoproj/argo/pkg/apis/workflow/v1alpha1,Inputs,Artifacts
 API rule violation: list_type_missing,github.com/argoproj/argo/pkg/apis/workflow/v1alpha1,Inputs,Parameters
+API rule violation: list_type_missing,github.com/argoproj/argo/pkg/apis/workflow/v1alpha1,NodeStatus,Children
+API rule violation: list_type_missing,github.com/argoproj/argo/pkg/apis/workflow/v1alpha1,NodeStatus,OutboundNodes
 API rule violation: list_type_missing,github.com/argoproj/argo/pkg/apis/workflow/v1alpha1,Outputs,Artifacts
 API rule violation: list_type_missing,github.com/argoproj/argo/pkg/apis/workflow/v1alpha1,Outputs,Parameters
 API rule violation: list_type_missing,github.com/argoproj/argo/pkg/apis/workflow/v1alpha1,Template,HostAliases
@@ -22,6 +24,7 @@ API rule violation: list_type_missing,github.com/argoproj/argo/pkg/apis/workflow
 API rule violation: list_type_missing,github.com/argoproj/argo/pkg/apis/workflow/v1alpha1,WorkflowSpec,Tolerations
 API rule violation: list_type_missing,github.com/argoproj/argo/pkg/apis/workflow/v1alpha1,WorkflowSpec,VolumeClaimTemplates
 API rule violation: list_type_missing,github.com/argoproj/argo/pkg/apis/workflow/v1alpha1,WorkflowSpec,Volumes
+API rule violation: list_type_missing,github.com/argoproj/argo/pkg/apis/workflow/v1alpha1,WorkflowStatus,PersistentVolumeClaims
 API rule violation: list_type_missing,github.com/argoproj/argo/pkg/apis/workflow/v1alpha1,WorkflowStep,WithItems
 API rule violation: list_type_missing,github.com/argoproj/argo/pkg/apis/workflow/v1alpha1,WorkflowTemplateList,Items
 API rule violation: list_type_missing,github.com/argoproj/argo/pkg/apis/workflow/v1alpha1,WorkflowTemplateSpec,Templates


### PR DESCRIPTION
With the last PR #1614, the `verify-codegen` make command failed with the below exception

```
2019/09/23 13:27:29 OpenAPI code generation error: Failed executing generator: some packages had errors:
errors in package "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1":
output for "pkg/apis/api-rules/violation_exceptions.list" differs; first existing/expected diff: 
  "Outputs,Artifacts\nAPI rule violation: list_type_missing,github.com/argoproj/argo/pkg/apis/workflow/v"
  "NodeStatus,Children\nAPI rule violation: list_type_missing,github.com/argoproj/argo/pkg/apis/workflow"

exit status 1
make: *** [verify-codegen] Error 1
```

This PR fixes the error, by updating the API Rule Violations lists.