### PR TITLE
pin colinmarc/hdfs to the next commit, which no longer has vendored deps

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -142,7 +142,7 @@
   version = "v0.2.1"
 
 [[projects]]
-  digest = "1:5cf8a8393124ac3d5632a8c51d08d8ff2aa29b6b328306cb8b7560a7e83cf760"
+  digest = "1:033dc1954ef1a33b1dba9fe5dc4296a4c8bcfbbd0e6f257b45585cc78ad7e3d5"
   name = "github.com/colinmarc/hdfs"
   packages = [
     ".",
@@ -151,7 +151,7 @@
     "rpc",
   ]
   pruneopts = ""
-  revision = "48eb8d6c34a97ffc73b406356f0f2e1c569b42a5"
+  revision = "9746310a4d311e21ce43b2a645c5a1e64c5e8efa"
 
 [[projects]]
   digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -58,7 +58,7 @@ required = [
 
 [[constraint]]
   name = "github.com/colinmarc/hdfs"
-  revision = "48eb8d6c34a97ffc73b406356f0f2e1c569b42a5"
+  revision = "9746310a4d311e21ce43b2a645c5a1e64c5e8efa"
 
 [[constraint]]
   name = "gopkg.in/jcmturner/gokrb5.v5"


### PR DESCRIPTION
### Description

When attempting to bump Argo to `2.3.1` in Nixpkgs (ref: https://github.com/NixOS/nixpkgs/pull/69139) I ran into the following build problem: 

```
go/src/github.com/argoproj/argo/workflow/artifacts/hdfs/util.go:21:26: cannot use krbClient (type *"gopkg.in/jcmturner/gokrb5.v5/client".Client) as type *"github.com/colinmarc/hdfs/vendor/gopkg.in/jcmturner/gokrb5.v5/client".Client in assignment
builder for '/nix/store/wfpzhnc91l4mdk4jxz37y743nqqhpbhk-argo-2.3.0.dr
```

The problem is still there on `2.4.0-rc1`.

After noticing that the very next commit in `colinmarc/hdfs` removes vendored deps, I guessed that going to that commit would solve the problem. It did!

So while I don't know why this issue is presenting when Nix is trying to build Argo `2.3.1`, this change at least removes the problem. 

