### PR TITLE
Increase timeout of golangci-lint

### DIFF
--- a/golangci.yml
+++ b/golangci.yml
@@ -3,6 +3,7 @@ run:
   tests: false
   skip-files:
     - "pkg/client"
+  deadline: 10m
 output:
   format: colored-line-number
   print-issued-lines: true


### PR DESCRIPTION
I increased the timeout duration of golangci-lint.