### PR TITLE
Save stored template ID in nodes

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -596,6 +596,10 @@
           "description": "Time at which this node started",
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
         },
+        "storedTemplateID": {
+          "description": "StoredTemplateID is the ID of stored template.",
+          "type": "string"
+        },
         "templateName": {
           "description": "TemplateName is the template name which this node corresponds to. Not applicable to virtual nodes (e.g. Retry, StepGroup)",
           "type": "string"

--- a/pkg/apis/workflow/v1alpha1/openapi_generated.go
+++ b/pkg/apis/workflow/v1alpha1/openapi_generated.go
@@ -1050,6 +1050,13 @@ func schema_pkg_apis_workflow_v1alpha1_NodeStatus(ref common.ReferenceCallback) 
 							Ref:         ref("github.com/argoproj/argo/pkg/apis/workflow/v1alpha1.TemplateRef"),
 						},
 					},
+					"storedTemplateID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "StoredTemplateID is the ID of stored template.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"workflowTemplateName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "WorkflowTemplateName is the WorkflowTemplate resource name on which the resolved template of this node is retrieved.",


### PR DESCRIPTION
I added `StoredTemplateID` which is used to refer a template in `StoredTemplates`. I added this field because it will be easy to change the logic to store templates (e.g. using MD5, just index or something) in the future.