### PR TITLE
Fix retry workflow state

### DIFF
--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -522,6 +522,13 @@ func RetryWorkflow(kubeClient kubernetes.Interface, wfClient v1alpha1.WorkflowIn
 			if err != nil && !apierr.IsNotFound(err) {
 				return nil, errors.InternalWrapError(err)
 			}
+		} else if node.Name == wf.ObjectMeta.Name {
+			newNode := node.DeepCopy()
+			newNode.Phase = wfv1.NodeRunning
+			newNode.Message = ""
+			newNode.FinishedAt = metav1.Time{}
+			newWF.Status.Nodes[newNode.ID] = *newNode
+			continue
 		}
 	}
 


### PR DESCRIPTION
I found the state of a retried workflow is not correct and already run nodes are not printed correctly until it is processed. I fixed the CLI so it can print the initial state of a retry correctly.

I tried the following workflow which fails at last always.

<details>
<summary>steps.yaml</summary>

```
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: steps-
spec:
  entrypoint: hello-hello-hello

  templates:
  - name: hello-hello-hello
    steps:
    - - name: hello1
        template: whalesay
        arguments:
          parameters: [{name: message, value: "hello1"}]
    - - name: hello2a
        template: whalesay
        arguments:
          parameters: [{name: message, value: "hello2a"}]
      - name: hello2b
        template: whalesay
        arguments:
          parameters: [{name: message, value: "hello2b"}]
      - name: fail
        template: fail
  - name: fail
    container:
      image: ubuntu:16.04
      command: [exit, 1]
  - name: whalesay
    inputs:
      parameters:
      - name: message
    container:
      image: docker/whalesay
      command: [cowsay]
      args: ["{{inputs.parameters.message}}"]
```

</details>

Here's the output of `argo get` before the fix.

```
$ argo retry steps-jblk7
INFO[0000] Deleting pod: steps-jblk7-3455248740
Name:                steps-jblk7
Namespace:           default
ServiceAccount:      default
Status:              Running
Created:             Tue Oct 01 13:54:16 +0900 (6 minutes ago)
Started:             Tue Oct 01 13:54:16 +0900 (6 minutes ago)
Duration:            6 minutes 55 seconds
```

And here's the output after the fix.

```
$ argo retry steps-jblk7
INFO[0000] Deleting pod: steps-jblk7-3455248740
Name:                steps-jblk7
Namespace:           default
ServiceAccount:      default
Status:              Running
Created:             Tue Oct 01 13:54:16 +0900 (8 minutes ago)
Started:             Tue Oct 01 13:54:16 +0900 (8 minutes ago)
Duration:            8 minutes 33 seconds

STEP                                PODNAME                 DURATION  MESSAGE
 ● steps-jblk7 (hello-hello-hello)
 ├---✔ hello1 (whalesay)            steps-jblk7-3804894428  8s
 ├-✔ hello2a (whalesay)             steps-jblk7-3956637645  11s
 └-✔ hello2b (whalesay)             steps-jblk7-3906304788  13s
```