### PR TITLE
Delay killing sidecars until artifacts are saved (#1282)

### DIFF
--- a/cmd/argoexec/commands/wait.go
+++ b/cmd/argoexec/commands/wait.go
@@ -34,24 +34,26 @@ func waitContainer() error {
 		wfExecutor.AddError(err)
 		// do not return here so we can still try to kill sidecars & save outputs
 	}
-	err = wfExecutor.KillSidecars()
-	if err != nil {
-		wfExecutor.AddError(err)
-		// do not return here so we can still try save outputs
-	}
+	// Saving logs
 	logArt, err := wfExecutor.SaveLogs()
 	if err != nil {
 		wfExecutor.AddError(err)
-		return err
+		// do not return here so we can still try to kill sidecars
 	}
 	// Saving output parameters
 	err = wfExecutor.SaveParameters()
 	if err != nil {
 		wfExecutor.AddError(err)
-		return err
+		// do not return here so we can still try to kill sidecars
 	}
 	// Saving output artifacts
 	err = wfExecutor.SaveArtifacts()
+	if err != nil {
+		wfExecutor.AddError(err)
+		// do not return here so we can still try to kill sidecars
+	}
+	// Killing sidecar containers
+	err = wfExecutor.KillSidecars()
 	if err != nil {
 		wfExecutor.AddError(err)
 		return err


### PR DESCRIPTION
* Supports service meshes such as Istio where all traffic is routed
through the sidecar.