### PR TITLE
Fix DAG output aggregation

### DIFF
--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -446,11 +446,7 @@ func (woc *wfOperationCtx) resolveDependencyReferences(dagCtx *dagContext, task 
 					ancestorNodes = append(ancestorNodes, node)
 				}
 			}
-			tmpl := dagCtx.wf.GetStoredOrLocalTemplate(ancestorNode)
-			if tmpl != nil {
-				return nil, errors.InternalErrorf("Template of ancestor node '%s' not found", ancestorNode.Name)
-			}
-			err := woc.processAggregateNodeOutputs(tmpl, &scope, prefix, ancestorNodes)
+			err := woc.processAggregateNodeOutputs(nil, &scope, prefix, ancestorNodes)
 			if err != nil {
 				return nil, errors.InternalWrapError(err)
 			}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1675,7 +1675,7 @@ func (woc *wfOperationCtx) processAggregateNodeOutputs(tmpl *wfv1.Template, scop
 			}
 		}
 	}
-	if tmpl.GetType() == wfv1.TemplateTypeScript {
+	if tmpl != nil && tmpl.GetType() == wfv1.TemplateTypeScript {
 		resultsJSON, err := json.Marshal(resultsList)
 		if err != nil {
 			return err


### PR DESCRIPTION
A task group ancestor node doesn't have a template and caused a template unavailable error.