### PR TITLE
Print multiple workflows in one command

### DIFF
--- a/cmd/argo/commands/get.go
+++ b/cmd/argo/commands/get.go
@@ -37,15 +37,17 @@ func NewGetCommand() *cobra.Command {
 				os.Exit(1)
 			}
 			wfClient := InitWorkflowClient()
-			wf, err := wfClient.Get(args[0], metav1.GetOptions{})
-			if err != nil {
-				log.Fatal(err)
+			for _, arg := range args {
+				wf, err := wfClient.Get(arg, metav1.GetOptions{})
+				if err != nil {
+					log.Fatal(err)
+				}
+				err = util.DecompressWorkflow(wf)
+				if err != nil {
+					log.Fatal(err)
+				}
+				printWorkflow(wf, getArgs.output, getArgs.status)
 			}
-			err = util.DecompressWorkflow(wf)
-			if err != nil {
-				log.Fatal(err)
-			}
-			printWorkflow(wf, getArgs.output, getArgs.status)
 		},
 	}
 

--- a/cmd/argo/commands/template/get.go
+++ b/cmd/argo/commands/template/get.go
@@ -27,11 +27,13 @@ func NewGetCommand() *cobra.Command {
 				os.Exit(1)
 			}
 			wftmplClient := InitWorkflowTemplateClient()
-			wftmpl, err := wftmplClient.Get(args[0], metav1.GetOptions{})
-			if err != nil {
-				log.Fatal(err)
+			for _, arg := range args {
+				wftmpl, err := wftmplClient.Get(arg, metav1.GetOptions{})
+				if err != nil {
+					log.Fatal(err)
+				}
+				printWorkflowTemplate(wftmpl, output)
 			}
-			printWorkflowTemplate(wftmpl, output)
 		},
 	}
 


### PR DESCRIPTION
Currently, `argo get` just ignores workflows other than the first one while `kubectl describe` can print multiple resources. I think it's reasonable to follow the spec. I also changed the behavior for `WorkflowTemplate` as well.

The output of multiple workflow printing will be like below.
```
$ argo get continue-on-fail-znnhj dag-daemon-task-2txg5
Name:                continue-on-fail-znnhj
Namespace:           default
ServiceAccount:      default
Status:              Succeeded
Created:             Sun Oct 06 16:07:37 +0900 (20 minutes ago)
Started:             Sun Oct 06 16:07:38 +0900 (20 minutes ago)
Finished:            Sun Oct 06 16:25:01 +0900 (2 minutes ago)
Duration:            17 minutes 23 seconds

STEP                                         PODNAME                            DURATION  MESSAGE
 ✔ continue-on-fail-znnhj (workflow-ignore)
 ├---✔ A (whalesay)                          continue-on-fail-znnhj-3643801775  1m
 ├-·-✔ B (whalesay)                          continue-on-fail-znnhj-1338814275  6m
 | └-✖ C (intentional-fail)                  continue-on-fail-znnhj-1322036656  8m        failed with exit code 1
 └---✔ D (whalesay)                          continue-on-fail-znnhj-444230942   1m
Name:                dag-daemon-task-2txg5
Namespace:           default
ServiceAccount:      default
Status:              Succeeded
Created:             Sun Oct 06 16:07:38 +0900 (20 minutes ago)
Started:             Sun Oct 06 16:07:39 +0900 (20 minutes ago)
Finished:            Sun Oct 06 16:25:14 +0900 (2 minutes ago)
Duration:            17 minutes 35 seconds

STEP                                       PODNAME                           DURATION  MESSAGE
 ✔ dag-daemon-task-2txg5 (daemon-example)
 ├-✔ influx (influxdb)                     dag-daemon-task-2txg5-474060011   2m
 ├-✔ init-database (influxdb-client)       dag-daemon-task-2txg5-1742263985  5m
 ├-✔ producer-1 (influxdb-client)          dag-daemon-task-2txg5-2574892151  8m
 ├-✔ producer-2 (influxdb-client)          dag-daemon-task-2txg5-2591669770  7m
 ├-✔ producer-3 (influxdb-client)          dag-daemon-task-2txg5-2608447389  6m
 └-✔ consumer (influxdb-client)            dag-daemon-task-2txg5-2449122295  51s
```

The output of multiple workflow template printing is like below. We still need to improve the output format, but it should not be the scope of this PR.

```
$ argo template get workflow-template-inner-dag workflow-template-inner-steps
Name:                workflow-template-inner-dag
Namespace:           default
Created:             Fri Aug 23 19:15:01 +0900 (1 month ago)
Name:                workflow-template-inner-steps
Namespace:           default
Created:             Fri Aug 23 19:14:59 +0900 (1 month ago)
```