### PR TITLE
Stop failing if artifact file exists, but empty

### DIFF
--- a/util/file/fileutil.go
+++ b/util/file/fileutil.go
@@ -30,7 +30,7 @@ func ExistsInTar(sourcePath string, tarReader TarReader) bool {
 		if hdr.FileInfo().IsDir() && strings.Contains(sourcePath, strings.Trim(hdr.Name, "/")) {
 			return true
 		}
-		if strings.Contains(sourcePath, hdr.Name) && hdr.Size > 0 {
+		if strings.Contains(sourcePath, hdr.Name) {
 			return true
 		}
 	}

--- a/util/file/fileutil_test.go
+++ b/util/file/fileutil_test.go
@@ -97,16 +97,14 @@ func TestExistsInTar(t *testing.T) {
 			},
 		},
 		{
-			sourcePath: "/empty.txt", expected: false,
+			sourcePath: "/empty.txt", expected: true,
 			files: []fakeFile{
-				// fails because empty.txt is empty
 				{name: "empty.txt", body: ""},
 			},
 		},
 		{
-			sourcePath: "/tmp/empty.txt", expected: false,
+			sourcePath: "/tmp/empty.txt", expected: true,
 			files: []fakeFile{
-				// fails because empty.txt is empty
 				{name: "empty.txt", body: ""},
 			},
 		},

--- a/workflow/executor/docker/docker.go
+++ b/workflow/executor/docker/docker.go
@@ -61,7 +61,7 @@ func (d *DockerExecutor) CopyFile(containerID string, sourcePath string, destPat
 		return err
 	}
 	if !file.ExistsInTar(sourcePath, tar.NewReader(gzipReader)) {
-		errMsg := fmt.Sprintf("path %s does not exist (or %s is empty) in archive %s", sourcePath, sourcePath, destPath)
+		errMsg := fmt.Sprintf("path %s does not exist in archive %s", sourcePath, destPath)
 		log.Warn(errMsg)
 		return errors.Errorf(errors.CodeNotFound, errMsg)
 	}


### PR DESCRIPTION

Empty output artifacts are a valid and desired use case. (Think of `grep` or any other filtering program where one of the outputs can be empty.)
Argo failing on empty outputs was a pretty bad surprise for us.

Fixes https://github.com/argoproj/argo/issues/1642
The problem was introduced in https://github.com/argoproj/argo/pulls/1247