### PR TITLE
Store locally referenced templates properly

### DIFF
--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -76,6 +76,7 @@ type TemplateGetter interface {
 type TemplateHolder interface {
 	GetTemplateName() string
 	GetTemplateRef() *TemplateRef
+	IsResolvable() bool
 }
 
 // Workflow is the definition of a workflow resource
@@ -367,6 +368,10 @@ func (tmpl *Template) GetTemplateRef() *TemplateRef {
 	return tmpl.TemplateRef
 }
 
+func (tmpl *Template) IsResolvable() bool {
+	return tmpl.Template != "" || tmpl.TemplateRef != nil
+}
+
 // GetBaseTemplate returns a base template content.
 func (tmpl *Template) GetBaseTemplate() *Template {
 	baseTemplate := tmpl.DeepCopy()
@@ -565,6 +570,10 @@ func (step *WorkflowStep) GetTemplateName() string {
 
 func (step *WorkflowStep) GetTemplateRef() *TemplateRef {
 	return step.TemplateRef
+}
+
+func (step *WorkflowStep) IsResolvable() bool {
+	return true
 }
 
 // Item expands a single workflow step into multiple parallel steps
@@ -771,16 +780,6 @@ type NodeStatus struct {
 	// a DAG/steps template invokes another DAG/steps template. In other words, the outbound nodes of
 	// a template, will be a superset of the outbound nodes of its last children.
 	OutboundNodes []string `json:"outboundNodes,omitempty"`
-}
-
-var _ TemplateHolder = &NodeStatus{}
-
-func (n *NodeStatus) GetTemplateName() string {
-	return n.TemplateName
-}
-
-func (n *NodeStatus) GetTemplateRef() *TemplateRef {
-	return n.TemplateRef
 }
 
 func (n NodeStatus) String() string {
@@ -1156,6 +1155,10 @@ func (t *DAGTask) GetTemplateName() string {
 
 func (t *DAGTask) GetTemplateRef() *TemplateRef {
 	return t.TemplateRef
+}
+
+func (t *DAGTask) IsResolvable() bool {
+	return true
 }
 
 // SuspendTemplate is a template subtype to suspend a workflow at a predetermined point in time

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1315,8 +1315,14 @@ func (woc *wfOperationCtx) initializeExecutableNode(nodeName string, nodeType wf
 	// Store the template for the later use.
 	if node.TemplateRef != nil {
 		node.StoredTemplateID = fmt.Sprintf("%s/%s", node.TemplateRef.Name, node.TemplateRef.Template)
-	} else if node.WorkflowTemplateName != "" {
-		node.StoredTemplateID = fmt.Sprintf("%s/%s", node.WorkflowTemplateName, node.TemplateName)
+	} else if node.TemplateName != "" {
+		if node.WorkflowTemplateName != "" {
+			// Locally resolvable in workflow template level.
+			node.StoredTemplateID = fmt.Sprintf("%s/%s", node.WorkflowTemplateName, node.TemplateName)
+		} else if orgTmpl.IsResolvable() {
+			// Locally resolvable in workflow level.
+			node.StoredTemplateID = fmt.Sprintf("/%s", node.TemplateName)
+		}
 	}
 	if node.StoredTemplateID != "" {
 		baseTemplate := executeTmpl.GetBaseTemplate()


### PR DESCRIPTION
Locally referenced templates cannot be executed successfully because the reference is not found in stored templates but found local templates still need to be resolved. Here's an example that reproduces the issue besides `examples/workflow-template/local-ref.yaml`.

```
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: argo-dag-
spec:
  entrypoint: dag
  templates:
  - dag:
      tasks:
      - name: task1
        template: container1-proxy
    name: dag
  - name: container1-proxy
    template: container1
  - container:
      image: python:alpine3.6
      command: [python, -c]
      args: ["import sys; sys.exit(0)"]
    name: container1
```