### PR TITLE
PodSpecPatch functionality 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1466,6 +1466,7 @@
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/clock",
     "k8s.io/apimachinery/pkg/util/runtime",
+    "k8s.io/apimachinery/pkg/util/strategicpatch",
     "k8s.io/apimachinery/pkg/util/validation",
     "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/apimachinery/pkg/version",

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1084,6 +1084,7 @@
           "format": "int64"
         },
         "podSpecPatch": {
+          "description": "PodSpecPatch holds json patch string to merge on Pod spec. Controller is using StrategicMergePatch to merge it.",
           "type": "string"
         },
         "priority": {
@@ -1493,6 +1494,7 @@
           "type": "string"
         },
         "podSpecPatch": {
+          "description": "PodSpecPatch holds json patch string to merge on Pod spec. Controller is using StrategicMergePatch to merge it.",
           "type": "string"
         },
         "priority": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1084,7 +1084,7 @@
           "format": "int64"
         },
         "podSpecPatch": {
-          "description": "PodSpecPatch holds json patch string to merge on Pod spec. Controller is using StrategicMergePatch to merge it.",
+          "description": "PodSpecPatch holds strategic merge patch to apply against the pod spec. Allows parameterization of container fields which are not strings (e.g. resource limits).",
           "type": "string"
         },
         "priority": {
@@ -1494,7 +1494,7 @@
           "type": "string"
         },
         "podSpecPatch": {
-          "description": "PodSpecPatch holds json patch string to merge on Pod spec. Controller is using StrategicMergePatch to merge it.",
+          "description": "PodSpecPatch holds strategic merge patch to apply against the pod spec. Allows parameterization of container fields which are not strings (e.g. resource limits).",
           "type": "string"
         },
         "priority": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1083,6 +1083,9 @@
           "type": "integer",
           "format": "int64"
         },
+        "podSpecPatch": {
+          "type": "string"
+        },
         "priority": {
           "description": "Priority to apply to workflow pods.",
           "type": "integer",
@@ -1487,6 +1490,9 @@
         },
         "podPriorityClassName": {
           "description": "PriorityClassName to apply to workflow pods.",
+          "type": "string"
+        },
+        "podSpecPatch": {
           "type": "string"
         },
         "priority": {

--- a/examples/pod-spec-patch-wf-tmpl.yaml
+++ b/examples/pod-spec-patch-wf-tmpl.yaml
@@ -8,6 +8,14 @@ spec:
     parameters:
       - name: cpu-limit
         value: 100m
+      - name: mem-limit
+        value: 100Mi
+  podSpecPatch: |
+    containers:
+      - name: main
+        resources:
+          limits:
+            memory: "{{workflow.parameters.mem-limit}}"
   templates:
   - name: whalesay
     podSpecPatch: '{"containers":[{"name":"main", "resources":{"limits":{"cpu": "{{workflow.parameters.cpu-limit}}" }}}]}'

--- a/examples/pod-spec-patch.yaml
+++ b/examples/pod-spec-patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: pod-spec-patch-
+spec:
+  entrypoint: whalesay
+  arguments:
+    parameters:
+      - name: message
+        value: 100m
+
+  templates:
+  - name: whalesay
+    podspecpatch: '{"containers":[{"name":"main", "resources":{"limits":{"cpu": "{{workflow.parameters.message}}"}}}]}'
+    container:
+      image: docker/whalesay:latest
+      command: [cowsay]
+      args: ["hello world"]

--- a/examples/pod-spec-yaml-patch.yaml
+++ b/examples/pod-spec-yaml-patch.yaml
@@ -6,11 +6,16 @@ spec:
   entrypoint: whalesay
   arguments:
     parameters:
-      - name: cpu-limit
-        value: 100m
+      - name: mem-limit
+        value: 100Mi
+  podSpecPatch: |
+    containers:
+      - name: main
+        resources:
+          limits:
+            memory: "{{workflow.parameters.mem-limit}}"
   templates:
   - name: whalesay
-    podSpecPatch: '{"containers":[{"name":"main", "resources":{"limits":{"cpu": "{{workflow.parameters.cpu-limit}}" }}}]}'
     container:
       image: docker/whalesay:latest
       command: [cowsay]

--- a/pkg/apis/workflow/v1alpha1/openapi_generated.go
+++ b/pkg/apis/workflow/v1alpha1/openapi_generated.go
@@ -2128,6 +2128,12 @@ func schema_pkg_apis_workflow_v1alpha1_Template(ref common.ReferenceCallback) co
 							Ref:         ref("k8s.io/api/core/v1.PodSecurityContext"),
 						},
 					},
+					"podSpecPatch": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"name"},
 			},
@@ -2816,6 +2822,12 @@ func schema_pkg_apis_workflow_v1alpha1_WorkflowSpec(ref common.ReferenceCallback
 						SchemaProps: spec.SchemaProps{
 							Description: "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.",
 							Ref:         ref("k8s.io/api/core/v1.PodSecurityContext"),
+						},
+					},
+					"podSpecPatch": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 				},

--- a/pkg/apis/workflow/v1alpha1/openapi_generated.go
+++ b/pkg/apis/workflow/v1alpha1/openapi_generated.go
@@ -2130,7 +2130,7 @@ func schema_pkg_apis_workflow_v1alpha1_Template(ref common.ReferenceCallback) co
 					},
 					"podSpecPatch": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PodSpecPatch holds json patch string to merge on Pod spec. Controller is using StrategicMergePatch to merge it.",
+							Description: "PodSpecPatch holds strategic merge patch to apply against the pod spec. Allows parameterization of container fields which are not strings (e.g. resource limits).",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2827,7 +2827,7 @@ func schema_pkg_apis_workflow_v1alpha1_WorkflowSpec(ref common.ReferenceCallback
 					},
 					"podSpecPatch": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PodSpecPatch holds json patch string to merge on Pod spec. Controller is using StrategicMergePatch to merge it.",
+							Description: "PodSpecPatch holds strategic merge patch to apply against the pod spec. Allows parameterization of container fields which are not strings (e.g. resource limits).",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/workflow/v1alpha1/openapi_generated.go
+++ b/pkg/apis/workflow/v1alpha1/openapi_generated.go
@@ -2130,8 +2130,9 @@ func schema_pkg_apis_workflow_v1alpha1_Template(ref common.ReferenceCallback) co
 					},
 					"podSpecPatch": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "PodSpecPatch holds json patch string to merge on Pod spec. Controller is using StrategicMergePatch to merge it.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -2826,8 +2827,9 @@ func schema_pkg_apis_workflow_v1alpha1_WorkflowSpec(ref common.ReferenceCallback
 					},
 					"podSpecPatch": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "PodSpecPatch holds json patch string to merge on Pod spec. Controller is using StrategicMergePatch to merge it.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -227,8 +227,14 @@ type WorkflowSpec struct {
 	// +optional
 	SecurityContext *apiv1.PodSecurityContext `json:"securityContext,omitempty"`
 
-	// PodSpecPatch holds json patch string to merge on Pod spec. Controller is using StrategicMergePatch to merge it.
+	// PodSpecPatch holds strategic merge patch to apply against the pod spec. Allows parameterization of
+	// container fields which are not strings (e.g. resource limits).
 	PodSpecPatch string `json:"podSpecPatch,omitempty"`
+}
+
+
+func (wfs *WorkflowSpec) HasPodSpecPatch() bool {
+	return wfs.PodSpecPatch != ""
 }
 
 // Template is a reusable and composable unit of execution in a workflow
@@ -355,7 +361,8 @@ type Template struct {
 	// +optional
 	SecurityContext *apiv1.PodSecurityContext `json:"securityContext,omitempty"`
 
-	// PodSpecPatch holds json patch string to merge on Pod spec. Controller is using StrategicMergePatch to merge it.
+	// PodSpecPatch holds strategic merge patch to apply against the pod spec. Allows parameterization of
+	// container fields which are not strings (e.g. resource limits).
 	PodSpecPatch string `json:"podSpecPatch,omitempty"`
 }
 
@@ -379,6 +386,11 @@ func (tmpl *Template) GetBaseTemplate() *Template {
 	baseTemplate.Inputs = Inputs{}
 	return baseTemplate
 }
+
+func (tmpl *Template) HasPodSpecPatch() bool {
+	return tmpl.PodSpecPatch != ""
+}
+
 
 // Inputs are the mechanism for passing parameters, artifacts, volumes from one template to another
 type Inputs struct {

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -232,7 +232,6 @@ type WorkflowSpec struct {
 	PodSpecPatch string `json:"podSpecPatch,omitempty"`
 }
 
-
 func (wfs *WorkflowSpec) HasPodSpecPatch() bool {
 	return wfs.PodSpecPatch != ""
 }
@@ -390,7 +389,6 @@ func (tmpl *Template) GetBaseTemplate() *Template {
 func (tmpl *Template) HasPodSpecPatch() bool {
 	return tmpl.PodSpecPatch != ""
 }
-
 
 // Inputs are the mechanism for passing parameters, artifacts, volumes from one template to another
 type Inputs struct {

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -226,6 +226,9 @@ type WorkflowSpec struct {
 	// Optional: Defaults to empty.  See type description for default values of each field.
 	// +optional
 	SecurityContext *apiv1.PodSecurityContext `json:"securityContext,omitempty"`
+
+	// PodSpecPatch holds json patch string to merge on Pod spec. Controller is using StrategicMergePatch to merge it.
+	PodSpecPatch string `json:"podSpecPatch,omitempty"`
 }
 
 // Template is a reusable and composable unit of execution in a workflow
@@ -351,6 +354,9 @@ type Template struct {
 	// Optional: Defaults to empty.  See type description for default values of each field.
 	// +optional
 	SecurityContext *apiv1.PodSecurityContext `json:"securityContext,omitempty"`
+
+	// PodSpecPatch holds json patch string to merge on Pod spec. Controller is using StrategicMergePatch to merge it.
+	PodSpecPatch string `json:"podSpecPatch,omitempty"`
 }
 
 var _ TemplateHolder = &Template{}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1128,8 +1128,17 @@ func (woc *wfOperationCtx) executeTemplate(nodeName string, orgTmpl wfv1.Templat
 	}
 
 	newTmplCtx, basedTmpl, err := woc.getResolvedTemplate(node, orgTmpl, tmplCtx, args)
+
 	if err != nil {
 		return woc.initializeNodeOrMarkError(node, nodeName, wfv1.NodeTypeSkipped, orgTmpl, boundaryID, err), err
+	}
+
+	if woc.wf.Spec.HasPodSpecPatch() {
+		err = util.PodSpecPatchMerge(woc.wf, basedTmpl)
+		fmt.Println(basedTmpl.PodSpecPatch)
+		if err != nil {
+			return woc.initializeNodeOrMarkError(node, nodeName, wfv1.NodeTypeSkipped, orgTmpl, boundaryID, err), err
+		}
 	}
 
 	localParams := make(map[string]string)

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1132,15 +1132,6 @@ func (woc *wfOperationCtx) executeTemplate(nodeName string, orgTmpl wfv1.Templat
 	if err != nil {
 		return woc.initializeNodeOrMarkError(node, nodeName, wfv1.NodeTypeSkipped, orgTmpl, boundaryID, err), err
 	}
-
-	if woc.wf.Spec.HasPodSpecPatch() {
-		err = util.PodSpecPatchMerge(woc.wf, basedTmpl)
-		fmt.Println(basedTmpl.PodSpecPatch)
-		if err != nil {
-			return woc.initializeNodeOrMarkError(node, nodeName, wfv1.NodeTypeSkipped, orgTmpl, boundaryID, err), err
-		}
-	}
-
 	localParams := make(map[string]string)
 	if basedTmpl.IsPodType() {
 		localParams[common.LocalVarPodName] = woc.wf.NodeID(nodeName)

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -233,6 +233,11 @@ func (woc *wfOperationCtx) createWorkflowPod(nodeName string, mainCtr apiv1.Cont
 			}
 		}
 		jsonstr, err := json.Marshal(pod.Spec)
+
+		if err != nil {
+			return nil, errors.Wrap(err, "", "Fail to marshal the Pod spec")
+		}
+
 		var spec apiv1.PodSpec
 		err = json.Unmarshal([]byte(tmpl.PodSpecPatch), &spec)
 

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -232,19 +232,15 @@ func (woc *wfOperationCtx) createWorkflowPod(nodeName string, mainCtr apiv1.Cont
 				return nil, err
 			}
 		}
-		podSpecPatch := tmpl.PodSpecPatch
 		jsonstr, err := json.Marshal(pod.Spec)
-
 		var spec apiv1.PodSpec
-		fmt.Println(podSpecPatch)
-
-		err = json.Unmarshal([]byte(podSpecPatch), &spec)
+		err = json.Unmarshal([]byte(tmpl.PodSpecPatch), &spec)
 
 		if err != nil {
 			return nil, errors.Wrap(err, "", "Invalid PodSpecPatch String")
 		}
 
-		modJson, err := strategicpatch.StrategicMergePatch(jsonstr, []byte(podSpecPatch), apiv1.PodSpec{})
+		modJson, err := strategicpatch.StrategicMergePatch(jsonstr, []byte(tmpl.PodSpecPatch), apiv1.PodSpec{})
 
 		if err != nil {
 			return nil, errors.Wrap(err, "", "Error occured during strategicpatch")

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -914,7 +914,7 @@ spec:
       args: ["hello world"]
 `
 
-var helloWorldWfWithWFYMALPatch = `
+var helloWorldWfWithWFYAMLPatch = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
@@ -949,7 +949,7 @@ func TestPodSpecPatch(t *testing.T) {
 	pod, _ = woc.createWorkflowPod(wf.Name, *mainCtr, &wf.Spec.Templates[0], false)
 	assert.Equal(t, "0.800", pod.Spec.Containers[1].Resources.Limits.Cpu().AsDec().String())
 
-	wf = unmarshalWF(helloWorldWfWithWFYMALPatch)
+	wf = unmarshalWF(helloWorldWfWithWFYAMLPatch)
 	woc = newWoc(*wf)
 	mainCtr = woc.wf.Spec.Templates[0].Container
 	pod, _ = woc.createWorkflowPod(wf.Name, *mainCtr, &wf.Spec.Templates[0], false)

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -898,12 +898,63 @@ spec:
       args: ["hello world"]
 `
 
+var helloWorldWfWithWFPatch = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: hello-world
+spec:
+  entrypoint: whalesay
+  podSpecPatch: '{"containers":[{"name":"main", "resources":{"limits":{"cpu": "800m"}}}]}'
+  templates:
+  - name: whalesay
+    container:
+      image: docker/whalesay:latest
+      command: [cowsay]
+      args: ["hello world"]
+`
+
+var helloWorldWfWithWFYMALPatch = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: hello-world
+spec:
+  entrypoint: whalesay
+  podSpecPatch: |
+    containers:
+      - name: main
+        resources:
+          limits:
+            cpu: "800m"
+  templates:
+  - name: whalesay
+    podSpecPatch: '{"containers":[{"name":"main", "resources":{"limits":{"memory": "100Mi"}}}]}'
+    container:
+      image: docker/whalesay:latest
+      command: [cowsay]
+      args: ["hello world"]
+`
+
 func TestPodSpecPatch(t *testing.T) {
 	wf := unmarshalWF(helloWorldWfWithPatch)
 	woc := newWoc(*wf)
 	mainCtr := woc.wf.Spec.Templates[0].Container
-	//mainCtr.Args = append(mainCtr.Args, common.ExecutorScriptSourcePath)
 	pod, _ := woc.createWorkflowPod(wf.Name, *mainCtr, &wf.Spec.Templates[0], false)
-	fmt.Println(pod.Spec.Containers[1].Resources.Limits.Cpu().AsInt64())
 	assert.Equal(t, "0.800", pod.Spec.Containers[1].Resources.Limits.Cpu().AsDec().String())
+
+	wf = unmarshalWF(helloWorldWfWithWFPatch)
+	woc = newWoc(*wf)
+	mainCtr = woc.wf.Spec.Templates[0].Container
+	pod, _ = woc.createWorkflowPod(wf.Name, *mainCtr, &wf.Spec.Templates[0], false)
+	assert.Equal(t, "0.800", pod.Spec.Containers[1].Resources.Limits.Cpu().AsDec().String())
+
+	wf = unmarshalWF(helloWorldWfWithWFYMALPatch)
+	woc = newWoc(*wf)
+	mainCtr = woc.wf.Spec.Templates[0].Container
+	pod, _ = woc.createWorkflowPod(wf.Name, *mainCtr, &wf.Spec.Templates[0], false)
+
+	assert.Equal(t, "0.800", pod.Spec.Containers[1].Resources.Limits.Cpu().AsDec().String())
+	assert.Equal(t, "104857600", pod.Spec.Containers[1].Resources.Limits.Memory().AsDec().String())
+
 }

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	apiv1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers/internalinterfaces"
@@ -718,9 +718,5 @@ func PodSpecPatchMerge(wf *wfv1.Workflow, tmpl *wfv1.Template) error {
 
 func ValidateJsonStr(jsonStr string, schema interface{}) bool {
 	err := json.Unmarshal([]byte(jsonStr), &schema)
-	if err != nil {
-		return false
-	}
-	return true
-
+	return err == nil
 }

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -3,16 +3,15 @@ package util
 import (
 	"encoding/json"
 	"io/ioutil"
-	v1 "k8s.io/api/core/v1"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/ghodss/yaml"
-
 	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	fakeClientset "github.com/argoproj/argo/pkg/client/clientset/versioned/fake"
+	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -171,7 +170,7 @@ func unmarshalWF(yamlStr string) *wfv1.Workflow {
 	return &wf
 }
 
-var ymal = `
+var yamlStr = `
 containers:
   - name: main
 	resources:
@@ -188,7 +187,7 @@ func TestPodSpecPatchMerge(t *testing.T) {
 	assert.Equal(t, "1.000", spec.Containers[0].Resources.Limits.Cpu().AsDec().String())
 	assert.Equal(t, "104857600", spec.Containers[0].Resources.Limits.Memory().AsDec().String())
 
-	tmpl = wfv1.Template{PodSpecPatch: ymal}
+	tmpl = wfv1.Template{PodSpecPatch: yamlStr}
 	wf = wfv1.Workflow{Spec: wfv1.WorkflowSpec{PodSpecPatch: "{\"containers\":[{\"name\":\"main\", \"resources\":{\"limits\":{\"memory\": \"100Mi\"}}}]}"}}
 	merged, _ = PodSpecPatchMerge(&wf, &tmpl)
 	json.Unmarshal([]byte(merged), &spec)

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -1,7 +1,9 @@
 package util
 
 import (
+	"encoding/json"
 	"io/ioutil"
+	v1 "k8s.io/api/core/v1"
 	"os"
 	"path/filepath"
 	"testing"
@@ -167,4 +169,30 @@ func unmarshalWF(yamlStr string) *wfv1.Workflow {
 		panic(err)
 	}
 	return &wf
+}
+
+var ymal = `
+containers:
+  - name: main
+	resources:
+	  limits:
+		cpu: 1000m
+`
+
+func TestPodSpecPatchMerge(t *testing.T) {
+	tmpl := wfv1.Template{PodSpecPatch: "{\"containers\":[{\"name\":\"main\", \"resources\":{\"limits\":{\"cpu\": \"1000m\"}}}]}"}
+	wf := wfv1.Workflow{Spec: wfv1.WorkflowSpec{PodSpecPatch: "{\"containers\":[{\"name\":\"main\", \"resources\":{\"limits\":{\"memory\": \"100Mi\"}}}]}"}}
+	merged, _ := PodSpecPatchMerge(&wf, &tmpl)
+	var spec v1.PodSpec
+	json.Unmarshal([]byte(merged), &spec)
+	assert.Equal(t, "1.000", spec.Containers[0].Resources.Limits.Cpu().AsDec().String())
+	assert.Equal(t, "104857600", spec.Containers[0].Resources.Limits.Memory().AsDec().String())
+
+	tmpl = wfv1.Template{PodSpecPatch: ymal}
+	wf = wfv1.Workflow{Spec: wfv1.WorkflowSpec{PodSpecPatch: "{\"containers\":[{\"name\":\"main\", \"resources\":{\"limits\":{\"memory\": \"100Mi\"}}}]}"}}
+	merged, _ = PodSpecPatchMerge(&wf, &tmpl)
+	json.Unmarshal([]byte(merged), &spec)
+	assert.Equal(t, "1.000", spec.Containers[0].Resources.Limits.Cpu().AsDec().String())
+	assert.Equal(t, "104857600", spec.Containers[0].Resources.Limits.Memory().AsDec().String())
+
 }


### PR DESCRIPTION
This PR will resolve  #703. This functionality will enable passing parameters all POD spec elements. 
```
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: pod-spec-patch-
spec:
  entrypoint: whalesay
  arguments:
    parameters:
      - name: message
        value: 100m

  templates:
  - name: whalesay
    podSpecPatch: '{"containers":[{"name":"main", "resources":{"limits":{"cpu": "{{workflow.parameters.message}}"}}}]}'
    container:
      image: docker/whalesay:latest
      command: [cowsay]
      args: ["hello world"]
```