### PR TITLE
Fixed incorrect `pod.name` in retry pods

### DIFF
--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -296,11 +296,11 @@ func ProcessArgs(tmpl *wfv1.Template, args wfv1.ArgumentsProvider, globalParams,
 	}
 	newTmpl.Inputs.Artifacts = newInputArtifacts
 
-	return substituteParams(newTmpl, globalParams, localParams)
+	return SubstituteParams(newTmpl, globalParams, localParams)
 }
 
-// substituteParams returns a new copy of the template with global, pod, and input parameters substituted
-func substituteParams(tmpl *wfv1.Template, globalParams, localParams map[string]string) (*wfv1.Template, error) {
+// SubstituteParams returns a new copy of the template with global, pod, and input parameters substituted
+func SubstituteParams(tmpl *wfv1.Template, globalParams, localParams map[string]string) (*wfv1.Template, error) {
 	tmplBytes, err := json.Marshal(tmpl)
 	if err != nil {
 		return nil, errors.InternalWrapError(err)

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1183,12 +1183,15 @@ func (woc *wfOperationCtx) executeTemplate(nodeName string, orgTmpl wfv1.Templat
 		//  but the retry node state is still running.
 		//  Create another child node.
 		nodeName = fmt.Sprintf("%s(%d)", retryNodeName, len(retryParentNode.Children))
-		// Change the `pod.name` variable to the new retry node name
-		processedTmpl, err = common.SubstituteParams(processedTmpl, map[string]string{}, map[string]string{common.LocalVarPodName: woc.wf.NodeID(nodeName)})
-		if err != nil {
-			return woc.initializeNodeOrMarkError(node, nodeName, wfv1.NodeTypeSkipped, orgTmpl, boundaryID, err), err
-		}
 		node = nil
+
+		// Change the `pod.name` variable to the new retry node name
+		if processedTmpl.IsPodType() {
+			processedTmpl, err = common.SubstituteParams(processedTmpl, map[string]string{}, map[string]string{common.LocalVarPodName: woc.wf.NodeID(nodeName)})
+			if err != nil {
+				return woc.initializeNodeOrMarkError(node, nodeName, wfv1.NodeTypeSkipped, orgTmpl, boundaryID, err), err
+			}
+		}
 	}
 
 	// Initialize node based on the template type.

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1134,7 +1134,9 @@ func (woc *wfOperationCtx) executeTemplate(nodeName string, orgTmpl wfv1.Templat
 		return woc.initializeNodeOrMarkError(node, nodeName, wfv1.NodeTypeSkipped, orgTmpl, boundaryID, err), err
 	}
 	localParams := make(map[string]string)
-	if basedTmpl.IsPodType() {
+	// Inject the pod name. If the pod has a retry strategy, the pod name will be changed and will be injected when it
+	// is determined
+	if basedTmpl.IsPodType() && basedTmpl.RetryStrategy == nil {
 		localParams[common.LocalVarPodName] = woc.wf.NodeID(nodeName)
 	}
 	// Inputs has been processed with arguments already, so pass empty arguments.
@@ -1181,6 +1183,11 @@ func (woc *wfOperationCtx) executeTemplate(nodeName string, orgTmpl wfv1.Templat
 		//  but the retry node state is still running.
 		//  Create another child node.
 		nodeName = fmt.Sprintf("%s(%d)", retryNodeName, len(retryParentNode.Children))
+		// Change the `pod.name` variable to the new retry node name
+		processedTmpl, err = common.SubstituteParams(processedTmpl, map[string]string{}, map[string]string{common.LocalVarPodName: woc.wf.NodeID(nodeName)})
+		if err != nil {
+			return woc.initializeNodeOrMarkError(node, nodeName, wfv1.NodeTypeSkipped, orgTmpl, boundaryID, err), err
+		}
 		node = nil
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/argoproj/argo/issues/1646. Thanks @c-dante

```
...
Name:                pod-name-pjdk9
Namespace:           argo
ServiceAccount:      default
Status:              Failed
Message:             No more retries left
Created:             Mon Oct 21 11:59:01 -0700 (11 seconds ago)
Started:             Mon Oct 21 11:59:01 -0700 (11 seconds ago)
Finished:            Mon Oct 21 11:59:12 -0700 (now)
Duration:            11 seconds

STEP                               PODNAME                    DURATION  MESSAGE
 ✖ pod-name-pjdk9 (pod-name)                                            No more retries left
 ├-✖ pod-name-pjdk9(0) (pod-name)  pod-name-pjdk9-3274678606  5s        failed with exit code 1
 └-✖ pod-name-pjdk9(1) (pod-name)  pod-name-pjdk9-2670537227  4s        failed with exit code 1
$  kubectl logs pod-name-pjdk9-3274678606 -c main
MY_KUBE_NAME=pod-name-pjdk9-3274678606
MY_ARGO_NAME=pod-name-pjdk9-3274678606
```