### PR TITLE
Fail suspended steps after deadline

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1879,7 +1879,7 @@ func (woc *wfOperationCtx) executeSuspend(nodeName string, tmpl *wfv1.Template, 
 	}
 
 	if deadline != nil {
-		woc.requeue(deadline.Sub(time.Now()))
+		woc.requeue(time.Until(*deadline))
 	}
 
 	_ = woc.markNodePhase(nodeName, wfv1.NodeRunning)

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -505,6 +505,51 @@ func TestSuspendResume(t *testing.T) {
 	assert.Equal(t, 2, len(pods.Items))
 }
 
+var suspendTemplateWithDeadline = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: suspend-template
+spec:
+  entrypoint: suspend
+  activeDeadlineSeconds: 0
+  templates:
+  - name: suspend
+    suspend: {}
+`
+
+func TestSuspendWithDeadline(t *testing.T) {
+	controller := newController()
+	wfcset := controller.wfclientset.ArgoprojV1alpha1().Workflows("")
+
+	// operate the workflow. it should become in a suspended state after
+	wf := unmarshalWF(suspendTemplateWithDeadline)
+	wf, err := wfcset.Create(wf)
+	assert.Nil(t, err)
+	woc := newWorkflowOperationCtx(wf, controller)
+	woc.operate()
+	wf, err = wfcset.Get(wf.ObjectMeta.Name, metav1.GetOptions{})
+	assert.Nil(t, err)
+	assert.True(t, util.IsWorkflowSuspended(wf))
+
+	// operate again and verify no pods were scheduled
+	woc = newWorkflowOperationCtx(wf, controller)
+	woc.operate()
+	updatedWf, err := wfcset.Get(wf.Name, metav1.GetOptions{})
+	assert.Nil(t, err)
+	found := false
+
+	for _, node := range updatedWf.Status.Nodes {
+		if node.Type == wfv1.NodeTypeSuspend {
+			assert.Equal(t, node.Phase, wfv1.NodeFailed)
+			assert.Equal(t, node.Message, "terminated")
+			found = true
+		}
+	}
+	assert.True(t, found)
+
+}
+
 var inputParametersAsJson = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow


### PR DESCRIPTION
Suspended steps would never time out, regardless of the setting of activeDeadlineSeconds.

This change fixes that.