### PR TITLE
Fixes incorrect parameters in stored templates

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1354,10 +1354,6 @@ func (woc *wfOperationCtx) storeTemplate(storedTemplateID string, unresolvedTemp
 	}
 }
 
-func (woc *wfOperationCtx) setStoredTemplate(storedTemplateID string) {
-
-}
-
 // initializeNodeOrMarkError initializes an error node or mark a node if it already exists.
 func (woc *wfOperationCtx) initializeNodeOrMarkError(node *wfv1.NodeStatus, nodeName string, nodeType wfv1.NodeType, orgTmpl wfv1.TemplateHolder, boundaryID string, err error) *wfv1.NodeStatus {
 	if node != nil {


### PR DESCRIPTION
Fixes #1713. Approach was to store templates _before_ resolution, and to do so all at once during the one-time validation sequence.

Currently not fully tested (hence why this is a Draft PR), just looking for initial feedback on the implementation.