### PR TITLE
Removed debug `Println`

### DIFF
--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -243,9 +243,7 @@ func (p *ParallelSteps) UnmarshalJSON(value []byte) error {
 }
 
 func (p *ParallelSteps) MarshalJSON() ([]byte, error) {
-	fmt.Println(p.Steps)
 	return json.Marshal(p.Steps)
-
 }
 
 func (wfs *WorkflowSpec) HasPodSpecPatch() bool {


### PR DESCRIPTION
An `fmt.Println(...)` most likely for debug purposes got merged to master causing debug information to be printed to the user on the CLI:
```
$ argo submit --watch temp.yaml
[{steps1 stepsTempalte {[] []} nil []  nil  nil}]
[{steps2 stepsTempalte {[] []} nil []  nil  nil}]
[{leafA whalesay {[] []} nil []  nil  nil}]
[{leafB whalesay {[] []} nil []  nil  nil}]
[{steps1 stepsTempalte {[] []} nil []  nil  nil}]
[{steps2 stepsTempalte {[] []} nil []  nil  nil}]
[{leafA whalesay {[] []} nil []  nil  nil}]
[{leafB whalesay {[] []} nil []  nil  nil}]
Name:                suspend-template-nsv4n
Namespace:           argo
ServiceAccount:      default
Status:              Pending
Created:             Wed Nov 06 07:32:12 -0800 (now)
Name:                suspend-template-nsv4n
Namespace:           argo
ServiceAccount:      default
Status:              Pending
Created:             Wed Nov 06 07:32:12 -0800 (now)
```

As well as on the logs:
```
...
time="2019-11-06T15:32:03Z" level=info msg="Processing workflow" namespace=argo workflow=suspend-template-tvhrn
[{steps1 stepsTempalte {[] []} nil []  nil  nil}]
[{steps2 stepsTempalte {[] []} nil []  nil  nil}]
[{leafA whalesay {[] []} nil []  nil  nil}]
[{leafB whalesay {[] []} nil []  nil  nil}]
time="2019-11-06T15:32:03Z" level=info msg="Updating node &NodeStatus{ID:suspend-template-tvhrn-3894610589,Name:suspend-template-tvhrn[1].steps2[1].leafB.onExit,DisplayName:leafB.onExit,Type:Pod,TemplateName:exitContainer,TemplateRef:nil,Phase:Pending,BoundaryID:suspend-template-tvhrn-4142322267,Message:ContainerCreating,StartedAt:2019-11-06 15:31:59 +0000 UTC,FinishedAt:0001-01-01 00:00:00 +0000 UTC,PodIP:,Daemoned:nil,Inputs:nil,Outputs:nil,Children:[],OutboundNodes:[],StoredTemplateID:/exitContainer,WorkflowTemplateName:,OnExitNode:nil,} status Pending -> Running"
...
```