### PR TITLE
fix blank lines

### DIFF
--- a/util/cmd/cmd.go
+++ b/util/cmd/cmd.go
@@ -1,5 +1,4 @@
 // Package cmd provides functionally common to various argo CLIs
-
 package cmd
 
 import (


### PR DESCRIPTION
According to the go golint report, package comment is detached.
So I delete that blank line.