### PR TITLE
SSL enabled database connection for workflow repository (#1712)

### DIFF
--- a/workflow/config/config.go
+++ b/workflow/config/config.go
@@ -108,6 +108,7 @@ type PostgreSQLConfig struct {
 	TableName      string                  `json:"tableName"`
 	UsernameSecret apiv1.SecretKeySelector `json:"userNameSecret"`
 	PasswordSecret apiv1.SecretKeySelector `json:"passwordSecret"`
+	SSL            bool                    `json:"ssl,omitempty"`
 }
 
 type MySQLConfig struct {

--- a/workflow/persist/sqldb/sqldb.go
+++ b/workflow/persist/sqldb/sqldb.go
@@ -85,6 +85,14 @@ func CreatePostGresDBSession(kubectlConfig kubernetes.Interface, namespace strin
 		Host:     postgresConfig.Host + ":" + postgresConfig.Port,
 		Database: postgresConfig.Database,
 	}
+
+	if postgresConfig.SSL {
+		var options := map[string]string{
+			"sslmode": "true"
+		}
+		settings.Options = options
+	}
+
 	session, err := postgresql.Open(settings)
 
 	if err != nil {

--- a/workflow/persist/sqldb/sqldb.go
+++ b/workflow/persist/sqldb/sqldb.go
@@ -87,8 +87,8 @@ func CreatePostGresDBSession(kubectlConfig kubernetes.Interface, namespace strin
 	}
 
 	if postgresConfig.SSL {
-		var options := map[string]string{
-			"sslmode": "true"
+		options := map[string]string{
+			"sslmode": "true",
 		}
 		settings.Options = options
 	}


### PR DESCRIPTION
Quick fix to enable SSL connection to Postgres databases for workflow repositories.

**disclaimer**: couldn't get this to work mysql as there didn't seem to be an option to do so using`upper.io/db.v3`...

**disclaimer 2**: I'm a bit of a noob when it comes to Golang so didn't manage to run tests/write new ones locally. I'm totally counting on your CI system to flag my possible mistakes :smile: 