### PR TITLE
Handle operation level errors

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1076,6 +1076,11 @@ func (woc *wfOperationCtx) createPVCs() error {
 }
 
 func (woc *wfOperationCtx) deletePVCs() error {
+	if woc.wf.Status.Phase != wfv1.NodeSucceeded {
+		// Skip deleting PVCs to reuse them for retried failed/error workflows.
+		// PVCs are automatically deleted when corresponded owner workflows get deleted.
+		return nil
+	}
 	totalPVCs := len(woc.wf.Status.PersistentVolumeClaims)
 	if totalPVCs == 0 {
 		// PVC list already empty. nothing to do


### PR DESCRIPTION
Fixes #1761

I fixed the retry failure on workflows with PVCs by marking main nodes error on operation-level error and keeping PVCs of failed/error nodes for future retries.