### PR TITLE
Make kubectl print status and start/finished time

### DIFF
--- a/manifests/base/crds/workflow-crd.yaml
+++ b/manifests/base/crds/workflow-crd.yaml
@@ -10,12 +10,7 @@ spec:
     type: string
   - JSONPath: .status.startedAt
     description: When the workflow was started
-    name: Started
-    format: date-time
-    type: date
-  - JSONPath: .status.finishedAt
-    description: When the workflow was finished
-    name: Finished
+    name: Age
     format: date-time
     type: date
   group: argoproj.io

--- a/manifests/base/crds/workflow-crd.yaml
+++ b/manifests/base/crds/workflow-crd.yaml
@@ -3,6 +3,21 @@ kind: CustomResourceDefinition
 metadata:
   name: workflows.argoproj.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: Status of the workflow
+    name: Status
+    type: string
+  - JSONPath: .status.startedAt
+    description: When the workflow was started
+    name: Started
+    format: date-time
+    type: date
+  - JSONPath: .status.finishedAt
+    description: When the workflow was finished
+    name: Finished
+    format: date-time
+    type: date
   group: argoproj.io
   version: v1alpha1
   scope: Namespaced


### PR DESCRIPTION
Set additionalPrinterColumns in the CRD to make k8s print the status and age of workflows when using kubectl.
This required k8s >= 1.11.


Example of `kubectl get workflows`:
```
NAME                         STATUS      AGE
abc-87-1573741887810-4nhds   Succeeded   43m
abc-88-1573741887810-5t2p6   Running     43m
abc-89-1573741887810-77xq5   Running     43m
abc-90-1573741887810-7nd57   Failed      43m
abc-91-1573741887810-jlzzr   Succeeded   43m
```