### PR TITLE
Wait container error on pod watch failure and exponential backoff

### DIFF
--- a/cmd/argoexec/commands/wait.go
+++ b/cmd/argoexec/commands/wait.go
@@ -37,9 +37,9 @@ func waitContainer() error {
 	}()
 
 	// Wait for main container to complete
-	err := wfExecutor.Wait()
-	if err != nil {
-		wfExecutor.AddError(err)
+	waitErr := wfExecutor.Wait()
+	if waitErr != nil {
+		wfExecutor.AddError(waitErr)
 		// do not return here so we can still try to kill sidecars & save outputs
 	}
 
@@ -72,5 +72,11 @@ func waitContainer() error {
 		wfExecutor.AddError(err)
 		return err
 	}
+
+	// To prevent the workflow step from completing successfully, return the error occurred during wait.
+	if waitErr != nil {
+		return waitErr
+	}
+
 	return nil
 }


### PR DESCRIPTION
#fixes #1697 When a failure on the pod watch occurred, the error should be returned after all information from the pod (log, artifacts) are collected. I also added an exponential backoff to the pod watch and the adding of pod annotations.