### PR TITLE
Do not resolve remote templates in lint

### DIFF
--- a/cmd/argo/commands/common.go
+++ b/cmd/argo/commands/common.go
@@ -122,8 +122,11 @@ func ansiFormat(s string, codes ...int) string {
 	return fmt.Sprintf("%s[%sm%s%s[%dm", escape, sequence, s, escape, noFormat)
 }
 
+// LazyWorkflowTemplateGetter is a wrapper of v1alpha1.WorkflowTemplateInterface which
+// supports lazy initialization.
 type LazyWorkflowTemplateGetter struct{}
 
+// Get initializes it just before it's actually used and returns a retrieved workflow template.
 func (c LazyWorkflowTemplateGetter) Get(name string) (*wfv1.WorkflowTemplate, error) {
 	if wftmplClient == nil {
 		_ = InitWorkflowClient()

--- a/cmd/argo/commands/common.go
+++ b/cmd/argo/commands/common.go
@@ -21,6 +21,7 @@ var (
 	restConfig       *rest.Config
 	clientConfig     clientcmd.ClientConfig
 	clientset        *kubernetes.Clientset
+	wftmplClient     v1alpha1.WorkflowTemplateInterface
 	wfClientset      *versioned.Clientset
 	wfClient         v1alpha1.WorkflowInterface
 	jobStatusIconMap map[wfv1.NodePhase]string
@@ -97,6 +98,7 @@ func InitWorkflowClient(ns ...string) v1alpha1.WorkflowInterface {
 	}
 	wfClientset = versioned.NewForConfigOrDie(restConfig)
 	wfClient = wfClientset.ArgoprojV1alpha1().Workflows(namespace)
+	wftmplClient = wfClientset.ArgoprojV1alpha1().WorkflowTemplates(namespace)
 	return wfClient
 }
 

--- a/cmd/argo/commands/lint.go
+++ b/cmd/argo/commands/lint.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	cmdutil "github.com/argoproj/argo/util/cmd"
-	"github.com/argoproj/argo/workflow/templateresolution"
 	"github.com/argoproj/argo/workflow/validate"
 )
 
@@ -25,9 +24,8 @@ func NewLintCommand() *cobra.Command {
 				os.Exit(1)
 			}
 
-			_ = InitWorkflowClient()
-			wftmplGetter := templateresolution.WrapWorkflowTemplateInterface(wftmplClient)
 			var err error
+			wftmplGetter := &LazyWorkflowTemplateGetter{}
 			validateDir := cmdutil.MustIsDir(args[0])
 			if validateDir {
 				if len(args) > 1 {

--- a/cmd/argo/commands/template/common.go
+++ b/cmd/argo/commands/template/common.go
@@ -60,8 +60,11 @@ func InitWorkflowTemplateClient(ns ...string) v1alpha1.WorkflowTemplateInterface
 	return wftmplClient
 }
 
+// LazyWorkflowTemplateGetter is a wrapper of v1alpha1.WorkflowTemplateInterface which
+// supports lazy initialization.
 type LazyWorkflowTemplateGetter struct{}
 
+// Get initializes it just before it's actually used and returns a retrieved workflow template.
 func (c LazyWorkflowTemplateGetter) Get(name string) (*wfv1.WorkflowTemplate, error) {
 	if wftmplClient == nil {
 		_ = InitWorkflowTemplateClient()

--- a/cmd/argo/commands/template/create.go
+++ b/cmd/argo/commands/template/create.go
@@ -9,6 +9,7 @@ import (
 
 	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo/workflow/common"
+	"github.com/argoproj/argo/workflow/templateresolution"
 	"github.com/argoproj/argo/workflow/util"
 	"github.com/argoproj/argo/workflow/validate"
 )
@@ -62,7 +63,8 @@ func CreateWorkflowTemplates(filePaths []string, cliOpts *cliCreateOpts) {
 	}
 
 	for _, wftmpl := range workflowTemplates {
-		err := validate.ValidateWorkflowTemplate(wfClientset, namespace, &wftmpl)
+		wftmplGetter := templateresolution.WrapWorkflowTemplateInterface(wftmplClient)
+		err := validate.ValidateWorkflowTemplate(wftmplGetter, &wftmpl)
 		if err != nil {
 			log.Fatalf("Failed to create workflow template: %v", err)
 		}

--- a/cmd/argo/commands/template/lint.go
+++ b/cmd/argo/commands/template/lint.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	cmdutil "github.com/argoproj/argo/util/cmd"
-	"github.com/argoproj/argo/workflow/templateresolution"
 	"github.com/argoproj/argo/workflow/validate"
 )
 
@@ -30,8 +29,7 @@ func NewLintCommand() *cobra.Command {
 				log.Fatal(err)
 			}
 
-			_ = InitWorkflowTemplateClient()
-			wftmplGetter := templateresolution.WrapWorkflowTemplateInterface(wftmplClient)
+			wftmplGetter := &LazyWorkflowTemplateGetter{}
 			validateDir := cmdutil.MustIsDir(args[0])
 			if validateDir {
 				if len(args) > 1 {

--- a/cmd/argo/commands/template/lint.go
+++ b/cmd/argo/commands/template/lint.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	cmdutil "github.com/argoproj/argo/util/cmd"
+	"github.com/argoproj/argo/workflow/templateresolution"
 	"github.com/argoproj/argo/workflow/validate"
 )
 
@@ -30,6 +31,7 @@ func NewLintCommand() *cobra.Command {
 			}
 
 			_ = InitWorkflowTemplateClient()
+			wftmplGetter := templateresolution.WrapWorkflowTemplateInterface(wftmplClient)
 			validateDir := cmdutil.MustIsDir(args[0])
 			if validateDir {
 				if len(args) > 1 {
@@ -37,7 +39,7 @@ func NewLintCommand() *cobra.Command {
 					os.Exit(1)
 				}
 				fmt.Printf("Verifying all workflow template manifests in directory: %s\n", args[0])
-				err = validate.LintWorkflowTemplateDir(wfClientset, namespace, args[0], strict)
+				err = validate.LintWorkflowTemplateDir(wftmplGetter, namespace, args[0], strict)
 			} else {
 				yamlFiles := make([]string, 0)
 				for _, filePath := range args {
@@ -48,7 +50,7 @@ func NewLintCommand() *cobra.Command {
 					yamlFiles = append(yamlFiles, filePath)
 				}
 				for _, yamlFile := range yamlFiles {
-					err = validate.LintWorkflowTemplateFile(wfClientset, namespace, yamlFile, strict)
+					err = validate.LintWorkflowTemplateFile(wftmplGetter, namespace, yamlFile, strict)
 					if err != nil {
 						break
 					}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -156,7 +156,8 @@ func (woc *wfOperationCtx) operate() {
 	if woc.wf.Status.Phase == "" {
 		woc.markWorkflowRunning()
 		validateOpts := validate.ValidateOpts{ContainerRuntimeExecutor: woc.controller.Config.ContainerRuntimeExecutor}
-		err := validate.ValidateWorkflow(woc.controller.wfclientset, woc.wf.Namespace, woc.wf, validateOpts)
+		wftmplGetter := templateresolution.WrapWorkflowTemplateInterface(woc.controller.wfclientset.ArgoprojV1alpha1().WorkflowTemplates(woc.wf.Namespace))
+		err := validate.ValidateWorkflow(wftmplGetter, woc.wf, validateOpts)
 		if err != nil {
 			woc.markWorkflowFailed(fmt.Sprintf("invalid spec: %s", err.Error()))
 			return

--- a/workflow/templateresolution/context.go
+++ b/workflow/templateresolution/context.go
@@ -3,6 +3,7 @@ package templateresolution
 import (
 	"github.com/argoproj/argo/errors"
 	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo/pkg/client/clientset/versioned/typed/workflow/v1alpha1"
 	typed "github.com/argoproj/argo/pkg/client/clientset/versioned/typed/workflow/v1alpha1"
 	"github.com/argoproj/argo/workflow/common"
 	log "github.com/sirupsen/logrus"
@@ -16,6 +17,10 @@ const maxResolveDepth int = 10
 // workflowTemplateInterfaceWrapper is an internal struct to wrap clientset.
 type workflowTemplateInterfaceWrapper struct {
 	clientset typed.WorkflowTemplateInterface
+}
+
+func WrapWorkflowTemplateInterface(clientset v1alpha1.WorkflowTemplateInterface) WorkflowTemplateNamespacedGetter {
+	return &workflowTemplateInterfaceWrapper{clientset: clientset}
 }
 
 // Get retrieves the WorkflowTemplate of a given name.
@@ -48,7 +53,7 @@ func NewContext(wftmplGetter WorkflowTemplateNamespacedGetter, tmplBase wfv1.Tem
 // NewContext returns new Context.
 func NewContextFromClientset(clientset typed.WorkflowTemplateInterface, tmplBase wfv1.TemplateGetter) *Context {
 	return &Context{
-		wftmplGetter: &workflowTemplateInterfaceWrapper{clientset: clientset},
+		wftmplGetter: WrapWorkflowTemplateInterface(clientset),
 		tmplBase:     tmplBase,
 	}
 }

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -43,6 +43,7 @@ import (
 	"github.com/argoproj/argo/util/retry"
 	unstructutil "github.com/argoproj/argo/util/unstructured"
 	"github.com/argoproj/argo/workflow/common"
+	"github.com/argoproj/argo/workflow/templateresolution"
 	"github.com/argoproj/argo/workflow/validate"
 )
 
@@ -258,7 +259,8 @@ func SubmitWorkflow(wfIf v1alpha1.WorkflowInterface, wfClientset wfclientset.Int
 		wf.SetOwnerReferences(append(wf.GetOwnerReferences(), *opts.OwnerReference))
 	}
 
-	err := validate.ValidateWorkflow(wfClientset, namespace, wf, validate.ValidateOpts{})
+	wftmplGetter := templateresolution.WrapWorkflowTemplateInterface(wfClientset.ArgoprojV1alpha1().WorkflowTemplates(namespace))
+	err := validate.ValidateWorkflow(wftmplGetter, wf, validate.ValidateOpts{})
 	if err != nil {
 		return nil, err
 	}

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/argoproj/argo/errors"
 	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
-	wfclientset "github.com/argoproj/argo/pkg/client/clientset/versioned"
 	"github.com/argoproj/argo/workflow/artifacts/hdfs"
 	"github.com/argoproj/argo/workflow/common"
 	"github.com/argoproj/argo/workflow/templateresolution"
@@ -48,7 +47,7 @@ type templateValidationCtx struct {
 	wf *wfv1.Workflow
 }
 
-func newTemplateValidationCtx(wfClientset wfclientset.Interface, namespace string, wf *wfv1.Workflow, opts ValidateOpts) *templateValidationCtx {
+func newTemplateValidationCtx(wf *wfv1.Workflow, opts ValidateOpts) *templateValidationCtx {
 	globalParams := make(map[string]string)
 	globalParams[common.GlobalVarWorkflowName] = placeholderValue
 	globalParams[common.GlobalVarWorkflowNamespace] = placeholderValue
@@ -85,13 +84,9 @@ func (args *FakeArguments) GetArtifactByName(name string) *wfv1.Artifact {
 var _ wfv1.ArgumentsProvider = &FakeArguments{}
 
 // ValidateWorkflow accepts a workflow and performs validation against it.
-func ValidateWorkflow(wfClientset wfclientset.Interface, namespace string, wf *wfv1.Workflow, opts ValidateOpts) error {
-	if wf.Namespace != "" {
-		namespace = wf.Namespace
-	}
-
-	ctx := newTemplateValidationCtx(wfClientset, namespace, wf, opts)
-	tmplCtx := templateresolution.NewContextFromClientset(wfClientset.ArgoprojV1alpha1().WorkflowTemplates(namespace), wf)
+func ValidateWorkflow(wftmplGetter templateresolution.WorkflowTemplateNamespacedGetter, wf *wfv1.Workflow, opts ValidateOpts) error {
+	ctx := newTemplateValidationCtx(wf, opts)
+	tmplCtx := templateresolution.NewContext(wftmplGetter, wf)
 
 	err := validateWorkflowFieldNames(wf.Spec.Templates)
 	if err != nil {
@@ -163,12 +158,9 @@ func ValidateWorkflow(wfClientset wfclientset.Interface, namespace string, wf *w
 }
 
 // ValidateWorkflow accepts a workflow template and performs validation against it.
-func ValidateWorkflowTemplate(wfClientset wfclientset.Interface, namespace string, wftmpl *wfv1.WorkflowTemplate) error {
-	if wftmpl.Namespace != "" {
-		namespace = wftmpl.Namespace
-	}
-	ctx := newTemplateValidationCtx(wfClientset, namespace, nil, ValidateOpts{})
-	tmplCtx := templateresolution.NewContextFromClientset(wfClientset.ArgoprojV1alpha1().WorkflowTemplates(namespace), wftmpl)
+func ValidateWorkflowTemplate(wftmplGetter templateresolution.WorkflowTemplateNamespacedGetter, wftmpl *wfv1.WorkflowTemplate) error {
+	ctx := newTemplateValidationCtx(nil, ValidateOpts{})
+	tmplCtx := templateresolution.NewContext(wftmplGetter, wftmpl)
 
 	// Check if all templates can be resolved.
 	for _, template := range wftmpl.Spec.Templates {

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -12,9 +12,11 @@ import (
 	fakewfclientset "github.com/argoproj/argo/pkg/client/clientset/versioned/fake"
 	"github.com/argoproj/argo/test"
 	"github.com/argoproj/argo/workflow/common"
+	"github.com/argoproj/argo/workflow/templateresolution"
 )
 
 var wfClientset = fakewfclientset.NewSimpleClientset()
+var wftmplGetter = templateresolution.WrapWorkflowTemplateInterface(wfClientset.ArgoprojV1alpha1().WorkflowTemplates(metav1.NamespaceDefault))
 
 func createWorkflowTemplate(yamlStr string) error {
 	wftmpl := unmarshalWftmpl(yamlStr)
@@ -29,14 +31,14 @@ func createWorkflowTemplate(yamlStr string) error {
 // its validation result.
 func validate(yamlStr string) error {
 	wf := unmarshalWf(yamlStr)
-	return ValidateWorkflow(wfClientset, metav1.NamespaceDefault, wf, ValidateOpts{})
+	return ValidateWorkflow(wftmplGetter, wf, ValidateOpts{})
 }
 
 // validateWorkflowTemplate is a test helper to accept WorkflowTemplate YAML as a string and return
 // its validation result.
 func validateWorkflowTemplate(yamlStr string) error {
 	wftmpl := unmarshalWftmpl(yamlStr)
-	return ValidateWorkflowTemplate(wfClientset, metav1.NamespaceDefault, wftmpl)
+	return ValidateWorkflowTemplate(wftmplGetter, wftmpl)
 }
 
 func unmarshalWf(yamlStr string) *wfv1.Workflow {
@@ -1007,14 +1009,13 @@ spec:
 func TestVolumeMountArtifactPathCollision(t *testing.T) {
 	// ensure we detect and reject path collisions
 	wf := unmarshalWf(volumeMountArtifactPathCollision)
-	namespace := metav1.NamespaceDefault
-	err := ValidateWorkflow(wfClientset, namespace, wf, ValidateOpts{})
+	err := ValidateWorkflow(wftmplGetter, wf, ValidateOpts{})
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "already mounted")
 	}
 	// tweak the mount path and validation should now be successful
 	wf.Spec.Templates[0].Container.VolumeMounts[0].MountPath = "/differentpath"
-	err = ValidateWorkflow(wfClientset, namespace, wf, ValidateOpts{})
+	err = ValidateWorkflow(wftmplGetter, wf, ValidateOpts{})
 	assert.NoError(t, err)
 }
 
@@ -1300,7 +1301,7 @@ func TestPodNameVariable(t *testing.T) {
 }
 
 func TestGlobalParamWithVariable(t *testing.T) {
-	err := ValidateWorkflow(wfClientset, metav1.NamespaceDefault, test.LoadE2EWorkflow("functional/global-outputs-variable.yaml"), ValidateOpts{})
+	err := ValidateWorkflow(wftmplGetter, test.LoadE2EWorkflow("functional/global-outputs-variable.yaml"), ValidateOpts{})
 	assert.NoError(t, err)
 }
 
@@ -1325,9 +1326,9 @@ spec:
 // TestSpecArgumentNoValue we allow parameters to have no value at the spec level during linting
 func TestSpecArgumentNoValue(t *testing.T) {
 	wf := unmarshalWf(specArgumentNoValue)
-	err := ValidateWorkflow(wfClientset, metav1.NamespaceDefault, wf, ValidateOpts{Lint: true})
+	err := ValidateWorkflow(wftmplGetter, wf, ValidateOpts{Lint: true})
 	assert.NoError(t, err)
-	err = ValidateWorkflow(wfClientset, metav1.NamespaceDefault, wf, ValidateOpts{})
+	err = ValidateWorkflow(wftmplGetter, wf, ValidateOpts{})
 	assert.NotNil(t, err)
 }
 
@@ -1362,7 +1363,7 @@ spec:
 // TestSpecArgumentSnakeCase we allow parameter and artifact names to be snake case
 func TestSpecArgumentSnakeCase(t *testing.T) {
 	wf := unmarshalWf(specArgumentSnakeCase)
-	err := ValidateWorkflow(wfClientset, metav1.NamespaceDefault, wf, ValidateOpts{Lint: true})
+	err := ValidateWorkflow(wftmplGetter, wf, ValidateOpts{Lint: true})
 	assert.NoError(t, err)
 }
 
@@ -1397,7 +1398,7 @@ spec:
 // TestSpecBadSequenceCountAndEnd verifies both count and end cannot be defined
 func TestSpecBadSequenceCountAndEnd(t *testing.T) {
 	wf := unmarshalWf(specBadSequenceCountAndEnd)
-	err := ValidateWorkflow(wfClientset, metav1.NamespaceDefault, wf, ValidateOpts{Lint: true})
+	err := ValidateWorkflow(wftmplGetter, wf, ValidateOpts{Lint: true})
 	assert.Error(t, err)
 }
 
@@ -1417,7 +1418,7 @@ spec:
 // TestCustomTemplatVariable verifies custom template variable
 func TestCustomTemplatVariable(t *testing.T) {
 	wf := unmarshalWf(customVariableInput)
-	err := ValidateWorkflow(wfClientset, metav1.NamespaceDefault, wf, ValidateOpts{Lint: true})
+	err := ValidateWorkflow(wftmplGetter, wf, ValidateOpts{Lint: true})
 	assert.Equal(t, err, nil)
 }
 
@@ -1518,28 +1519,28 @@ func TestBaseImageOutputVerify(t *testing.T) {
 	for _, executor := range []string{common.ContainerRuntimeExecutorK8sAPI, common.ContainerRuntimeExecutorKubelet, common.ContainerRuntimeExecutorPNS, common.ContainerRuntimeExecutorDocker, ""} {
 		switch executor {
 		case common.ContainerRuntimeExecutorK8sAPI, common.ContainerRuntimeExecutorKubelet:
-			err = ValidateWorkflow(wfClientset, metav1.NamespaceDefault, wfBaseOutArt, ValidateOpts{ContainerRuntimeExecutor: executor})
+			err = ValidateWorkflow(wftmplGetter, wfBaseOutArt, ValidateOpts{ContainerRuntimeExecutor: executor})
 			assert.Error(t, err)
-			err = ValidateWorkflow(wfClientset, metav1.NamespaceDefault, wfBaseOutParam, ValidateOpts{ContainerRuntimeExecutor: executor})
+			err = ValidateWorkflow(wftmplGetter, wfBaseOutParam, ValidateOpts{ContainerRuntimeExecutor: executor})
 			assert.Error(t, err)
-			err = ValidateWorkflow(wfClientset, metav1.NamespaceDefault, wfBaseWithEmptyDirOutArt, ValidateOpts{ContainerRuntimeExecutor: executor})
+			err = ValidateWorkflow(wftmplGetter, wfBaseWithEmptyDirOutArt, ValidateOpts{ContainerRuntimeExecutor: executor})
 			assert.Error(t, err)
 		case common.ContainerRuntimeExecutorPNS:
-			err = ValidateWorkflow(wfClientset, metav1.NamespaceDefault, wfBaseOutArt, ValidateOpts{ContainerRuntimeExecutor: executor})
+			err = ValidateWorkflow(wftmplGetter, wfBaseOutArt, ValidateOpts{ContainerRuntimeExecutor: executor})
 			assert.NoError(t, err)
-			err = ValidateWorkflow(wfClientset, metav1.NamespaceDefault, wfBaseOutParam, ValidateOpts{ContainerRuntimeExecutor: executor})
+			err = ValidateWorkflow(wftmplGetter, wfBaseOutParam, ValidateOpts{ContainerRuntimeExecutor: executor})
 			assert.NoError(t, err)
-			err = ValidateWorkflow(wfClientset, metav1.NamespaceDefault, wfBaseWithEmptyDirOutArt, ValidateOpts{ContainerRuntimeExecutor: executor})
+			err = ValidateWorkflow(wftmplGetter, wfBaseWithEmptyDirOutArt, ValidateOpts{ContainerRuntimeExecutor: executor})
 			assert.Error(t, err)
 		case common.ContainerRuntimeExecutorDocker, "":
-			err = ValidateWorkflow(wfClientset, metav1.NamespaceDefault, wfBaseOutArt, ValidateOpts{ContainerRuntimeExecutor: executor})
+			err = ValidateWorkflow(wftmplGetter, wfBaseOutArt, ValidateOpts{ContainerRuntimeExecutor: executor})
 			assert.NoError(t, err)
-			err = ValidateWorkflow(wfClientset, metav1.NamespaceDefault, wfBaseOutParam, ValidateOpts{ContainerRuntimeExecutor: executor})
+			err = ValidateWorkflow(wftmplGetter, wfBaseOutParam, ValidateOpts{ContainerRuntimeExecutor: executor})
 			assert.NoError(t, err)
-			err = ValidateWorkflow(wfClientset, metav1.NamespaceDefault, wfBaseWithEmptyDirOutArt, ValidateOpts{ContainerRuntimeExecutor: executor})
+			err = ValidateWorkflow(wftmplGetter, wfBaseWithEmptyDirOutArt, ValidateOpts{ContainerRuntimeExecutor: executor})
 			assert.NoError(t, err)
 		}
-		err = ValidateWorkflow(wfClientset, metav1.NamespaceDefault, wfEmptyDirOutArt, ValidateOpts{ContainerRuntimeExecutor: executor})
+		err = ValidateWorkflow(wftmplGetter, wfEmptyDirOutArt, ValidateOpts{ContainerRuntimeExecutor: executor})
 		assert.NoError(t, err)
 	}
 }
@@ -1737,7 +1738,7 @@ spec:
 // TestValidResourceWorkflow verifies a workflow of a valid resource.
 func TestValidResourceWorkflow(t *testing.T) {
 	wf := unmarshalWf(validResourceWorkflow)
-	err := ValidateWorkflow(wfClientset, metav1.NamespaceDefault, wf, ValidateOpts{})
+	err := ValidateWorkflow(wftmplGetter, wf, ValidateOpts{})
 	assert.Equal(t, err, nil)
 }
 
@@ -1780,11 +1781,11 @@ spec:
 // TestInvalidResourceWorkflow verifies an error against a workflow of an invalid resource.
 func TestInvalidResourceWorkflow(t *testing.T) {
 	wf := unmarshalWf(invalidResourceWorkflow)
-	err := ValidateWorkflow(wfClientset, metav1.NamespaceDefault, wf, ValidateOpts{})
+	err := ValidateWorkflow(wftmplGetter, wf, ValidateOpts{})
 	assert.EqualError(t, err, "templates.whalesay.resource.manifest must be a valid yaml")
 
 	wf = unmarshalWf(invalidActionResourceWorkflow)
-	err = ValidateWorkflow(wfClientset, metav1.NamespaceDefault, wf, ValidateOpts{})
+	err = ValidateWorkflow(wftmplGetter, wf, ValidateOpts{})
 	assert.EqualError(t, err, "templates.whalesay.resource.action must be one of: get, create, apply, delete, replace, patch")
 }
 
@@ -1808,12 +1809,12 @@ spec:
 // TestUnknownPodGCStrategy verifies pod gc strategy is correct.
 func TestUnknownPodGCStrategy(t *testing.T) {
 	wf := unmarshalWf(invalidPodGC)
-	err := ValidateWorkflow(wfClientset, metav1.NamespaceDefault, wf, ValidateOpts{})
+	err := ValidateWorkflow(wftmplGetter, wf, ValidateOpts{})
 	assert.EqualError(t, err, "podGC.strategy unknown strategy 'Foo'")
 
 	for _, strat := range []wfv1.PodGCStrategy{wfv1.PodGCOnPodCompletion, wfv1.PodGCOnPodSuccess, wfv1.PodGCOnWorkflowCompletion, wfv1.PodGCOnWorkflowSuccess} {
 		wf.Spec.PodGC.Strategy = strat
-		err = ValidateWorkflow(wfClientset, metav1.NamespaceDefault, wf, ValidateOpts{})
+		err = ValidateWorkflow(wftmplGetter, wf, ValidateOpts{})
 		assert.NoError(t, err)
 	}
 }
@@ -1886,25 +1887,24 @@ spec:
 
 // TestAutomountServiceAccountTokenUse verifies an error against a workflow of an invalid automountServiceAccountToken use.
 func TestAutomountServiceAccountTokenUse(t *testing.T) {
-	namespace := metav1.NamespaceDefault
 	{
 		wf := unmarshalWf(validAutomountServiceAccountTokenUseWfLevel)
-		err := ValidateWorkflow(wfClientset, namespace, wf, ValidateOpts{})
+		err := ValidateWorkflow(wftmplGetter, wf, ValidateOpts{})
 		assert.NoError(t, err)
 	}
 	{
 		wf := unmarshalWf(validAutomountServiceAccountTokenUseTmplLevel)
-		err := ValidateWorkflow(wfClientset, namespace, wf, ValidateOpts{})
+		err := ValidateWorkflow(wftmplGetter, wf, ValidateOpts{})
 		assert.NoError(t, err)
 	}
 	{
 		wf := unmarshalWf(invalidAutomountServiceAccountTokenUseWfLevel)
-		err := ValidateWorkflow(wfClientset, namespace, wf, ValidateOpts{})
+		err := ValidateWorkflow(wftmplGetter, wf, ValidateOpts{})
 		assert.EqualError(t, err, "templates.whalesay.executor.serviceAccountName must not be empty if automountServiceAccountToken is false")
 	}
 	{
 		wf := unmarshalWf(invalidAutomountServiceAccountTokenUseTmplLevel)
-		err := ValidateWorkflow(wfClientset, namespace, wf, ValidateOpts{})
+		err := ValidateWorkflow(wftmplGetter, wf, ValidateOpts{})
 		assert.EqualError(t, err, "templates.whalesay.executor.serviceAccountName must not be empty if automountServiceAccountToken is false")
 	}
 }


### PR DESCRIPTION
Fixes #1662

I created a concept of `local template resolution context` so lint validation rejects remote template resolutions unless passed a flag.

Here's the lint test result with this fix.

```
$ argo lint examples/workflow-template/steps.yaml
FATA[0000] examples/workflow-template/steps.yaml: templates.hello-hello-hello.steps[0].hello1 failed to get a remote template in local context

$ argo lint --resolve-remote-templates examples/workflow-template/steps.yaml
Workflow manifests validated

$ argo lint --kubeconfig=config examples/workflow-template/steps.yaml
FATA[0000] examples/workflow-template/steps.yaml: templates.hello-hello-hello.steps[0].hello1 failed to get a remote template in local context

$ argo lint --kubeconfig=config --resolve-remote-templates examples/workflowtemplate/steps.yaml
FATA[0000] invalid configuration: no configuration has been provided

$ argo template lint examples/workflow-template/tem
plates.yaml
FATA[0000] examples/workflow-template/templates.yaml: templates.whalesay-inner-template failed to get a remote template in local context

$ argo template lint --resolve-remote-templates exa
mples/workflow-template/templates.yaml
WorkflowTemplate manifests validated

$ argo template lint --kubeconfig=config examples/workflow-template/templates.yaml
FATA[0000] examples/workflow-template/templates.yaml: templates.whalesay-inner-template failed to get a remote template in local context

$ argo template lint --kubeconfig=config --resolve-remote-templates examples/workflow-template/templates.yaml
FATA[0000] invalid configuration: no configuration has been provided
```