### PR TITLE
Allow config object to be set publicly

### DIFF
--- a/cmd/argo/commands/root.go
+++ b/cmd/argo/commands/root.go
@@ -53,5 +53,10 @@ func addKubectlFlagsToCmd(cmd *cobra.Command) {
 	kflags := clientcmd.RecommendedConfigOverrideFlags("")
 	cmd.PersistentFlags().StringVar(&loadingRules.ExplicitPath, "kubeconfig", "", "Path to a kube config. Only required if out-of-cluster")
 	clientcmd.BindOverrideFlags(&overrides, cmd.PersistentFlags(), kflags)
-	clientConfig = clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, &overrides, os.Stdin)
+	SetClientConfig(clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, &overrides, os.Stdin))
+}
+
+// SetClientConfig is a utility function used to set the clientConfig
+func SetClientConfig(config clientcmd.ClientConfig) {
+	clientConfig = config
 }


### PR DESCRIPTION
This allows downstream developers to consume a subset of Argo's CLI
commands to use as subcommands to their own applications

Addresses #1797 