### PR TITLE
Added hint when using certain tokens in when expressions

### DIFF
--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -258,7 +258,7 @@ func shouldExecute(when string) (bool, error) {
 	expression, err := govaluate.NewEvaluableExpression(when)
 	if err != nil {
 		if strings.Contains(err.Error(), "Invalid token") {
-			return false, errors.Errorf(errors.CodeBadRequest, "Invalid 'when' expression '%s': %v (Hint: try wrapping the affected expression in quotes (\"))", when, err)
+			return false, errors.Errorf(errors.CodeBadRequest, "Invalid 'when' expression '%s': %v (hint: try wrapping the affected expression in quotes (\"))", when, err)
 		}
 		return false, errors.Errorf(errors.CodeBadRequest, "Invalid 'when' expression '%s': %v", when, err)
 	}

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -257,6 +257,9 @@ func shouldExecute(when string) (bool, error) {
 	}
 	expression, err := govaluate.NewEvaluableExpression(when)
 	if err != nil {
+		if strings.Contains(err.Error(), "Invalid token") {
+			return false, errors.Errorf(errors.CodeBadRequest, "Invalid 'when' expression '%s': %v (Hint: try wrapping the affected expression in quotes (\"))", when, err)
+		}
 		return false, errors.Errorf(errors.CodeBadRequest, "Invalid 'when' expression '%s': %v", when, err)
 	}
 	// The following loop converts govaluate variables (which we don't use), into strings. This


### PR DESCRIPTION
Fixes #1801 by adding a hint when a `when` expression contains tokens that `govaluate` considers invalid.

Example:
```
Name:                brackets-test-dl284
Namespace:           argo
ServiceAccount:      default
Status:              Failed
Message:             Invalid 'when' expression '{true} == {true}': Invalid token: '{' (Hint: try wrapping the affected expression in quotes ("))
Created:             Mon Dec 02 09:55:33 -0800 (16 seconds ago)
Started:             Mon Dec 02 09:55:33 -0800 (16 seconds ago)
Finished:            Mon Dec 02 09:55:49 -0800 (now)
Duration:            16 seconds

STEP                                    PODNAME                         DURATION  MESSAGE
 ✖ brackets-test-dl284 (brackets-test)                                            Invalid 'when' expression '{true} == {true}': Invalid token: '{' (Hint: try wrapping the affected expression in quotes ("))
 ├-·-✔ brackets (brackets)              brackets-test-dl284-69222893    8s
 | └-✔ no-brackets (no-brackets)        brackets-test-dl284-1849379471  7s
 ├---✔ no-brackets-test (success)       brackets-test-dl284-1733141821  4s
 └---⚠ brackets-test (success)                                                    Invalid 'when' expression '{true} == {true}': Invalid token: '{' (Hint: try wrapping the affected expression in quotes ("))
```

This issue arises because `govaluate` actually requires strings to be quoted – otherwise they are treated as tokens. Up to this point we have hard-coded a workaround to this so that users wouldn't have to always quote their strings:
https://github.com/argoproj/argo/blob/efb748fe35c6f24c736db8e002078abd02b57141/workflow/controller/steps.go#L262-L273

Since the only way to actively solve this (as opposed to passively providing a hint) would be to attempt to quote the strings for the user (which seems like a slippery slope), and we can't force users to quote their strings due to compatibility issues, I came to the conclusion that adding this hint is the best way to solve this problem. 