### PR TITLE
Do not submit duplicate workflows

### DIFF
--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -270,7 +270,7 @@ func (woc *wfOperationCtx) createWorkflowPod(nodeName string, mainCtr apiv1.Cont
 	created, err := woc.controller.kubeclientset.CoreV1().Pods(woc.wf.ObjectMeta.Namespace).Get(nodeID, metav1.GetOptions{})
 
 	if err != nil {
-		woc.log.Infof("There was an error when getting the pod named %s: %v", nodeID, err)
+		// pod does not exist yet
 		created, err = woc.controller.kubeclientset.CoreV1().Pods(woc.wf.ObjectMeta.Namespace).Create(pod)
 	} else {
 		// workflow pod names are deterministic. We can get here if the


### PR DESCRIPTION
Closes: #1720 

Description
------------
Prior to creating a workflow pod, ensure that it does not yet exist by using a GET call to the k8s api. If it already exists, do nothing. If it does not, create the pod as before.

Result
------
Instead of repeatedly sending invalid create-pod requests to the k8s api, only a single request is sent. Previously, these invalid requests were counting against resource quotas due to bugs in kubernetes (see kubernetes/kubernetes#70563 and kubernetes/kubernetes#51476)