### PR TITLE
fix: Ensure timer channel is empty after stop

### DIFF
--- a/workflow/executor/common/common.go
+++ b/workflow/executor/common/common.go
@@ -43,7 +43,9 @@ func WaitForTermination(c KubernetesClientInterface, containerID string, timeout
 	defer ticker.Stop()
 	timer := time.NewTimer(timeout)
 	if timeout == 0 {
-		timer.Stop()
+		if !timer.Stop() {
+			<-timer.C
+		}
 	} else {
 		defer timer.Stop()
 	}


### PR DESCRIPTION
Found that the k8sapi/kubelet executor that use the `WaitForTermination()`
of the common executor randomly throw the error as below and
also issue has been reported (#1573)

```
=== 8< ===
time="2019-12-05T06:00:16Z" level=info msg="Waiting on main container"
time="2019-12-05T06:00:20Z" level=info msg="main container started with container ID: 980c0415db8e7c404161eb37ada3f5a17fe38f284ff02960e130526b69d3b7a3"
time="2019-12-05T06:00:20Z" level=info msg="Starting annotations monitor"
time="2019-12-05T06:00:20Z" level=info msg="Waiting for container 980c0415db8e7c404161eb37ada3f5a17fe38f284ff02960e130526b69d3b7a3 to complete"
time="2019-12-05T06:00:20Z" level=info msg="Starting deadline monitor"
time="2019-12-05T06:00:20Z" level=info msg="Starting to wait completion of containerID 980c0415db8e7c404161eb37ada3f5a17fe38f284ff02960e130526b69d3b7a3 ..."
time="2019-12-05T06:00:20Z" level=warning msg="Failed to wait for container id '980c0415db8e7c404161eb37ada3f5a17fe38f284ff02960e130526b69d3b7a3': timeout after 0s"
time="2019-12-05T06:00:20Z" level=error msg="executor error: timeout after 0s"
time="2019-12-05T06:00:20Z" level=info msg="Saving output parameters"
=== >8 ===
```

Refers to [1], we should ensure that the timer channel is empty after stop,
otherwise, the error will be thrown unexpectedly.

---
[1] https://golang.org/pkg/time/#Timer.Stop