### PR TITLE
docs: Update doc based on helm 3.x changes

### DIFF
--- a/docs/configure-artifact-repository.md
+++ b/docs/configure-artifact-repository.md
@@ -7,9 +7,10 @@ This section shows how to configure the artifact repository. Subsequent sections
 ## Configuring Minio
 
 ```
-$ brew install kubernetes-helm # mac
-$ helm init
-$ helm install stable/minio --name argo-artifacts --set service.type=LoadBalancer
+$ brew install helm # mac, helm 3.x
+$ helm repo add stable https://kubernetes-charts.storage.googleapis.com/ # official Helm stable charts
+$ helm repo update
+$ helm install argo-artifacts stable/minio --set service.type=LoadBalancer --set fullnameOverride=argo-artifacts
 ```
 
 Login to the Minio UI using a web browser (port 9000) after obtaining the external IP using `kubectl`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -124,8 +124,7 @@ This tutorial uses Minio for the sake of portability.
 
 Install Minio:
 ```sh
-helm install stable/minio \
-  --name argo-artifacts \
+helm install argo-artifacts stable/minio \
   --set service.type=LoadBalancer \
   --set defaultBucket.enabled=true \
   --set defaultBucket.name=my-bucket \


### PR DESCRIPTION
Helm 3 has been the default version in brew repository, and it has
quite different operations from before. This change is to make the
doc update to date.