### PR TITLE
docs: Adding Wavefront to the users list

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Currently **officially** using Argo:
 1. [Styra](https://www.styra.com/)
 1. [Threekit](https://www.threekit.com/)
 1. [Tiger Analytics](https://www.tigeranalytics.com/)
+1. [Wavefront](https://www.wavefront.com/)
 
 ## Community Blogs and Presentations
 * [Argo Ansible role: Provisioning Argo Workflows on OpenShift](https://medium.com/@marekermk/provisioning-argo-on-openshift-with-ansible-and-kustomize-340a1fda8b50)


### PR DESCRIPTION
Wavefront internally uses argo for release automation