### PR TITLE
fix: quick fail after pod termination

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,7 @@ jobs:
             docker pull golang:1.11.5
             docker pull minio/minio
             docker pull docker/whalesay:latest
+            docker pull bitnami/kubectl
           background: true
       - restore_go_cache
       - install_golang

--- a/test/e2e/expectedfailures/pod-termination-failure.yaml
+++ b/test/e2e/expectedfailures/pod-termination-failure.yaml
@@ -1,0 +1,61 @@
+# Simulate the case of pod termination due to reasons such as node failure.
+# It should fast fail if termination is detected.
+# 
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: sleeptest-
+spec:
+  entrypoint: entry
+  templates:
+  - name: entry
+    dag:
+      tasks:
+      - name: sleep
+        template: sleep-n-sec
+        arguments:
+          parameters:
+          - name: seconds
+            value: 1200
+      - name: check-running
+        template: check-status
+      - name: trigger-termination
+        dependencies: [check-running]
+        template: delete-sleep-pod
+        arguments:
+          parameters:
+          - name: pod
+            value: "{{tasks.check-running.outputs.result}}"
+        when: "\"{{tasks.check-running.outputs.result}}\" != \"failed\""
+  - name: sleep-n-sec
+    inputs:
+      parameters:
+      - name: seconds
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["echo sleeping for {{inputs.parameters.seconds}} seconds; sleep {{inputs.parameters.seconds}}; echo done"]
+  - name: check-status
+    script:
+      image: bitnami/kubectl
+      command: [bash]
+      source: |
+        host=`hostname`;
+        result="failed";
+        for i in $(seq 1 20); do
+          sleep 5;
+          if [[ `kubectl get po | grep sleeptest | grep -i running| grep -v $host | wc -l` -gt 0 ]]; then
+            result=`kubectl get po | grep sleeptest | grep -i running| grep -v $host | awk '{print $1}'`;
+            break;
+          fi
+        done
+        echo $result;
+  - name: delete-sleep-pod
+    inputs:
+      parameters:
+      - name: pod
+    container:
+      image: bitnami/kubectl
+      command: [bash, -c]
+      args: ["kubectl delete po {{inputs.parameters.pod}}"]
+

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -69,6 +69,22 @@ spec:
 		})
 }
 
+func (s *FunctionalSuite) TestFastFailOnPodTermination() {
+	s.Given().
+		Workflow("@expectedfailures/pod-termination-failure.yaml").
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow(120 * time.Second).
+		Then().
+		Expect(func(t *testing.T, status *wfv1.WorkflowStatus) {
+			assert.Equal(t, wfv1.NodeFailed, status.Phase)
+			assert.Len(t, status.Nodes, 4)
+			nodeStatus := status.Nodes.FindByDisplayName("sleep")
+			assert.Equal(t, wfv1.NodeFailed, nodeStatus.Phase)
+			assert.Equal(t, "pod termination", nodeStatus.Message)
+		})
+}
+
 func TestFunctionalSuite(t *testing.T) {
 	suite.Run(t, new(FunctionalSuite))
 }

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -799,7 +799,7 @@ func assessNodeStatus(pod *apiv1.Pod, node *wfv1.NodeStatus) *wfv1.NodeStatus {
 	case apiv1.PodRunning:
 		if pod.DeletionTimestamp != nil {
 			// pod is being terminated
-			newPhase = wfv1.NodeError
+			newPhase = wfv1.NodeFailed
 			message = "pod termination"
 		} else {
 			newPhase = wfv1.NodeRunning

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -801,7 +801,6 @@ func assessNodeStatus(pod *apiv1.Pod, node *wfv1.NodeStatus) *wfv1.NodeStatus {
 			// pod is being terminated
 			newPhase = wfv1.NodeError
 			message = "pod termination"
-			log.Info(message)
 		} else {
 			newPhase = wfv1.NodeRunning
 			tmplStr, ok := pod.Annotations[common.AnnotationKeyTemplate]

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -371,7 +371,7 @@ func TestAssessNodeStatus(t *testing.T) {
 			},
 		},
 		node: &wfv1.NodeStatus{},
-		want: wfv1.NodeError,
+		want: wfv1.NodeFailed,
 	}, {
 		name: "pod running",
 		pod: &apiv1.Pod{


### PR DESCRIPTION
Fixes: https://github.com/argoproj/argo/issues/1832

When a k8s node where the POD runs has an issue, the POD will go to "terminating" state - which is actually "running" phase but with "DeletionTimestamp", and stuck there. This fix quick fails it when this kind of situation is detected.