### PR TITLE
docs: Fix e2e testing link

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -62,4 +62,4 @@ images.controller workflow-controller:latest
 
 ### E2E Testing
 
-See [test/e2e/README.md](test/e2e/README.md).
+See [test/e2e/README.md](../test/e2e/README.md).


### PR DESCRIPTION
The current target looks like an absolute reference but is browser-interpreted as relative. The change makes it explicitly a relative reference and avoids a 404 in GitHub.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) **this does not need to be in the release notes**.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) ~~suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`. Why? for the release notes~~. 
* [x] Optional. I've added My organization is added to the README.
* [x] I've signed the CLA and required builds are green. 
