### PR TITLE
fix: Decrease docker build time by ignoring node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 # Prevent vendor directory from being copied to ensure we are not not pulling unexpected cruft from 
 # a user's workspace, and are only building off of what is locked by dep.
+.git
 vendor
 dist
+ui/node_modules


### PR DESCRIPTION
It takes a long time to send `node_modules` to the deamon build context even though it is unnecessary to do so.