### PR TITLE
feat: Enhancement for namespace installation mode configuration

### DIFF
--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -38,7 +38,7 @@ func NewRootCommand() *cobra.Command {
 		glogLevel               int    // --gloglevel
 		workflowWorkers         int    // --workflow-workers
 		podWorkers              int    // --pod-workers
-		namespaceMode           bool   // --namespace-mode
+		namespaced              bool   // --namespaced
 		filteredNamespace       string // --namespace
 	)
 
@@ -78,10 +78,10 @@ func NewRootCommand() *cobra.Command {
 				fmt.Printf("\n------------------------    WARNING    ------------------------\n")
 				fmt.Printf("Namespace installation mode with configmap setting is deprecated, \n")
 				fmt.Printf("it will be removed in next major release. Instead please add \n")
-				fmt.Printf("\"--namespace-mode\" to workflow-controller start args.\n")
+				fmt.Printf("\"--namespaced\" to workflow-controller start args.\n")
 				fmt.Printf("-----------------------------------------------------------------\n\n")
 			} else {
-				if namespaceMode {
+				if namespaced {
 					if len(filteredNamespace) > 0 {
 						wfController.Config.Namespace = filteredNamespace
 					} else {
@@ -116,7 +116,7 @@ func NewRootCommand() *cobra.Command {
 	command.Flags().IntVar(&glogLevel, "gloglevel", 0, "Set the glog logging level")
 	command.Flags().IntVar(&workflowWorkers, "workflow-workers", 8, "Number of workflow workers")
 	command.Flags().IntVar(&podWorkers, "pod-workers", 8, "Number of pod workers")
-	command.Flags().BoolVar(&namespaceMode, "namespace-mode", false, "run workflow-controller as namespace mode")
+	command.Flags().BoolVar(&namespaced, "namespaced", false, "run workflow-controller as namespace mode")
 	command.Flags().StringVar(&filteredNamespace, "namespace", "", "namespace that workflow-controller listens to, default to the installation namespace")
 	return &command
 }

--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -81,7 +81,7 @@ func NewRootCommand() *cobra.Command {
 				fmt.Fprintf(os.Stderr, "Namespaced installation with configmap setting is deprecated, \n")
 				fmt.Fprintf(os.Stderr, "it will be removed in next major release. Instead please add \n")
 				fmt.Fprintf(os.Stderr, "\"--namespaced\" to workflow-controller start args or add \n")
-				fmt.Fprintf(os.Stderr, "\"NAMESPACED=true\" to ENV.\n")
+				fmt.Fprintf(os.Stderr, "NAMESPACED=\"true\" to ENV.\n")
 				fmt.Fprintf(os.Stderr, "-----------------------------------------------------------------\n\n")
 			} else {
 				if namespaced {

--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"time"
 
 	"github.com/argoproj/argo/workflow/cron"
@@ -119,11 +118,7 @@ func NewRootCommand() *cobra.Command {
 	command.Flags().IntVar(&glogLevel, "gloglevel", 0, "Set the glog logging level")
 	command.Flags().IntVar(&workflowWorkers, "workflow-workers", 8, "Number of workflow workers")
 	command.Flags().IntVar(&podWorkers, "pod-workers", 8, "Number of pod workers")
-	namespacedMode, err := strconv.ParseBool(os.Getenv("NAMESPACED"))
-	if err != nil {
-		namespacedMode = false
-	}
-	command.Flags().BoolVar(&namespaced, "namespaced", namespacedMode, "run workflow-controller as namespaced mode")
+	command.Flags().BoolVar(&namespaced, "namespaced", os.Getenv("NAMESPACED") == "true", "run workflow-controller as namespaced mode")
 	command.Flags().StringVar(&watchedNamespace, "watched-namespace", os.Getenv("WATCHED_NAMESPACE"), "namespace that workflow-controller watches, default to the installation namespace")
 	return &command
 }

--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -77,8 +77,8 @@ func NewRootCommand() *cobra.Command {
 			if len(wfController.Config.Namespace) > 0 {
 				fmt.Printf("\n------------------------    WARNING    ------------------------\n")
 				fmt.Printf("Namespace installation mode with configmap setting is deprecated, \n")
-				fmt.Printf("it will be removed in next release. Instead please add \n")
-				fmt.Printf("\"--namespace-mode\" to workflow-controller start args instead.\n")
+				fmt.Printf("it will be removed in next major release. Instead please add \n")
+				fmt.Printf("\"--namespace-mode\" to workflow-controller start args.\n")
 				fmt.Printf("-----------------------------------------------------------------\n\n")
 			} else {
 				if namespaceMode {

--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -40,7 +40,7 @@ func NewRootCommand() *cobra.Command {
 		workflowWorkers         int    // --workflow-workers
 		podWorkers              int    // --pod-workers
 		namespaced              bool   // --namespaced
-		watchedNamespace        string // --watched-namespace
+		managedNamespace        string // --managed-namespace
 	)
 
 	var command = cobra.Command{
@@ -79,13 +79,12 @@ func NewRootCommand() *cobra.Command {
 				fmt.Fprintf(os.Stderr, "\n------------------------    WARNING    ------------------------\n")
 				fmt.Fprintf(os.Stderr, "Namespaced installation with configmap setting is deprecated, \n")
 				fmt.Fprintf(os.Stderr, "it will be removed in next major release. Instead please add \n")
-				fmt.Fprintf(os.Stderr, "\"--namespaced\" to workflow-controller start args or add \n")
-				fmt.Fprintf(os.Stderr, "NAMESPACED=\"true\" to ENV.\n")
+				fmt.Fprintf(os.Stderr, "\"--namespaced\" to workflow-controller start args.\n")
 				fmt.Fprintf(os.Stderr, "-----------------------------------------------------------------\n\n")
 			} else {
 				if namespaced {
-					if len(watchedNamespace) > 0 {
-						wfController.Config.Namespace = watchedNamespace
+					if len(managedNamespace) > 0 {
+						wfController.Config.Namespace = managedNamespace
 					} else {
 						wfController.Config.Namespace = namespace
 					}
@@ -118,8 +117,8 @@ func NewRootCommand() *cobra.Command {
 	command.Flags().IntVar(&glogLevel, "gloglevel", 0, "Set the glog logging level")
 	command.Flags().IntVar(&workflowWorkers, "workflow-workers", 8, "Number of workflow workers")
 	command.Flags().IntVar(&podWorkers, "pod-workers", 8, "Number of pod workers")
-	command.Flags().BoolVar(&namespaced, "namespaced", os.Getenv("NAMESPACED") == "true", "run workflow-controller as namespaced mode")
-	command.Flags().StringVar(&watchedNamespace, "watched-namespace", os.Getenv("WATCHED_NAMESPACE"), "namespace that workflow-controller watches, default to the installation namespace")
+	command.Flags().BoolVar(&namespaced, "namespaced", false, "run workflow-controller as namespaced mode")
+	command.Flags().StringVar(&managedNamespace, "managed-namespace", "", "namespace that workflow-controller watches, default to the installation namespace")
 	return &command
 }
 

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -262,7 +262,7 @@ spec:
         - workflow-controller-configmap
         - --executor-image
         - argoproj/argoexec:latest
-        - - --namespaced
+        - --namespaced
         command:
         - workflow-controller
         image: argoproj/workflow-controller:latest

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -262,11 +262,9 @@ spec:
         - workflow-controller-configmap
         - --executor-image
         - argoproj/argoexec:latest
+        - - --namespaced
         command:
         - workflow-controller
-        env:
-        - name: NAMESPACED
-          value: "true"
         image: argoproj/workflow-controller:latest
         name: workflow-controller
       serviceAccountName: argo

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -262,7 +262,7 @@ spec:
         - workflow-controller-configmap
         - --executor-image
         - argoproj/argoexec:latest
-        - --namespace-mode
+        - --namespaced
         command:
         - workflow-controller
         image: argoproj/workflow-controller:latest

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -262,9 +262,11 @@ spec:
         - workflow-controller-configmap
         - --executor-image
         - argoproj/argoexec:latest
-        - --namespaced
         command:
         - workflow-controller
+        env:
+        - name: NAMESPACED
+          value: true
         image: argoproj/workflow-controller:latest
         name: workflow-controller
       serviceAccountName: argo

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -266,7 +266,7 @@ spec:
         - workflow-controller
         env:
         - name: NAMESPACED
-          value: true
+          value: "true"
         image: argoproj/workflow-controller:latest
         name: workflow-controller
       serviceAccountName: argo

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1,4 +1,3 @@
-# This is an auto-generated file. DO NOT EDIT
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -197,9 +196,6 @@ subjects:
   name: argo-ui
 ---
 apiVersion: v1
-data:
-  config: |
-    namespace: argo
 kind: ConfigMap
 metadata:
   name: workflow-controller-configmap
@@ -266,6 +262,7 @@ spec:
         - workflow-controller-configmap
         - --executor-image
         - argoproj/argoexec:latest
+        - --namespace-mode
         command:
         - workflow-controller
         image: argoproj/workflow-controller:latest

--- a/manifests/namespace-install/kustomization.yaml
+++ b/manifests/namespace-install/kustomization.yaml
@@ -7,5 +7,5 @@ bases:
 - ./argo-ui-rbac
 
 patchesStrategicMerge:
-- ./overlays/workflow-controller-configmap.yaml
 - ./overlays/argo-ui-deployment.yaml
+- ./overlays/workflow-controller-deployment.yaml

--- a/manifests/namespace-install/kustomization.yaml
+++ b/manifests/namespace-install/kustomization.yaml
@@ -8,4 +8,11 @@ bases:
 
 patchesStrategicMerge:
 - ./overlays/argo-ui-deployment.yaml
-- ./overlays/workflow-controller-deployment.yaml
+
+patchesJson6902:
+- target:
+    version: v1
+    group: apps
+    kind: Deployment
+    name: workflow-controller
+  path: ./overlays/workflow-controller-deployment.yaml

--- a/manifests/namespace-install/overlays/workflow-controller-configmap.yaml
+++ b/manifests/namespace-install/overlays/workflow-controller-configmap.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: workflow-controller-configmap
-data:
-  config: |
-    namespace: argo

--- a/manifests/namespace-install/overlays/workflow-controller-deployment.yaml
+++ b/manifests/namespace-install/overlays/workflow-controller-deployment.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       containers:
       - name: workflow-controller
-        args:
-        - --configmap
-        - workflow-controller-configmap
-        - --executor-image
-        - argoproj/argoexec:latest
-        - --namespaced
+        env:
+        - name: NAMESPACED
+          value: true

--- a/manifests/namespace-install/overlays/workflow-controller-deployment.yaml
+++ b/manifests/namespace-install/overlays/workflow-controller-deployment.yaml
@@ -1,5 +1,5 @@
 - op: add
   path: /spec/template/spec/containers/0/args/-
   value:
-    - --namespaced
+    --namespaced
 

--- a/manifests/namespace-install/overlays/workflow-controller-deployment.yaml
+++ b/manifests/namespace-install/overlays/workflow-controller-deployment.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workflow-controller
+spec:
+  template:
+    spec:
+      containers:
+      - name: workflow-controller
+        args:
+        - --configmap
+        - workflow-controller-configmap
+        - --executor-image
+        - argoproj/argoexec:latest
+        - --namespace-mode

--- a/manifests/namespace-install/overlays/workflow-controller-deployment.yaml
+++ b/manifests/namespace-install/overlays/workflow-controller-deployment.yaml
@@ -9,4 +9,4 @@ spec:
       - name: workflow-controller
         env:
         - name: NAMESPACED
-          value: true
+          value: "true"

--- a/manifests/namespace-install/overlays/workflow-controller-deployment.yaml
+++ b/manifests/namespace-install/overlays/workflow-controller-deployment.yaml
@@ -12,4 +12,4 @@ spec:
         - workflow-controller-configmap
         - --executor-image
         - argoproj/argoexec:latest
-        - --namespace-mode
+        - --namespaced

--- a/manifests/namespace-install/overlays/workflow-controller-deployment.yaml
+++ b/manifests/namespace-install/overlays/workflow-controller-deployment.yaml
@@ -1,12 +1,5 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: workflow-controller
-spec:
-  template:
-    spec:
-      containers:
-      - name: workflow-controller
-        env:
-        - name: NAMESPACED
-          value: "true"
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    - --namespaced
+


### PR DESCRIPTION
This is the implementation for proposal https://github.com/argoproj/argo/issues/1938, with this change, `workflow-controller` adds 2 optional args`--namespaced` and `--namespace`. 

This deprecates the dependency of `namespace` configuration in the configmap for namespace only mode installation.