### PR TITLE
fix: Only run archived wf testing when persistence is enabled

### DIFF
--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -256,62 +256,66 @@ func (s *ArgoServerSuite) TestPermission() {
 			Status(403)
 	})
 
-	// Simply wait 10 seconds for the wf to be completed
-	s.Given().
-		WorkflowName("test-wf-good").
-		When().
-		WaitForWorkflow(10 * time.Second)
+	if s.Persistence.IsEnabled() {
 
-	// Test list archived WFs with good token
-	s.bearerToken = goodToken
-	s.Run("ListArchivedWFsGoodToken", func(t *testing.T) {
-		s.e(t).GET("/api/v1/archived-workflows").
-			WithQuery("listOptions.labelSelector", "argo-e2e").
-			WithQuery("listOptions.fieldSelector", "metadata.namespace="+nsName).
-			Expect().
-			Status(200).
-			JSON().
-			Path("$.items").
-			Array().Length().Gt(0)
-	})
+		// Simply wait 10 seconds for the wf to be completed
+		s.Given().
+			WorkflowName("test-wf-good").
+			When().
+			WaitForWorkflow(10 * time.Second)
 
-	// Test get archived wf with good token
-	s.bearerToken = goodToken
-	s.Run("GetArchivedWFsGoodToken", func(t *testing.T) {
-		s.e(t).GET("/api/v1/archived-workflows/"+uid).
-			WithQuery("listOptions.labelSelector", "argo-e2e").
-			Expect().
-			Status(200).
-			JSON().
-			Path("$.metadata.name").
-			Equal("test-wf-good")
-	})
+		// Test list archived WFs with good token
+		s.bearerToken = goodToken
+		s.Run("ListArchivedWFsGoodToken", func(t *testing.T) {
+			s.e(t).GET("/api/v1/archived-workflows").
+				WithQuery("listOptions.labelSelector", "argo-e2e").
+				WithQuery("listOptions.fieldSelector", "metadata.namespace="+nsName).
+				Expect().
+				Status(200).
+				JSON().
+				Path("$.items").
+				Array().Length().Gt(0)
+		})
 
-	// Test list archived WFs with bad token
-	// TODO: Uncomment following code after https://github.com/argoproj/argo/issues/2049 is resolved.
+		// Test get archived wf with good token
+		s.bearerToken = goodToken
+		s.Run("GetArchivedWFsGoodToken", func(t *testing.T) {
+			s.e(t).GET("/api/v1/archived-workflows/"+uid).
+				WithQuery("listOptions.labelSelector", "argo-e2e").
+				Expect().
+				Status(200).
+				JSON().
+				Path("$.metadata.name").
+				Equal("test-wf-good")
+		})
 
-	// s.bearerToken = badToken
-	// s.Run("ListArchivedWFsBadToken", func(t *testing.T) {
-	// 	s.e(t).GET("/api/v1/archived-workflows").
-	// 		WithQuery("listOptions.labelSelector", "argo-e2e").
-	// 		WithQuery("listOptions.fieldSelector", "metadata.namespace="+nsName).
-	// 		Expect().
-	// 		Status(200).
-	// 		JSON().
-	// 		Path("$.items").
-	// 		Array().
-	// 		Length().
-	// 		Equal(0)
-	// })
+		// Test list archived WFs with bad token
+		// TODO: Uncomment following code after https://github.com/argoproj/argo/issues/2049 is resolved.
 
-	// Test get archived wf with bad token
-	s.bearerToken = badToken
-	s.Run("ListArchivedWFsBadToken", func(t *testing.T) {
-		s.e(t).GET("/api/v1/archived-workflows/"+uid).
-			WithQuery("listOptions.labelSelector", "argo-e2e").
-			Expect().
-			Status(403)
-	})
+		// s.bearerToken = badToken
+		// s.Run("ListArchivedWFsBadToken", func(t *testing.T) {
+		// 	s.e(t).GET("/api/v1/archived-workflows").
+		// 		WithQuery("listOptions.labelSelector", "argo-e2e").
+		// 		WithQuery("listOptions.fieldSelector", "metadata.namespace="+nsName).
+		// 		Expect().
+		// 		Status(200).
+		// 		JSON().
+		// 		Path("$.items").
+		// 		Array().
+		// 		Length().
+		// 		Equal(0)
+		// })
+
+		// Test get archived wf with bad token
+		s.bearerToken = badToken
+		s.Run("ListArchivedWFsBadToken", func(t *testing.T) {
+			s.e(t).GET("/api/v1/archived-workflows/"+uid).
+				WithQuery("listOptions.labelSelector", "argo-e2e").
+				Expect().
+				Status(403)
+		})
+
+	}
 
 	// Test delete workflow with bad token
 	s.bearerToken = badToken


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.
* [ ] Optional. I've added My organization is added to the README.
* [ ] I've signed the CLA and required builds are green. 
