### PR TITLE
fix: "base64 -d" not always available, using "base64 --decode"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -340,7 +340,7 @@ up:
 	# Wait for pods to be ready
 	kubectl -n argo wait --for=condition=Ready pod --all -l app --timeout 2m
 	# Token
-	kubectl -n argo get `kubectl -n argo get secret -o name | grep argo-server` -o jsonpath='{.data.token}' | base64 -d
+	kubectl -n argo get `kubectl -n argo get secret -o name | grep argo-server` -o jsonpath='{.data.token}' | base64 --decode
 
 .PHONY: pf
 pf:


### PR DESCRIPTION
`-d` is not avaliable in my system:
```
kubectl -n argo get `kubectl -n argo get secret -o name | grep argo-server` -o jsonpath='{.data.token}' | base64 -d
base64: invalid option -- d
Usage:	base64 [-hvD] [-b num] [-i in_file] [-o out_file]
  -h, --help     display this message
  -D, --decode   decodes input
  -b, --break    break encoded string into num character lines
  -i, --input    input file (default: "-" for stdin)
  -o, --output   output file (default: "-" for stdout)
```
Seems like it's safer to use `--decode`

