### PR TITLE
fix: Fix Resource Deletion Bug

### DIFF
--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -158,8 +158,6 @@ func checkIfResourceDeleted(resourceNamespace string, resourceName string) bool 
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		// Println(Sprint(err) + ": " + stderr.String())
-		// Println(err.Error())
 		if strings.Contains(stderr.String(), "NotFound") {
 			return true
 		}

--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -148,8 +148,8 @@ func (we *WorkflowExecutor) WaitResource(resourceNamespace string, resourceName 
 	return err
 }
 
-func checkIfResourceDeleted(resourceNamespace string, resourceName string) bool {
-	args := []string{"get", resourceName, "-o", "yaml"}
+func checkIfResourceDeleted(resourceName string, resourceNamespace string) bool {
+	args := []string{"get", resourceName}
 	if resourceNamespace != "" {
 		args = append(args, "-n", resourceNamespace)
 	}


### PR DESCRIPTION
Fix https://github.com/argoproj/argo/issues/2078

Test:
Tested on minikube with the yaml mentioned [here](https://github.com/argoproj/argo/issues/2078#issuecomment-579407628). Manually delete the `Job` resource. Then `kubectl get wf zjl-k8s-jobs -o yaml` and the output is as expected:
```
......
  status:
    finishedAt: "2020-01-29T04:28:48Z"
    message: Resource Job.batch/pi-job-gsvvn in namespace default has been deleted
      somehow.
    nodes:
      zjl-k8s-jobs:
        displayName: zjl-k8s-jobs
        finishedAt: "2020-01-29T04:28:48Z"
        id: zjl-k8s-jobs
        message: Resource Job.batch/pi-job-gsvvn in namespace default has been deleted
          somehow.
        name: zjl-k8s-jobs
        phase: Failed
        startedAt: "2020-01-29T04:28:36Z"
        templateName: pi-tmpl
        type: Pod
    phase: Failed
    startedAt: "2020-01-29T04:28:36Z"
......
```