### PR TITLE
 fix: Namespace redirects no longer error and are snappier

### DIFF
--- a/ui/src/app/archived-workflows/components/archived-workflow-list/archived-workflow-list.tsx
+++ b/ui/src/app/archived-workflows/components/archived-workflow-list/archived-workflow-list.tsx
@@ -35,7 +35,7 @@ export class ArchivedWorkflowList extends BasePage<RouteComponentProps<any>, Sta
     }
 
     private set namespace(namespace: string) {
-        this.setState({namespace: namespace});
+        this.setState({namespace});
         history.pushState(null, '', uiUrl('cron-workflows/' + namespace));
     }
 
@@ -61,7 +61,7 @@ export class ArchivedWorkflowList extends BasePage<RouteComponentProps<any>, Sta
 
     public render() {
         if (this.state.loading) {
-            return <Loading/>;
+            return <Loading />;
         }
         if (this.state.error) {
             throw this.state.error;

--- a/ui/src/app/cron-workflows/components/cron-workflow-list/cron-workflow-list.tsx
+++ b/ui/src/app/cron-workflows/components/cron-workflow-list/cron-workflow-list.tsx
@@ -13,20 +13,24 @@ import {ZeroState} from '../../../shared/components/zero-state';
 import {Consumer} from '../../../shared/context';
 import {exampleCronWorkflow} from '../../../shared/examples';
 import {services} from '../../../shared/services';
+
 require('./cron-workflow-list.scss');
 
 interface State {
+    loading: boolean;
+    namespace: string;
     cronWorkflows?: models.CronWorkflow[];
     error?: Error;
 }
 
 export class CronWorkflowList extends BasePage<RouteComponentProps<any>, State> {
     private get namespace() {
-        return this.props.match.params.namespace || '';
+        return this.state.namespace;
     }
 
     private set namespace(namespace: string) {
-        document.location.href = uiUrl('cron-workflows/' + namespace);
+        this.setState({namespace: namespace});
+        history.pushState(null, '', uiUrl('cron-workflows/' + namespace));
     }
 
     private get sidePanel() {
@@ -38,10 +42,10 @@ export class CronWorkflowList extends BasePage<RouteComponentProps<any>, State> 
     }
     constructor(props: any) {
         super(props);
-        this.state = {};
+        this.state = {loading: true, namespace: this.props.match.params.namespace || ''};
     }
 
-    public componentDidMount(): void {
+    public componentWillMount(): void {
         services.info
             .get()
             .then(info => {
@@ -50,11 +54,14 @@ export class CronWorkflowList extends BasePage<RouteComponentProps<any>, State> 
                 }
                 return services.cronWorkflows.list(this.namespace);
             })
-            .then(cronWorkflows => this.setState({cronWorkflows}))
-            .catch(error => this.setState({error}));
+            .then(cronWorkflows => this.setState({cronWorkflows, loading: false}))
+            .catch(error => this.setState({error, loading: false}));
     }
 
     public render() {
+        if (this.state.loading) {
+            return <Loading/>;
+        }
         if (this.state.error) {
             throw this.state.error;
         }

--- a/ui/src/app/cron-workflows/components/cron-workflow-list/cron-workflow-list.tsx
+++ b/ui/src/app/cron-workflows/components/cron-workflow-list/cron-workflow-list.tsx
@@ -29,7 +29,7 @@ export class CronWorkflowList extends BasePage<RouteComponentProps<any>, State> 
     }
 
     private set namespace(namespace: string) {
-        this.setState({namespace: namespace});
+        this.setState({namespace});
         history.pushState(null, '', uiUrl('cron-workflows/' + namespace));
     }
 
@@ -60,7 +60,7 @@ export class CronWorkflowList extends BasePage<RouteComponentProps<any>, State> 
 
     public render() {
         if (this.state.loading) {
-            return <Loading/>;
+            return <Loading />;
         }
         if (this.state.error) {
             throw this.state.error;

--- a/ui/src/app/workflow-templates/components/workflow-template-list/workflow-template-list.tsx
+++ b/ui/src/app/workflow-templates/components/workflow-template-list/workflow-template-list.tsx
@@ -17,17 +17,20 @@ import {services} from '../../../shared/services';
 require('./workflow-template-list.scss');
 
 interface State {
+    loading: boolean;
+    namespace: string;
     templates?: models.WorkflowTemplate[];
     error?: Error;
 }
 
 export class WorkflowTemplateList extends BasePage<RouteComponentProps<any>, State> {
     private get namespace() {
-        return this.props.match.params.namespace || '';
+        return this.state.namespace;
     }
 
     private set namespace(namespace: string) {
-        document.location.href = uiUrl('workflow-templates/' + namespace);
+        this.setState({namespace: namespace});
+        history.pushState(null, '', uiUrl('workflow-templates/' + namespace));
     }
 
     private get sidePanel() {
@@ -40,7 +43,7 @@ export class WorkflowTemplateList extends BasePage<RouteComponentProps<any>, Sta
 
     constructor(props: RouteComponentProps<any>, context: any) {
         super(props, context);
-        this.state = {};
+        this.state = {loading: true, namespace: this.props.match.params.namespace || ''};
     }
 
     public componentDidMount(): void {
@@ -52,11 +55,14 @@ export class WorkflowTemplateList extends BasePage<RouteComponentProps<any>, Sta
                 }
                 return services.workflowTemplate.list(this.namespace);
             })
-            .then(templates => this.setState({templates}))
-            .catch(error => this.setState({error}));
+            .then(templates => this.setState({templates, loading: false}))
+            .catch(error => this.setState({error, loading: false}));
     }
 
     public render() {
+        if (this.state.loading) {
+            return <Loading/>;
+        }
         if (this.state.error) {
             throw this.state.error;
         }

--- a/ui/src/app/workflow-templates/components/workflow-template-list/workflow-template-list.tsx
+++ b/ui/src/app/workflow-templates/components/workflow-template-list/workflow-template-list.tsx
@@ -29,7 +29,7 @@ export class WorkflowTemplateList extends BasePage<RouteComponentProps<any>, Sta
     }
 
     private set namespace(namespace: string) {
-        this.setState({namespace: namespace});
+        this.setState({namespace});
         history.pushState(null, '', uiUrl('workflow-templates/' + namespace));
     }
 
@@ -61,7 +61,7 @@ export class WorkflowTemplateList extends BasePage<RouteComponentProps<any>, Sta
 
     public render() {
         if (this.state.loading) {
-            return <Loading/>;
+            return <Loading />;
         }
         if (this.state.error) {
             throw this.state.error;

--- a/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
+++ b/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
@@ -36,7 +36,7 @@ export class WorkflowsList extends BasePage<RouteComponentProps<any>, State> {
     }
 
     private set namespace(namespace: string) {
-        this.setState({namespace: namespace});
+        this.setState({namespace});
         history.pushState(null, '', uiUrl('workflows/' + namespace));
     }
 
@@ -114,7 +114,7 @@ export class WorkflowsList extends BasePage<RouteComponentProps<any>, State> {
 
     public render() {
         if (this.state.loading) {
-            return <Loading/>;
+            return <Loading />;
         }
         if (this.state.error) {
             throw this.state.error;

--- a/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
+++ b/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
@@ -22,6 +22,8 @@ import {WorkflowSubmit} from '../workflow-submit';
 require('./workflows-list.scss');
 
 interface State {
+    loading: boolean;
+    namespace: string;
     workflows?: Workflow[];
     error?: Error;
 }
@@ -30,11 +32,12 @@ export class WorkflowsList extends BasePage<RouteComponentProps<any>, State> {
     private subscription: Subscription;
 
     private get namespace() {
-        return this.props.match.params.namespace || '';
+        return this.state.namespace;
     }
 
     private set namespace(namespace: string) {
-        document.location.href = uiUrl('workflows/' + namespace);
+        this.setState({namespace: namespace});
+        history.pushState(null, '', uiUrl('workflows/' + namespace));
     }
 
     private get phases() {
@@ -51,10 +54,10 @@ export class WorkflowsList extends BasePage<RouteComponentProps<any>, State> {
 
     constructor(props: RouteComponentProps<State>, context: any) {
         super(props, context);
-        this.state = {};
+        this.state = {loading: true, namespace: this.props.match.params.namespace || ''};
     }
 
-    public componentDidMount(): void {
+    public componentWillMount(): void {
         services.info
             .get()
             .then(info => {
@@ -99,7 +102,8 @@ export class WorkflowsList extends BasePage<RouteComponentProps<any>, State> {
                     })
                     .subscribe(workflows => this.setState({workflows}));
             })
-            .catch(error => this.setState({error}));
+            .then(_ => this.setState({loading: false}))
+            .catch(error => this.setState({error, loading: false}));
     }
 
     public componentWillUnmount(): void {
@@ -109,6 +113,9 @@ export class WorkflowsList extends BasePage<RouteComponentProps<any>, State> {
     }
 
     public render() {
+        if (this.state.loading) {
+            return <Loading/>;
+        }
         if (this.state.error) {
             throw this.state.error;
         }


### PR DESCRIPTION
Fixes #2102 

Demo (notice `managedNamespace` redirection still happens): https://cl.ly/4f3a073db983