### PR TITLE
fix: logs UI should fall back to archive

### DIFF
--- a/ui/src/app/shared/services/requests.ts
+++ b/ui/src/app/shared/services/requests.ts
@@ -7,13 +7,6 @@ import {apiUrl, uiUrl} from '../base';
 
 const superagentPromise = require('superagent-promise');
 
-enum ReadyState {
-    CONNECTING = 0,
-    OPEN = 1,
-    CLOSED = 2,
-    DONE = 4
-}
-
 const auth = (req: SuperAgentRequest) => {
     return req.on('error', handle);
 };
@@ -61,11 +54,7 @@ export default {
             };
             eventSource.onmessage = (msg: any) => observer.next(msg.data);
             eventSource.onerror = (e: any) => {
-                if (e.eventPhase === ReadyState.CLOSED || eventSource.readyState === ReadyState.CONNECTING) {
-                    observer.complete();
-                } else {
-                    observer.error(e);
-                }
+                observer.error(e);
             };
             return () => {
                 eventSource.close();

--- a/ui/src/app/shared/services/workflows-service.ts
+++ b/ui/src/app/shared/services/workflows-service.ts
@@ -59,7 +59,7 @@ export class WorkflowsService {
             requests
                 .get(this.getArtifactDownloadUrl(workflow, nodeId, container + '-logs', archived))
                 .then(resp => {
-                    resp.text.split('\n').forEach(line => observer.next(line));
+                    resp.text.split('\n').forEach(line => observer.next(JSON.stringify(line)));
                 })
                 .catch(err => observer.error(err));
             // tslint:disable-next-line
@@ -79,8 +79,8 @@ export class WorkflowsService {
 
     public getArtifactDownloadUrl(workflow: Workflow, nodeId: string, artifactName: string, archived: boolean) {
         return archived
-            ? `/artifacts-by-uid/${workflow.metadata.uid}/${nodeId}/${encodeURIComponent(artifactName)}?Authorization=${localStorage.getItem('token')}`
-            : `/artifacts/${workflow.metadata.namespace}/${workflow.metadata.name}/${nodeId}/${encodeURIComponent(artifactName)}?Authorization=${localStorage.getItem('token')}`;
+            ? `artifacts-by-uid/${workflow.metadata.uid}/${nodeId}/${encodeURIComponent(artifactName)}?Authorization=${localStorage.getItem('token')}`
+            : `artifacts/${workflow.metadata.namespace}/${workflow.metadata.name}/${nodeId}/${encodeURIComponent(artifactName)}?Authorization=${localStorage.getItem('token')}`;
     }
 
     private queryParams(filter: {namespace?: string; name?: string; phases?: Array<string>}) {

--- a/ui/src/app/workflows/components/workflow-artifacts.tsx
+++ b/ui/src/app/workflows/components/workflow-artifacts.tsx
@@ -19,7 +19,7 @@ export const WorkflowArtifacts = (props: Props) => {
                 const items = nodeOutputs.artifacts || [];
                 return items.map(item =>
                     Object.assign({}, item, {
-                        downloadUrl: services.workflows.getArtifactDownloadUrl(props.workflow, node.id, item.name, props.archived),
+                        downloadUrl: '/' + services.workflows.getArtifactDownloadUrl(props.workflow, node.id, item.name, props.archived),
                         stepName: node.name,
                         dateCreated: node.finishedAt,
                         nodeName


### PR DESCRIPTION
I've not tested this yet, and I don't /really/ know what I'm doing. But
the onerror handler currently breaks the logs UI as it does not result
in the catch getting triggered.
