### PR TITLE
fix: Allow Input Artifact Tar Check to Be Ignored. Fixes #2140

### DIFF
--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -123,6 +123,14 @@ func (we *WorkflowExecutor) LoadArtifacts() error {
 
 		log.Infof("Downloading artifact: %s", art.Name)
 
+		// By default, assume that tar.gz/gz files should be extracted
+		archiveStrategy := art.Archive
+		if archiveStrategy == nil {
+			archiveStrategy = &wfv1.ArchiveStrategy{
+				Tar: &wfv1.TarStrategy{},
+			}
+		}
+
 		if !art.HasLocation() {
 			if art.Optional {
 				log.Warnf("Ignoring optional artifact '%s' which was not supplied", art.Name)
@@ -161,7 +169,7 @@ func (we *WorkflowExecutor) LoadArtifacts() error {
 		if err != nil {
 			return err
 		}
-		if art.Archive.None == nil && isTarball(tempArtPath) {
+		if archiveStrategy.None == nil && isTarball(tempArtPath) {
 			err = untar(tempArtPath, artPath)
 			_ = os.Remove(tempArtPath)
 		} else {

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -161,7 +161,7 @@ func (we *WorkflowExecutor) LoadArtifacts() error {
 		if err != nil {
 			return err
 		}
-		if isTarball(tempArtPath) {
+		if art.Archive.None == nil && isTarball(tempArtPath) {
 			err = untar(tempArtPath, artPath)
 			_ = os.Remove(tempArtPath)
 		} else {


### PR DESCRIPTION
Allows a user to bypass the untarring / tar-check by specifying:

```yaml
archive:
    none: {}
```
on an input artifact.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.
* [ ] Optional. I've added My organization is added to the README.
* [x] I've signed the CLA and required builds are green. 

Fixes #2140