### PR TITLE
feat: Add a new symbol for suspended nodes. Closes #1896

### DIFF
--- a/cmd/argo/commands/common.go
+++ b/cmd/argo/commands/common.go
@@ -34,6 +34,7 @@ var (
 	// DEPRECATED
 	wftmplClient     v1alpha1.WorkflowTemplateInterface
 	jobStatusIconMap map[wfv1.NodePhase]string
+	nodeTypeIconMap  map[wfv1.NodeType]string
 	noColor          bool
 	// DEPRECATED
 	namespace string
@@ -70,6 +71,9 @@ func initializeSession() {
 		wfv1.NodeSkipped:   ansiFormat("○", FgDefault),
 		wfv1.NodeFailed:    ansiFormat("✖", FgRed),
 		wfv1.NodeError:     ansiFormat("⚠", FgRed),
+	}
+	nodeTypeIconMap = map[wfv1.NodeType]string{
+		wfv1.NodeTypeSuspend: ansiFormat("ǁ", FgCyan),
 	}
 }
 

--- a/cmd/argo/commands/get.go
+++ b/cmd/argo/commands/get.go
@@ -432,6 +432,9 @@ func printNode(w *tabwriter.Writer, node wfv1.NodeStatus, nodePrefix string, get
 		return
 	}
 	nodeName := fmt.Sprintf("%s %s", jobStatusIconMap[node.Phase], node.DisplayName)
+	if node.IsActiveSuspendNode() {
+		nodeName = fmt.Sprintf("%s %s", nodeTypeIconMap[node.Type], node.DisplayName)
+	}
 	if node.TemplateRef != nil {
 		nodeName = fmt.Sprintf("%s (%s/%s)", nodeName, node.TemplateRef.Name, node.TemplateRef.Template)
 	} else if node.TemplateName != "" {

--- a/cmd/argo/commands/get_test.go
+++ b/cmd/argo/commands/get_test.go
@@ -1,0 +1,86 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"text/tabwriter"
+	"time"
+
+	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestPrintNode
+func TestPrintNode(t *testing.T) {
+	var result bytes.Buffer
+	w := tabwriter.NewWriter(&result, 0, 8, 1, '\t', 0)
+	nodeName := "testNode"
+	nodePrefix := ""
+	nodeTemplateName := "testTemplate"
+	nodeTemplateRefName := "testTemplateRef"
+	nodeID := "testID"
+	nodeMessage := "test"
+	getArgs := getFlags{
+		output: "",
+		status: "",
+	}
+	timestamp := metav1.Time{
+		Time: time.Now(),
+	}
+	node := wfv1.NodeStatus{
+		Name:        nodeName,
+		Phase:       wfv1.NodeRunning,
+		DisplayName: nodeName,
+		Type:        wfv1.NodeTypePod,
+		ID:          nodeID,
+		StartedAt:   timestamp,
+		FinishedAt:  timestamp,
+		Message:     nodeMessage,
+	}
+
+	printNode(w, node, nodePrefix, getArgs)
+	w.Flush()
+	assert.Equal(t, fmt.Sprintf("%s %s\t%s\t%s\t%s\n", jobStatusIconMap[wfv1.NodeRunning], nodeName, nodeID, "0s", nodeMessage), result.String())
+	result.Reset()
+
+	node.TemplateName = nodeTemplateName
+	printNode(w, node, nodePrefix, getArgs)
+	w.Flush()
+	assert.Equal(t, fmt.Sprintf("%s %s (%s)\t%s\t%s\t%s\n", jobStatusIconMap[wfv1.NodeRunning], nodeName, nodeTemplateName, nodeID, "0s", nodeMessage), result.String())
+	result.Reset()
+
+	node.TemplateName = nodeTemplateName
+	printNode(w, node, nodePrefix, getArgs)
+	w.Flush()
+	assert.Equal(t, fmt.Sprintf("%s %s (%s)\t%s\t%s\t%s\n", jobStatusIconMap[wfv1.NodeRunning], nodeName, nodeTemplateName, nodeID, "0s", nodeMessage), result.String())
+	result.Reset()
+
+	node.Type = wfv1.NodeTypeSuspend
+	printNode(w, node, nodePrefix, getArgs)
+	w.Flush()
+	assert.Equal(t, fmt.Sprintf("%s %s (%s)\t%s\t%s\t%s\n", nodeTypeIconMap[wfv1.NodeTypeSuspend], nodeName, nodeTemplateName, "", "", nodeMessage), result.String())
+	result.Reset()
+
+	node.TemplateRef = &wfv1.TemplateRef{
+		Name:     nodeTemplateRefName,
+		Template: nodeTemplateRefName,
+	}
+	printNode(w, node, nodePrefix, getArgs)
+	w.Flush()
+	assert.Equal(t, fmt.Sprintf("%s %s (%s/%s)\t%s\t%s\t%s\n", nodeTypeIconMap[wfv1.NodeTypeSuspend], nodeName, nodeTemplateRefName, nodeTemplateRefName, "", "", nodeMessage), result.String())
+	result.Reset()
+
+	getArgs.output = "wide"
+	printNode(w, node, nodePrefix, getArgs)
+	w.Flush()
+	assert.Equal(t, fmt.Sprintf("%s %s (%s/%s)\t%s\t%s\t%s\t%s\n", nodeTypeIconMap[wfv1.NodeTypeSuspend], nodeName, nodeTemplateRefName, nodeTemplateRefName, "", "", getArtifactsString(node), nodeMessage), result.String())
+	result.Reset()
+
+	getArgs.status = "foobar"
+	printNode(w, node, nodePrefix, getArgs)
+	w.Flush()
+	assert.Equal(t, "", result.String())
+	result.Reset()
+}

--- a/cmd/argo/commands/get_test.go
+++ b/cmd/argo/commands/get_test.go
@@ -7,9 +7,10 @@ import (
 	"text/tabwriter"
 	"time"
 
-	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 )
 
 func testPrintNodeImpl(t *testing.T, expected string, node wfv1.NodeStatus, nodePrefix string, getArgs getFlags) {

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -1005,6 +1005,11 @@ func (n *NodeStatus) IsResolvable() bool {
 	return true
 }
 
+// IsActiveSuspendNode returns whether this node is an active suspend node
+func (n *NodeStatus) IsActiveSuspendNode() bool {
+	return n.Type == NodeTypeSuspend && n.Phase == NodeRunning
+}
+
 // S3Bucket contains the access information required for interfacing with an S3 bucket
 type S3Bucket struct {
 	// Endpoint is the hostname of the bucket endpoint

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -753,7 +753,7 @@ func (woc *wfOperationCtx) podReconciliation() error {
 func (woc *wfOperationCtx) failSuspendedNodesAfterDeadline() error {
 	if woc.workflowDeadline != nil && time.Now().UTC().After(*woc.workflowDeadline) {
 		for _, node := range woc.wf.Status.Nodes {
-			if node.Type == wfv1.NodeTypeSuspend && node.Phase == wfv1.NodeRunning {
+			if node.IsActiveSuspendNode() {
 				var message string
 				if woc.workflowDeadline.IsZero() {
 					message = "terminated"

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -356,7 +356,7 @@ func ResumeWorkflow(wfIf v1alpha1.WorkflowInterface, workflowName string) error 
 		}
 		// To resume a workflow with a suspended node we simply mark the node as Successful
 		for nodeID, node := range wf.Status.Nodes {
-			if node.Type == wfv1.NodeTypeSuspend && node.Phase == wfv1.NodeRunning {
+			if node.IsActiveSuspendNode() {
 				node.Phase = wfv1.NodeSucceeded
 				node.FinishedAt = metav1.Time{Time: time.Now().UTC()}
 				wf.Status.Nodes[nodeID] = node
@@ -585,7 +585,7 @@ func IsWorkflowSuspended(wf *wfv1.Workflow) bool {
 		return true
 	}
 	for _, node := range wf.Status.Nodes {
-		if node.Type == wfv1.NodeTypeSuspend && node.Phase == wfv1.NodeRunning {
+		if node.IsActiveSuspendNode() {
 			return true
 		}
 	}


### PR DESCRIPTION
Here I chose a half-width character `ǁ` (U+01C1) for suspended nodes. I wanted to look for characters where the two bars are separated a bit more but couldn't find any. For its color, I chose cyan since the node is still a running node. Closes #1896.

By the way, could anyone please point me to the test files for commands? I don't see any in the repo.

Screenshot:
![Screenshot from 2020-02-14 22-21-44](https://user-images.githubusercontent.com/4591982/74540116-2f83e980-4f7a-11ea-9cb7-b76408f154c5.png)

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.
* [x] Optional. I've added My organization is added to the README.
* [x] I've signed the CLA and required builds are green. 
