### PR TITLE
fix: Removed duplicate Watch Command

### DIFF
--- a/cmd/argo/commands/root.go
+++ b/cmd/argo/commands/root.go
@@ -47,7 +47,6 @@ If you're using the Argo Server (e.g. because you need large workflow support or
 	command.AddCommand(NewSuspendCommand())
 	command.AddCommand(auth.NewAuthCommand())
 	command.AddCommand(NewWatchCommand())
-	command.AddCommand(NewWatchCommand())
 	command.AddCommand(NewTerminateCommand())
 	command.AddCommand(archive.NewArchiveCommand())
 	command.AddCommand(cmd.NewVersionCmd(CLIName))


### PR DESCRIPTION
CLI had watch command listed twice, fixed by removing duplicate command call.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.
* [ ] Optional. I've added My organization is added to the README.
* [ ] I've signed the CLA and required builds are green. 
