### PR TITLE
fix(ui): Removed tailLines from EventSource

### DIFF
--- a/ui/src/app/shared/services/workflows-service.ts
+++ b/ui/src/app/shared/services/workflows-service.ts
@@ -68,7 +68,7 @@ export class WorkflowsService {
         return requests
             .loadEventSource(
                 `api/v1/workflows/${workflow.metadata.namespace}/${workflow.metadata.name}/${nodeId}/log` +
-                    `?logOptions.container=${container}&logOptions.tailLines=20&logOptions.follow=true`
+                    `?logOptions.container=${container}&logOptions.follow=true`
             )
             .pipe(
                 map(line => JSON.parse(line).result.content),


### PR DESCRIPTION
Currently Argo UI is displaying just the last 20 logs when opening logs of a step, removing the tailLines=20 logOptions argument fixes this issue.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.
* [ ] Optional. I've added My organization is added to the README.
* [ ] I've signed the CLA and required builds are green. 
