### PR TITLE
fix: Always validate templates with different input parameters. Fixes #2313

### DIFF
--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -286,7 +286,7 @@ func (s *workflowServer) LintWorkflow(ctx context.Context, req *workflowpkg.Work
 
 	wftmplGetter := templateresolution.WrapWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().WorkflowTemplates(req.Namespace))
 
-	err := validate.ValidateWorkflow(wftmplGetter, req.Workflow, validate.ValidateOpts{})
+	err := validate.ValidateWorkflow(wftmplGetter, req.Workflow, validate.ValidateOpts{Lint: true})
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -327,6 +327,20 @@ func (s *CLISuite) TestWorkflowLint() {
 			}
 		})
 	})
+	s.Run("LintFileEmptyParamDAG", func() {
+		s.Given().RunCli([]string{"lint", "expectedfailures/empty-parameter-dag.yaml"}, func(t *testing.T, output string, err error) {
+			if assert.Error(t, err, "exit status 1") {
+				assert.Contains(t, output, "templates.abc.tasks.a templates.whalesay inputs.parameters.message was not supplied")
+			}
+		})
+	})
+	s.Run("LintFileEmptyParamSteps", func() {
+		s.Given().RunCli([]string{"lint", "expectedfailures/empty-parameter-steps.yaml"}, func(t *testing.T, output string, err error) {
+			if assert.Error(t, err, "exit status 1") {
+				assert.Contains(t, output, "templates.abc.steps[0].a templates.whalesay inputs.parameters.message was not supplied")
+			}
+		})
+	})
 	s.Run("LintFileWithTemplate", func() {
 		s.Given().
 			WorkflowTemplate("@smoke/workflow-template-whalesay-template.yaml").

--- a/test/e2e/expectedfailures/empty-parameter-dag.yaml
+++ b/test/e2e/expectedfailures/empty-parameter-dag.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: arguments-dag-
+spec:
+  entrypoint: abc
+  arguments:
+    parameters: []
+  templates:
+    - dag:
+        tasks:
+          - name: a
+            template: whalesay
+            arguments:
+              parameters:
+          - name: b
+            template: whalesay
+            arguments:
+              parameters:
+                - name: message
+                  value: "banana"
+      name: abc
+    - name: whalesay
+      inputs:
+        parameters:
+          - name: message
+      container:
+        image: cowsay:v1
+        command: [cowsay]
+        args: ["{{inputs.parameters.message}}"]

--- a/test/e2e/expectedfailures/empty-parameter-steps.yaml
+++ b/test/e2e/expectedfailures/empty-parameter-steps.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: arguments-steps-
+spec:
+  entrypoint: abc
+  arguments:
+    parameters: []
+  templates:
+    - steps:
+        - - name: a
+            template: whalesay
+            arguments:
+              parameters:
+        - - name: b
+            template: whalesay
+            arguments:
+              parameters:
+                - name: message
+                  value: "banana"
+      name: abc
+    - name: whalesay
+      inputs:
+        parameters:
+          - name: message
+      container:
+        image: cowsay:v1
+        command: [cowsay]
+        args: ["{{inputs.parameters.message}}"]

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -205,14 +205,6 @@ func ValidateCronWorkflow(wftmplGetter templateresolution.WorkflowTemplateNamesp
 }
 
 func (ctx *templateValidationCtx) validateTemplate(tmpl *wfv1.Template, tmplCtx *templateresolution.Context, args wfv1.ArgumentsProvider, extraScope map[string]interface{}) error {
-	tmplID := getTemplateID(tmpl)
-	_, ok := ctx.results[tmplID]
-	if ok {
-		// we already processed this template
-		return nil
-	}
-	ctx.results[tmplID] = true
-
 	if err := validateTemplateType(tmpl); err != nil {
 		return err
 	}
@@ -243,6 +235,15 @@ func (ctx *templateValidationCtx) validateTemplate(tmpl *wfv1.Template, tmplCtx 
 	if err != nil {
 		return errors.Errorf(errors.CodeBadRequest, "templates.%s %s", tmpl.Name, err)
 	}
+
+	tmplID := getTemplateID(tmpl)
+	_, ok := ctx.results[tmplID]
+	if ok {
+		// we can skip the rest since it has been validated.
+		return nil
+	}
+	ctx.results[tmplID] = true
+
 	for globalVar, val := range ctx.globalParams {
 		scope[globalVar] = val
 	}


### PR DESCRIPTION
Fixes #2313

The issue was introduced in #1744, where `ResolveTemplate()` in `context.go` does not call `ProcessArgs()` any more.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.
* [ ] Optional. I've added My organization is added to the README.
* [ ] I've signed the CLA and required builds are green. 
