### PR TITLE
fix: Simplify completion detection logic in DAGs

### DIFF
--- a/examples/template-on-exit.yaml
+++ b/examples/template-on-exit.yaml
@@ -9,7 +9,7 @@
 #   ├---✔ stepB (whalesay)                     container-on-exit-m6wq5-2803967195  5s
 #   └-✔ stepB.onExit (exitContainer)           container-on-exit-m6wq5-22494146    4s
 #
-# Template onExit containers work for all templates: DAG, Steps, Container, Script, Suspend, and Resource.
+# Template onExit containers work for DAG Tasks and Steps.
 
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -305,8 +305,7 @@ func (woc *wfOperationCtx) executeDAGTask(dagCtx *dagContext, taskName string) {
 	node := dagCtx.GetTaskNode(taskName)
 	task := dagCtx.getTask(taskName)
 	if node != nil && node.Completed() {
-		// Run the node's onExit node, if any. Only leaf nodes will have their onExit nodes executed here. Nodes that
-		// have dependencies will have their onExit nodes executed below
+		// Run the node's onExit node, if any.
 		hasOnExitNode, onExitNode, err := woc.runOnExitNode(task.Name, task.OnExit, dagCtx.boundaryID, dagCtx.tmplCtx)
 		if hasOnExitNode && (onExitNode == nil || !onExitNode.Completed() || err != nil) {
 			// The onExit node is either not complete or has errored out, return.


### PR DESCRIPTION
Currently we run onExit handlers from a dependent node. Simplify logic so that `onExit` handlers are run by their own respective nodes. This will simplify implementations of #1839 and #2254 