### PR TITLE
docs: Make Getting Started agnostic to version

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,56 +11,16 @@ the workflows. Here are the requirements and steps to run the workflows.
 
 ## 1. Download the Argo CLI
 
-### Mac
+Download the latest Argo CLI from our [releases page](https://github.com/argoproj/argo/releases).
 
-Available via `brew`
-```sh
-brew install argoproj/tap/argo
-```
-And via `curl`
-```sh
-# Download the binary
-curl -sLO https://github.com/argoproj/argo/releases/download/v2.6.0/argo-darwin-amd64
-
-# Make binary executable
-chmod +x argo-darwin-amd64
-
-# Move binary to path
-mv ./argo-darwin-amd64 /usr/local/bin/argo
-
-# Test installation
-argo version
-```
-
-### Linux
-
-Available via `curl`
-```sh
-# Download the binary
-curl -sLO https://github.com/argoproj/argo/releases/download/v2.6.0/argo-linux-amd64
-
-# Make binary executable
-chmod +x argo-linux-amd64
-
-# Move binary to path
-mv ./argo-linux-amd64 /usr/local/bin/argo
-
-# Test installation
-argo version
-```
-
-### Binaries
-
-You can download the latest and previous Argo binaries from our [releases page](https://github.com/argoproj/argo/releases/).
-
-## 2. Install the Controller and UI
+## 2. Install the Controller
 
 ```sh
 kubectl create namespace argo
-kubectl apply -n argo -f https://raw.githubusercontent.com/argoproj/argo/v2.6.0/manifests/install.yaml
+kubectl apply -n argo -f https://raw.githubusercontent.com/argoproj/argo/stable/manifests/install.yaml
 ```
 
-Namespaced installs as well as installs with MinIO and/or a database built in [are also available](https://github.com/argoproj/argo/tree/v2.6.0/manifests). 
+Namespaced installs as well as installs with MinIO and/or a database built in [are also available](https://github.com/argoproj/argo/tree/stable/manifests). 
 
 Examples below will assume you've installed argo in the `argo` namespace. If you have not, adjust 
 the commands accordingly.


### PR DESCRIPTION
We currently have specific version information in Getting Started, forcing us to update it with every release. Make Getting Started agnostic to versions by moving specific download instructions to each release and redirecting users there, as well as showing manifests with the `stable` tag as opposed to the specific version tag.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.
* [ ] Optional. I've added My organization is added to the README.
* [ ] I've signed the CLA and required builds are green. 
