### PR TITLE
fix(controller): Mount volumes defined in script templates. Closes #1722

### DIFF
--- a/test/e2e/smoke/artifact-passing.yaml
+++ b/test/e2e/smoke/artifact-passing.yaml
@@ -6,6 +6,8 @@ metadata:
     argo-e2e: true
 spec:
   entrypoint: artifact-example
+  volumes:
+    - name: test-volume
   templates:
     - name: artifact-example
       steps:
@@ -13,6 +15,12 @@ spec:
             template: generate-message
         - - name: consume-artifact
             template: print-message
+            arguments:
+              artifacts:
+                - name: message
+                  from: "{{steps.generate-artifact.outputs.artifacts.hello-art}}"
+          - name: consume-artifact-2
+            template: print-message-with-volume
             arguments:
               artifacts:
                 - name: message
@@ -39,3 +47,17 @@ spec:
         imagePullPolicy: IfNotPresent
         command: [sh, -c]
         args: ["cat /tmp/message"]
+
+    - name: print-message-with-volume
+      inputs:
+        artifacts:
+          - name: message
+            path: /test-volume/message
+      script:
+        volumeMounts:
+        - mountPath: /test-volume
+          name: test-volume
+        image: cowsay:v1
+        imagePullPolicy: IfNotPresent
+        command: [sh, -c]
+        args: ["cat /test-volume/message"]

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -732,12 +732,17 @@ func (woc *wfOperationCtx) addInputArtifactsVolumes(pod *apiv1.Pod, tmpl *wfv1.T
 			// We also add the user supplied mount paths to the init container,
 			// in case the executor needs to load artifacts to this volume
 			// instead of the artifacts volume
+			tmplVolumeMounts := []apiv1.VolumeMount{}
 			if tmpl.Container != nil {
-				for _, mnt := range tmpl.Container.VolumeMounts {
-					mnt.MountPath = filepath.Join(common.ExecutorMainFilesystemDir, mnt.MountPath)
-					initCtr.VolumeMounts = append(initCtr.VolumeMounts, mnt)
-				}
+				tmplVolumeMounts = tmpl.Container.VolumeMounts
+			} else if tmpl.Script != nil {
+				tmplVolumeMounts = tmpl.Script.Container.VolumeMounts
 			}
+			for _, mnt := range tmplVolumeMounts {
+				mnt.MountPath = filepath.Join(common.ExecutorMainFilesystemDir, mnt.MountPath)
+				initCtr.VolumeMounts = append(initCtr.VolumeMounts, mnt)
+			}
+
 			pod.Spec.InitContainers[i] = initCtr
 			break
 		}

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -82,6 +83,25 @@ script:
     ls -al
 `
 
+var scriptTemplateWithOptionalInputArtifactProvidedAndOverlappedPath = `
+name: script-with-input-artifact
+inputs:
+  artifacts:
+  - name: manifest
+    path: /manifest
+    optional: true
+    http:
+        url: https://raw.githubusercontent.com/argoproj/argo/stable/manifests/install.yaml
+script:
+  volumeMounts:
+  - mountPath: /manifest
+    name: my-mount
+  image: alpine:latest
+  command: [sh]
+  source: |
+    ls -al
+`
+
 var scriptTemplateWithOptionalInputArtifactNotProvided = `
 name: script-with-input-artifact
 inputs:
@@ -107,6 +127,24 @@ func TestScriptTemplateWithoutVolumeOptionalArtifact(t *testing.T) {
 		SubPathExpr:      "",
 	}
 
+	customVolumeMount := apiv1.VolumeMount{
+		Name:             "my-mount",
+		ReadOnly:         false,
+		MountPath:        "/manifest",
+		SubPath:          "",
+		MountPropagation: nil,
+		SubPathExpr:      "",
+	}
+
+	customVolumeMountForInit := apiv1.VolumeMount{
+		Name:             "my-mount",
+		ReadOnly:         false,
+		MountPath:        filepath.Join(common.ExecutorMainFilesystemDir, "/manifest"),
+		SubPath:          "",
+		MountPropagation: nil,
+		SubPathExpr:      "",
+	}
+
 	// Ensure that volume mount is added when artifact is provided
 	tmpl := unmarshalTemplate(scriptTemplateWithOptionalInputArtifactProvided)
 	woc := newWoc()
@@ -114,7 +152,24 @@ func TestScriptTemplateWithoutVolumeOptionalArtifact(t *testing.T) {
 	mainCtr.Args = append(mainCtr.Args, common.ExecutorScriptSourcePath)
 	pod, err := woc.createWorkflowPod(tmpl.Name, mainCtr, tmpl, true)
 	assert.NoError(t, err)
+	// Note: pod.Spec.Containers[0] is wait
 	assert.Contains(t, pod.Spec.Containers[1].VolumeMounts, volumeMount)
+	assert.NotContains(t, pod.Spec.Containers[1].VolumeMounts, customVolumeMount)
+	assert.NotContains(t, pod.Spec.InitContainers[0].VolumeMounts, customVolumeMountForInit)
+
+	// Ensure that volume mount is added to initContainer when artifact is provided
+	// and the volume is mounted manually in the template
+	tmpl = unmarshalTemplate(scriptTemplateWithOptionalInputArtifactProvidedAndOverlappedPath)
+	wf := unmarshalWF(helloWorldWf)
+	wf.Spec.Volumes = append(wf.Spec.Volumes, apiv1.Volume{Name: "my-mount"})
+	woc = newWoc(*wf)
+	mainCtr = tmpl.Script.Container
+	mainCtr.Args = append(mainCtr.Args, common.ExecutorScriptSourcePath)
+	pod, err = woc.createWorkflowPod(tmpl.Name, mainCtr, tmpl, true)
+	assert.NoError(t, err)
+	assert.NotContains(t, pod.Spec.Containers[1].VolumeMounts, volumeMount)
+	assert.Contains(t, pod.Spec.Containers[1].VolumeMounts, customVolumeMount)
+	assert.Contains(t, pod.Spec.InitContainers[0].VolumeMounts, customVolumeMountForInit)
 
 	// Ensure that volume mount is not created when artifact is not provided
 	tmpl = unmarshalTemplate(scriptTemplateWithOptionalInputArtifactNotProvided)


### PR DESCRIPTION
Description:

Closes #1722.

The controller has a behavior that when a template has an artifact whose path overlaps with any of the volumes to be mounted in this template, it will not load the artifact into the default artifact directory but to the volume to be mounted. It should mount the volume to the init container as well before doing so. However, when we check for volumes that should be mounted to the init container, we miss out volumes defined in script templates, and thus artifacts cannot be loaded properly only for this type of template. To be safe, I also checked other types of templates, and I think we've covered all cases, i.e., container templates and script templates.

Updated E2E to cover this case and tested manually with the following template (basically fetched from the issue):
```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: artifact-passing-
spec:
  entrypoint: artifact-example
  volumes:
    - name: aws
  templates:
  - name: artifact-example
    steps:
    - - name: generate-artifact
        template: execute

  - name: execute
    inputs:
      artifacts:
      - name: config
        path: /mnt/vol/.aws/config
        mode: 0777
        raw:
          data: |
            [profile default]
            role_arn = arn:abc
            credential_source = Ec2InstanceMetadata
    script:
      volumeMounts:
      - mountPath: /mnt/vol/.aws
        name: aws
      image: alpine:latest
      env:
      - name: AWS_DEFAULT_REGION
        value: us-west-2
      - name: AWS_CONFIG_FILE
        value: /mnt/vol/.aws/config
      command: [sh]
      source: |
        echo "Hello World"
```


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.
* [x] Optional. I've added My organization is added to the README.
* [x] I've signed the CLA and required builds are green. 
