### PR TITLE
fix (docs): change duration to a string

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -769,7 +769,7 @@ spec:
       limit: 10
       retryOn: "Always"
       backoff:
-        duration: 1         # Default unit is seconds. Could also be a Duration, e.g.: "2m", "6h", "1d"
+        duration: "1m"         # Default unit is seconds. Could also be a Duration, e.g.: "2m", "6h", "1d"
         factor: 2
         maxDuration: "1m"   # Default unit is seconds. Could also be a Duration, e.g.: "2m", "6h", "1d"
     container:


### PR DESCRIPTION
Running this example as written gives `json: cannot unmarshal number into Go struct field Backoff.workflow.spec.templates.retryStrategy.backoff.duration of type string`

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.
* [ ] Optional. I've added My organization is added to the README.
* [ ] I've signed the CLA and required builds are green. 
