### PR TITLE
fix: Don't display Retry Nodes in UI if len(children) == 1

### DIFF
--- a/ui/src/app/shared/services/workflows-service.ts
+++ b/ui/src/app/shared/services/workflows-service.ts
@@ -67,8 +67,7 @@ export class WorkflowsService {
         });
         return requests
             .loadEventSource(
-                `api/v1/workflows/${workflow.metadata.namespace}/${workflow.metadata.name}/${nodeId}/log` +
-                    `?logOptions.container=${container}&logOptions.follow=true`
+                `api/v1/workflows/${workflow.metadata.namespace}/${workflow.metadata.name}/${nodeId}/log` + `?logOptions.container=${container}&logOptions.follow=true`
             )
             .pipe(
                 map(line => JSON.parse(line).result.content),

--- a/ui/src/app/workflows/components/workflow-dag/workflow-dag.tsx
+++ b/ui/src/app/workflows/components/workflow-dag/workflow-dag.tsx
@@ -118,7 +118,7 @@ export class WorkflowDag extends React.Component<WorkflowDagProps> {
                                     'workflow-dag__node-status--' + (Utils.isNodeSuspended(node) ? 'suspended' : node.phase.toLocaleLowerCase()),
                                     {
                                         active: node.id === this.props.selectedNodeId,
-                                        virtual: this.isVirtual(node),
+                                        virtual: this.filterNode(node),
                                         small
                                     }
                                 )}
@@ -178,7 +178,7 @@ export class WorkflowDag extends React.Component<WorkflowDagProps> {
     }
 
     private isSmall(node: models.NodeStatus) {
-        return this.isVirtual(node) || (this.props.renderOptions.hideSucceeded && node.phase === NODE_PHASE.SUCCEEDED);
+        return this.filterNode(node) || (this.props.renderOptions.hideSucceeded && node.phase === NODE_PHASE.SUCCEEDED);
     }
 
     private getOutboundNodes(nodeID: string): string[] {
@@ -200,6 +200,11 @@ export class WorkflowDag extends React.Component<WorkflowDagProps> {
 
     private isVirtual(node: models.NodeStatus) {
         return (node.type === 'StepGroup' || node.type === 'DAG' || node.type === 'TaskGroup') && !!node.boundaryID;
+    }
+
+    private filterNode(node: models.NodeStatus) {
+        // Filter the node if it is a virtual node or a Retry node with one child
+        return this.isVirtual(node) || (node.type === 'Retry' && node.children.length === 1);
     }
 
     private getGraphSize(nodes: dagre.Node[]): {width: number; height: number} {


### PR DESCRIPTION
Fixes #2384. This new behavior reflects `argo watch` correctly.

Before:
<img width="352" alt="image" src="https://user-images.githubusercontent.com/614838/76166887-5c619180-611f-11ea-94fa-05978e015921.png">
After:
<img width="282" alt="image" src="https://user-images.githubusercontent.com/614838/76166892-68e5ea00-611f-11ea-915e-ee454d2282e0.png">


Behavior if `len(children) > 1` is conserved:
<img width="330" alt="image" src="https://user-images.githubusercontent.com/614838/76166900-7a2ef680-611f-11ea-8997-abf8a05ee01e.png">
