### PR TITLE
feat(ui): Use a monospace font family for yaml editors. Closes #2378

### DIFF
--- a/ui/src/app/shared/components/yaml/yaml.scss
+++ b/ui/src/app/shared/components/yaml/yaml.scss
@@ -3,7 +3,7 @@
 .yaml {
   margin: 10px;
   padding: 10px;
-  font: normal 13px/1.2 'Courier', sans-serif;
+  font: normal 13px/1.2 'Courier New', monospace;
   white-space: pre;
   color: $argo-color-gray-7;
   border-color: $argo-color-gray-2;;
@@ -11,4 +11,5 @@
   border-style: inset;
   overflow-y: scroll;
   width: 100%;
+  min-height: 300px;
 }

--- a/ui/src/app/workflows/components/workflow-yaml-viewer/workflow-yaml-viewer.scss
+++ b/ui/src/app/workflows/components/workflow-yaml-viewer/workflow-yaml-viewer.scss
@@ -1,7 +1,7 @@
 @import 'node_modules/argo-ui/src/styles/config';
 
 .workflow-yaml-viewer {
-  font: normal 13px/1.2 'Courier', sans-serif;
+  font: normal 13px/1.2 'Courier New', monospace;
   color: $argo-color-gray-7;
   overflow-y: scroll;
 


### PR DESCRIPTION
Closes #2378.

Also I updated the min-height of the editor. The default 50px was annoying.

Screenshot:
![image](https://user-images.githubusercontent.com/4591982/76200889-4e019b80-622d-11ea-9ae2-cb567baf2251.png)


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.
* [x] Optional. I've added My organization is added to the README.
* [x] I've signed the CLA and required builds are green. 
