### PR TITLE
fix(server): Update manifests to figure "Unable to retry workflow".

### DIFF
--- a/manifests/cluster-install/argo-server-rbac/argo-server-clusterole.yaml
+++ b/manifests/cluster-install/argo-server-rbac/argo-server-clusterole.yaml
@@ -27,6 +27,7 @@ rules:
       - get
       - list
       - watch
+      - delete
   - apiGroups:
       - ""
     resources:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -265,6 +265,7 @@ rules:
   - get
   - list
   - watch
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -186,6 +186,7 @@ rules:
   - get
   - list
   - watch
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/manifests/namespace-install/argo-server-rbac/argo-server-role.yaml
+++ b/manifests/namespace-install/argo-server-rbac/argo-server-role.yaml
@@ -27,6 +27,7 @@ rules:
       - get
       - list
       - watch
+      - delete
   - apiGroups:
       - ""
     resources:

--- a/manifests/quick-start-mysql.yaml
+++ b/manifests/quick-start-mysql.yaml
@@ -186,6 +186,7 @@ rules:
   - get
   - list
   - watch
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/manifests/quick-start-no-db.yaml
+++ b/manifests/quick-start-no-db.yaml
@@ -186,6 +186,7 @@ rules:
   - get
   - list
   - watch
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/manifests/quick-start-postgres.yaml
+++ b/manifests/quick-start-postgres.yaml
@@ -186,6 +186,7 @@ rules:
   - get
   - list
   - watch
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/test/e2e/manifests/mysql.yaml
+++ b/test/e2e/manifests/mysql.yaml
@@ -186,6 +186,7 @@ rules:
   - get
   - list
   - watch
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/test/e2e/manifests/no-db.yaml
+++ b/test/e2e/manifests/no-db.yaml
@@ -186,6 +186,7 @@ rules:
   - get
   - list
   - watch
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/test/e2e/manifests/postgres.yaml
+++ b/test/e2e/manifests/postgres.yaml
@@ -186,6 +186,7 @@ rules:
   - get
   - list
   - watch
+  - delete
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
Checklist:

* [x] this is a bug fix
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.
* [ ] Optional. I've added My organization is added to the USERS.md.
* [x] I've signed the CLA and required builds are green. 

When I use retry button in the argo-server, it will response:
```
{"error":"pods \"continue-on-fail-s6n6s-2335603486\" is forbidden: User \"system:serviceaccount:argo:argo-server\" cannot delete resource \"pods\" in API group \"\" in the namespace \"argo\"","code":2,"message":"pods \"continue-on-fail-s6n6s-2335603486\" is forbidden: User \"system:serviceaccount:argo:argo-server\" cannot delete resource \"pods\" in API group \"\" in the namespace \"argo\""}
```

I cannot understand why the argo-server will delete the pod. However, this PR will fix this problem.