### PR TITLE
docs: Update CONTRIBUTING.md with argo auth token command fix. 

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -44,7 +44,7 @@ You need the token to access the CLI or UI:
 
     eval $(make env)
 
-    ./dist/argo token
+    ./dist/argo auth token
 
 At this point you’ll have everything you need to use the CLI and UI.
 


### PR DESCRIPTION
The current suggested way to get the auth token for argo when deployed don't seam to work. This PR contains a fix where: 

```bash 
./dist/argo auth token
```
is suggested to replace 

```bash 
./dist/argo token
```
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.
* [ ] Optional. I've added My organization is added to the USERS.md.
* [x] I've signed the CLA and required builds are green. 