### PR TITLE
fix: Delete PVCs unless WF Failed/Errored

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1197,7 +1197,7 @@ func (woc *wfOperationCtx) createPVCs() error {
 }
 
 func (woc *wfOperationCtx) deletePVCs() error {
-	if woc.wf.Status.Phase != wfv1.NodeSucceeded {
+	if woc.wf.Status.Phase == wfv1.NodeError || woc.wf.Status.Phase == wfv1.NodeFailed {
 		// Skip deleting PVCs to reuse them for retried failed/error workflows.
 		// PVCs are automatically deleted when corresponded owner workflows get deleted.
 		return nil


### PR DESCRIPTION
Fixes: https://github.com/argoproj/argo/issues/2415

The check introduced in #1762 `woc.wf.Status.Phase != wfv1.NodeSucceeded` was insufficient because at that point in the operation, the workflow itself is not yet marked as succeeded. This lead to PVCs never being deleted. Switched the logic to `woc.wf.Status.Phase == wfv1.NodeError || woc.wf.Status.Phase == wfv1.NodeFailed ` to keep PVCs on Failure/Error explicitly.

Regardless, I believe this behavior should be an opt-in feature flag. Users should be able to use if they want their PVCs deleted regardless of status. @dtaniwaki Do you want to own implementing the feature flag behavior?