### PR TITLE
fix(example) make dir if needed

### DIFF
--- a/examples/artifact-path-placeholders.yaml
+++ b/examples/artifact-path-placeholders.yaml
@@ -37,4 +37,4 @@ spec:
         path: /outputs/text/data
     container:
       image: busybox
-      command: [sh, -c, 'head -n {{inputs.parameters.lines-count}} <"{{inputs.artifacts.text.path}}" | tee "{{outputs.artifacts.text.path}}" | wc -l > "{{outputs.parameters.actual-lines-count.path}}"']
+      command: [sh, -c, 'mkdir -p "$(dirname "{{outputs.artifacts.text.path}}")" "$(dirname "{{outputs.parameters.actual-lines-count.path}}")" ; head -n {{inputs.parameters.lines-count}} < "{{inputs.artifacts.text.path}}" | tee "{{outputs.artifacts.text.path}}" | wc -l > "{{outputs.parameters.actual-lines-count.path}}"']


### PR DESCRIPTION
Without this fix, the submission failed with

``` raw
sh: can't create /outputs/actual-lines-count/data: nonexistent directory
tee: /outputs/text/data: No such file or directory
```
