### PR TITLE
fix: ParallelSteps child type so replacements happen correctly

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -2250,7 +2250,7 @@
     "io.argoproj.workflow.v1alpha1.ParallelSteps": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/io.argoproj.io.argoproj.workflow.v1alpha1.v1alpha1.WorkflowStep"
+        "$ref": "#/definitions/io.argoproj.workflow.v1alpha1.WorkflowStep"
       }
     },
     "io.argoproj.workflow.v1alpha1.Parameter": {

--- a/pkg/apiclient/_.primary.swagger.json
+++ b/pkg/apiclient/_.primary.swagger.json
@@ -34,7 +34,7 @@
     "github.com.argoproj.argo.pkg.apis.workflow.v1alpha1.ParallelSteps": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/io.argoproj.workflow.v1alpha1.WorkflowStep"
+        "$ref": "#/definitions/github.com.argoproj.argo.pkg.apis.workflow.v1alpha1.WorkflowStep"
       }
     }
   }


### PR DESCRIPTION
I failed to double-check the ParallelSteps child type in swagger.json and thus caused this: argoproj-labs/argo-client-gen#5

Tested `make java` in argo-client-gen. Still get a build error, but a different one (I don't think openapi-generator/java knows how to deal with nested lists). I'll open another issue for that one.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.
* [x] Optional. I've added My organization is added to the USERS.md.
* [x] I've signed the CLA and required builds are green. 
