### PR TITLE
chore: Revert "feat: Add support for arm64 platform (#2364)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,14 +28,13 @@ WORKDIR /tmp
 # Install docker
 ENV DOCKER_CHANNEL stable
 ENV DOCKER_VERSION 18.09.1
-
-RUN wget -O docker.tgz https://download.docker.com/linux/static/${DOCKER_CHANNEL}/$(uname -m)/docker-${DOCKER_VERSION}.tgz && \
+RUN wget -O docker.tgz "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/x86_64/docker-${DOCKER_VERSION}.tgz" && \
     tar --extract --file docker.tgz --strip-components 1 --directory /usr/local/bin/ && \
     rm docker.tgz
 
 # Install dep
-ENV DEP_VERSION=0.5.1
-RUN wget https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-$(dpkg --print-architecture) -O /usr/local/bin/dep && \
+ENV DEP_VERSION=0.5.0
+RUN wget https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -O /usr/local/bin/dep && \
     chmod +x /usr/local/bin/dep
 
 ####################################################################################################
@@ -56,7 +55,7 @@ RUN apt-get update && \
         /usr/share/man \
         /usr/share/doc \
         /usr/share/doc-base && \
-    curl -L -o /usr/local/bin/kubectl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/$(dpkg --print-architecture)/kubectl && \
+    curl -L -o /usr/local/bin/kubectl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
     chmod +x /usr/local/bin/kubectl && \
     curl -L -o /usr/local/bin/jq -LO https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 && \
     chmod +x /usr/local/bin/jq
@@ -87,13 +86,13 @@ RUN mkdir -p ui/dist
 COPY --from=argo-ui dist/app ui/dist/app
 # stop make from trying to re-build this without yarn installed
 RUN touch ui/dist/app
-RUN make dist/argo-linux-$(dpkg --print-architecture) dist/workflow-controller-linux-$(dpkg --print-architecture) dist/argoexec-linux-$(dpkg --print-architecture)
+RUN make dist/argo-linux-amd64 dist/workflow-controller-linux-amd64 dist/argoexec-linux-amd64
 
 ####################################################################################################
 # argoexec
 ####################################################################################################
 FROM argoexec-base as argoexec
-COPY --from=argo-build /go/src/github.com/argoproj/argo/dist/argoexec-linux-* /usr/local/bin/argoexec
+COPY --from=argo-build /go/src/github.com/argoproj/argo/dist/argoexec-linux-amd64 /usr/local/bin/argoexec
 ENTRYPOINT [ "argoexec" ]
 
 ####################################################################################################
@@ -102,7 +101,7 @@ ENTRYPOINT [ "argoexec" ]
 FROM scratch as workflow-controller
 # Add timezone data
 COPY --from=argo-build /usr/share/zoneinfo /usr/share/zoneinfo
-COPY --from=argo-build /go/src/github.com/argoproj/argo/dist/workflow-controller-linux-* /bin/workflow-controller
+COPY --from=argo-build /go/src/github.com/argoproj/argo/dist/workflow-controller-linux-amd64 /bin/workflow-controller
 ENTRYPOINT [ "workflow-controller" ]
 
 ####################################################################################################
@@ -111,5 +110,5 @@ ENTRYPOINT [ "workflow-controller" ]
 FROM scratch as argocli
 COPY --from=argoexec-base /etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts
 COPY --from=argoexec-base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=argo-build /go/src/github.com/argoproj/argo/dist/argo-linux-* /bin/argo
+COPY --from=argo-build /go/src/github.com/argoproj/argo/dist/argo-linux-amd64 /bin/argo
 ENTRYPOINT [ "argo" ]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -28,13 +28,13 @@ WORKDIR /tmp
 # Install docker
 ENV DOCKER_CHANNEL stable
 ENV DOCKER_VERSION 18.09.1
-RUN wget -O docker.tgz https://download.docker.com/linux/static/${DOCKER_CHANNEL}/$(uname -m)/docker-${DOCKER_VERSION}.tgz && \
+RUN wget -O docker.tgz "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/x86_64/docker-${DOCKER_VERSION}.tgz" && \
     tar --extract --file docker.tgz --strip-components 1 --directory /usr/local/bin/ && \
     rm docker.tgz
 
 # Install dep
-ENV DEP_VERSION=0.5.1
-RUN wget https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-$(dpkg --print-architecture) -O /usr/local/bin/dep && \
+ENV DEP_VERSION=0.5.0
+RUN wget https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -O /usr/local/bin/dep && \
     chmod +x /usr/local/bin/dep
 
 ####################################################################################################
@@ -55,7 +55,7 @@ RUN apt-get update && \
         /usr/share/man \
         /usr/share/doc \
         /usr/share/doc-base && \
-    curl -L -o /usr/local/bin/kubectl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/$(dpkg --print-architecture)/kubectl && \
+    curl -L -o /usr/local/bin/kubectl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
     chmod +x /usr/local/bin/kubectl && \
     curl -L -o /usr/local/bin/jq -LO https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 && \
     chmod +x /usr/local/bin/jq

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,4 @@
 
-GOOS ?= $(shell go env GOOS)
-GOARCH ?= $(shell go env GOARCH)
-
 BUILD_DATE             = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 GIT_COMMIT             = $(shell git rev-parse HEAD)
 GIT_REMOTE             = origin
@@ -125,23 +122,28 @@ server/static/files.go: $(HOME)/go/bin/staticfiles ui/dist/app
 dist/argo: server/static/files.go $(CLI_PKGS)
 	go build -v -i -ldflags '${LDFLAGS}' -o dist/argo ./cmd/argo
 
-dist/argo-linux-amd64: GOARGS = GOOS=linux GOARCH=amd64
-dist/argo-darwin-amd64: GOARGS = GOOS=darwin GOARCH=amd64
-dist/argo-windows-amd64: GOARGS = GOOS=windows GOARCH=amd64
-dist/argo-linux-arm64: GOARGS = GOOS=linux GOARCH=arm64
-dist/argo-linux-ppc64le: GOARGS = GOOS=linux GOARCH=ppc64le
-dist/argo-linux-s390x: GOARGS = GOOS=linux GOARCH=s390x
+dist/argo-linux-amd64: server/static/files.go $(CLI_PKGS)
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -i -ldflags '${LDFLAGS}' -o dist/argo-linux-amd64 ./cmd/argo
 
-dist/argo-%: server/static/files.go $(CLI_PKGS)
-	CGO_ENABLED=0 $(GOARGS) go build -v -i -ldflags '${LDFLAGS}' -o $@ ./cmd/argo
+dist/argo-linux-ppc64le: server/static/files.go $(CLI_PKGS)
+	CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -v -i -ldflags '${LDFLAGS}' -o dist/argo-linux-ppc64le ./cmd/argo
+
+dist/argo-linux-s390x: server/static/files.go $(CLI_PKGS)
+	CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -v -i -ldflags '${LDFLAGS}' -o dist/argo-linux-s390x ./cmd/argo
+
+dist/argo-darwin-amd64: server/static/files.go $(CLI_PKGS)
+	CGO_ENABLED=0 GOOS=darwin go build -v -i -ldflags '${LDFLAGS}' -o dist/argo-darwin-amd64 ./cmd/argo
+
+dist/argo-windows-amd64: server/static/files.go $(CLI_PKGS)
+	CGO_ENABLED=0 GOARCH=amd64 GOOS=windows go build -v -i -ldflags '${LDFLAGS}' -o dist/argo-windows-amd64 ./cmd/argo
 
 .PHONY: cli-image
 cli-image: dist/cli-image
 
-dist/cli-image: dist/argo-$(GOOS)-$(GOARCH)
+dist/cli-image: dist/argo-linux-amd64
 	# Create CLI image
 ifeq ($(DEV_IMAGE),true)
-	cp dist/argo-$(GOOS)-$(GOARCH) argo
+	cp dist/argo-linux-amd64 argo
 	docker build -t $(IMAGE_NAMESPACE)/argocli:$(VERSION) --target argocli -f Dockerfile.dev .
 	rm -f argo
 else
@@ -153,23 +155,20 @@ ifeq ($(K3D),true)
 endif
 
 .PHONY: clis
-clis: dist/argo-linux-amd64 dist/argo-linux-arm64 dist/argo-linux-ppc64le dist/argo-linux-s390x dist/argo-darwin-amd64 dist/argo-windows-amd64 cli-image
+clis: dist/argo-linux-amd64 dist/argo-linux-ppc64le dist/argo-linux-s390x dist/argo-darwin-amd64 dist/argo-windows-amd64 cli-image
 
 # controller
 
-dist/workflow-controller-linux-amd64: GOARGS = GOOS=linux GOARCH=amd64
-dist/workflow-controller-linux-arm64: GOARGS = GOOS=linux GOARCH=arm64
-
-dist/workflow-controller-%: $(CONTROLLER_PKGS)
-	CGO_ENABLED=0 $(GOARGS) go build -v -i -ldflags '${LDFLAGS}' -o $@ ./cmd/workflow-controller
+dist/workflow-controller-linux-amd64: $(CONTROLLER_PKGS)
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -i -ldflags '${LDFLAGS}' -o dist/workflow-controller-linux-amd64 ./cmd/workflow-controller
 
 .PHONY: controller-image
 controller-image: dist/controller-image
 
-dist/controller-image: dist/workflow-controller-$(GOOS)-$(GOARCH)
+dist/controller-image: dist/workflow-controller-linux-amd64
 	# Create controller image
 ifeq ($(DEV_IMAGE),true)
-	cp dist/workflow-controller-$(GOOS)-$(GOARCH) workflow-controller
+	cp dist/workflow-controller-linux-amd64 workflow-controller
 	docker build -t $(IMAGE_NAMESPACE)/workflow-controller:$(VERSION) --target workflow-controller -f Dockerfile.dev .
 	rm -f workflow-controller
 else
@@ -182,19 +181,16 @@ endif
 
 # argoexec
 
-dist/argoexec-linux-amd64: GOARGS = GOOS=linux GOARCH=amd64
-dist/argoexec-linux-arm64: GOARGS = GOOS=linux GOARCH=arm64
-
-dist/argoexec-%: $(ARGOEXEC_PKGS)
-	CGO_ENABLED=0 $(GOARGS) go build -v -i -ldflags '${LDFLAGS}' -o $@ ./cmd/argoexec
+dist/argoexec-linux-amd64: $(ARGOEXEC_PKGS)
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -i -ldflags '${LDFLAGS}' -o dist/argoexec-linux-amd64 ./cmd/argoexec
 
 .PHONY: executor-image
 executor-image: dist/executor-image
 
-dist/executor-image: dist/argoexec-$(GOOS)-$(GOARCH)
+dist/executor-image: dist/argoexec-linux-amd64
 	# Create executor image
 ifeq ($(DEV_IMAGE),true)
-	cp dist/argoexec-$(GOOS)-$(GOARCH) argoexec
+	cp dist/argoexec-linux-amd64 argoexec
 	docker build -t $(IMAGE_NAMESPACE)/argoexec:$(VERSION) --target argoexec -f Dockerfile.dev .
 	rm -f argoexec
 else


### PR DESCRIPTION
This reverts commit c724c7c1afca646e09c0cb82acf8b59f8c413780. The commit breaks `workflow-controller` and `argo-server` with error:

```standard_init_linux.go:190: exec user process caused "exec format error"```

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.
* [ ] Optional. I've added My organization is added to the USERS.md.
* [ ] I've signed the CLA and required builds are green. 
