### PR TITLE
fix(cli): Rearrange the order of chunk size argument in list command. Closes #2420

### DIFF
--- a/cmd/argo/commands/list.go
+++ b/cmd/argo/commands/list.go
@@ -62,9 +62,6 @@ func NewListCommand() *cobra.Command {
 				labelSelector = labelSelector.Add(*req)
 			}
 			listOpts.LabelSelector = labelSelector.String()
-			if listArgs.chunkSize != 0 {
-				listOpts.Limit = listArgs.chunkSize
-			}
 
 			ctx, apiClient := client.NewAPIClient()
 			serviceClient := apiClient.NewWorkflowServiceClient()
@@ -116,6 +113,9 @@ func NewListCommand() *cobra.Command {
 				for _, wf := range tmpWorkFlowsSelected {
 					if wf.Status.FinishedAt.IsZero() || wf.ObjectMeta.CreationTimestamp.After(*minTime) {
 						workflows = append(workflows, wf)
+					}
+					if listArgs.chunkSize != 0 && int64(len(workflows)) == listArgs.chunkSize {
+						break
 					}
 				}
 			}

--- a/cmd/argo/commands/list.go
+++ b/cmd/argo/commands/list.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"sort"
 	"strings"
@@ -114,12 +115,14 @@ func NewListCommand() *cobra.Command {
 					if wf.Status.FinishedAt.IsZero() || wf.ObjectMeta.CreationTimestamp.After(*minTime) {
 						workflows = append(workflows, wf)
 					}
-					if listArgs.chunkSize != 0 && int64(len(workflows)) == listArgs.chunkSize {
-						break
-					}
 				}
 			}
 			sort.Sort(workflows)
+
+			if listArgs.chunkSize != 0 {
+				idx := int64(math.Min(float64(listArgs.chunkSize), float64(len(workflows))))
+				workflows = workflows[0:idx]
+			}
 
 			switch listArgs.output {
 			case "", "wide":

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -183,10 +184,23 @@ func (s *CLISuite) TestRoot() {
 		const rowCount = 1
 		for i := 0; i < rowCount*3; i++ {
 			s.Given().
-				Workflow(`@testdata/basic.yaml`).
+				Workflow("@smoke/basic-generate-name.yaml").
 				When().
 				SubmitWorkflow()
 		}
+		s.Given().RunCli([]string{"list"}, func(t *testing.T, output string, err error) {
+			if assert.NoError(t, err) {
+				assert.Contains(t, output, "NAME")
+				assert.Contains(t, output, "STATUS")
+				assert.Contains(t, output, "AGE")
+				assert.Contains(t, output, "DURATION")
+				assert.Contains(t, output, "PRIORITY")
+
+				// header + rowCount*3 workflows + empty line
+				assert.Equal(t, 5, len(strings.Split(output, "\n")))
+			}
+		})
+
 		s.Given().RunCli([]string{"list", "--chunk-size", "1"}, func(t *testing.T, output string, err error) {
 			if assert.NoError(t, err) {
 				assert.Contains(t, output, "NAME")
@@ -195,6 +209,8 @@ func (s *CLISuite) TestRoot() {
 				assert.Contains(t, output, "DURATION")
 				assert.Contains(t, output, "PRIORITY")
 
+				// header + 1 workflow + empty line
+				assert.Equal(t, 3, len(strings.Split(output, "\n")))
 			}
 		})
 	})

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -180,13 +180,21 @@ func (s *CLISuite) TestRoot() {
 		})
 	})
 	s.Run("List", func() {
-		s.Given().RunCli([]string{"list"}, func(t *testing.T, output string, err error) {
+		const rowCount = 1
+		for i := 0; i < rowCount*3; i++ {
+			s.Given().
+				Workflow(`@testdata/basic.yaml`).
+				When().
+				SubmitWorkflow()
+		}
+		s.Given().RunCli([]string{"list", "--chunk-size", "1"}, func(t *testing.T, output string, err error) {
 			if assert.NoError(t, err) {
 				assert.Contains(t, output, "NAME")
 				assert.Contains(t, output, "STATUS")
 				assert.Contains(t, output, "AGE")
 				assert.Contains(t, output, "DURATION")
 				assert.Contains(t, output, "PRIORITY")
+
 			}
 		})
 	})

--- a/test/e2e/smoke/basic-generate-name.yaml
+++ b/test/e2e/smoke/basic-generate-name.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: basic-
+  labels:
+    argo-e2e: true
+spec:
+  entrypoint: run-workflow
+  templates:
+    - name: run-workflow
+      container:
+        image: cowsay:v1
+        command: [cowsay, ":) Hello Argo!"]
+        imagePullPolicy: IfNotPresent


### PR DESCRIPTION
This PR ensures that the returned list of workflows has a max length of `chunkSize`. Previously we apply `chunkSize` before all the filtering such that the returned list may have fewer items than expected.

Closes #2420.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.
* [ ] Optional. I've added My organization is added to the USERS.md.
* [ ] I've signed the CLA and required builds are green. 
