### PR TITLE
fix: fix wrong assertions

### DIFF
--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -385,14 +385,14 @@ func (s *CLISuite) TestWorkflowLint() {
 	})
 	s.Run("LintFileEmptyParamDAG", func() {
 		s.Given().RunCli([]string{"lint", "expectedfailures/empty-parameter-dag.yaml"}, func(t *testing.T, output string, err error) {
-			if assert.Error(t, err, "exit status 1") {
+			if assert.EqualError(t, err, "exit status 1") {
 				assert.Contains(t, output, "templates.abc.tasks.a templates.whalesay inputs.parameters.message was not supplied")
 			}
 		})
 	})
 	s.Run("LintFileEmptyParamSteps", func() {
 		s.Given().RunCli([]string{"lint", "expectedfailures/empty-parameter-steps.yaml"}, func(t *testing.T, output string, err error) {
-			if assert.Error(t, err, "exit status 1") {
+			if assert.EqualError(t, err, "exit status 1") {
 				assert.Contains(t, output, "templates.abc.steps[0].a templates.whalesay inputs.parameters.message was not supplied")
 			}
 		})
@@ -514,7 +514,7 @@ func (s *CLISuite) TestTemplate() {
 	})
 	s.Run("Get", func() {
 		s.Given().RunCli([]string{"template", "get", "not-found"}, func(t *testing.T, output string, err error) {
-			if assert.Error(t, err, "exit status 1") {
+			if assert.EqualError(t, err, "exit status 1") {
 				assert.Contains(t, output, `"not-found" not found`)
 
 			}
@@ -625,7 +625,7 @@ func (s *CLISuite) TestCron() {
 	})
 	s.Run("Get", func() {
 		s.Given().RunCli([]string{"cron", "get", "not-found"}, func(t *testing.T, output string, err error) {
-			if assert.Error(t, err, "exit status 1") {
+			if assert.EqualError(t, err, "exit status 1") {
 				assert.Contains(t, output, `\"not-found\" not found`)
 
 			}

--- a/workflow/common/util_test.go
+++ b/workflow/common/util_test.go
@@ -66,5 +66,5 @@ spec:
 
 `
 	_, err = SplitWorkflowYAMLFile([]byte(invalidWf), false)
-	assert.Error(t, err, `unknown field "doesNotExist"`)
+	assert.EqualError(t, err, `error unmarshaling JSON: while decoding JSON: json: unknown field "doesNotExist"`)
 }


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.

bug fix

* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.
* [x] Optional. I've added My organization is added to the USERS.md.
* [x] I've signed the CLA and required builds are green. 


`assert.Error` doesn't check error messages while `assert.EqualError` does.