### PR TITLE
chore(docker): upgrade base image for executor image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN if [ "${IMAGE_OS}" = "linux" -a "${IMAGE_ARCH}" = "amd64" ]; then \
 # argoexec-base
 # Used as the base for both the release and development version of argoexec
 ####################################################################################################
-FROM debian:9.6-slim as argoexec-base
+FROM debian:10.3-slim as argoexec-base
 
 ARG IMAGE_OS=linux
 ARG IMAGE_ARCH=amd64

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -52,7 +52,7 @@ RUN if [ "${IMAGE_OS}" = "linux" -a "${IMAGE_ARCH}" = "amd64" ]; then \
 # argoexec-base
 # Used as the base for both the release and development version of argoexec
 ####################################################################################################
-FROM debian:9.6-slim as argoexec-base
+FROM debian:10.3-slim as argoexec-base
 
 ARG IMAGE_OS=linux
 ARG IMAGE_ARCH=amd64


### PR DESCRIPTION
This upgrades the executor base image from debian:9.6-slim to
debian:10.3-slim. This fixes a number of CVEs. As of today,
debian:9.6-slim has 10 high, 11 medium, and 60 low CVEs [1], while
debian:10.3-slim has 0 high, 4 medium, and 43 low CVEs [2].

1 - https://snyk.io/test/docker/debian%3A9.6-slim
2 - https://snyk.io/test/docker/debian%3A10.3-slim

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] ~~I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.~~
* [ ] ~~Optional. I've added My organization is added to the USERS.md.~~
* [x] I've signed the CLA and required builds are green. 
