### PR TITLE
fix: Use outputs of last child instead of retry node itslef

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1917,6 +1917,14 @@ func (woc *wfOperationCtx) executeScript(nodeName string, templateScope string, 
 // buildLocalScope adds all of a nodes outputs to the local scope with the given prefix, as well
 // as the global scope, if specified with a globalName
 func (woc *wfOperationCtx) buildLocalScope(scope *wfScope, prefix string, node *wfv1.NodeStatus) {
+	// It may be that the node is a retry node, in which case we want to get the outputs of the last node
+	// in the retry group instead of the retry node itself.
+	if node.Type == wfv1.NodeTypeRetry {
+		if lastNode, err := woc.getLastChildNode(node); err == nil {
+			node = lastNode
+		}
+	}
+
 	if node.PodIP != "" {
 		key := fmt.Sprintf("%s.ip", prefix)
 		scope.addParamToScope(key, node.PodIP)


### PR DESCRIPTION
Fixes #2560 

When using a retry node, we would add the outputs of the retry node instead of the last child to the scope. Changed to add the outputs of the last child node.

Wonder how this went undetected for so long.