### PR TITLE
style: Correct the confused logic in resource executor

### DIFF
--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -143,9 +143,10 @@ func (we *WorkflowExecutor) WaitResource(resourceNamespace string, resourceName 
 		} else {
 			log.Warnf("Waiting for resource %s resulted in error %v", resourceName, err)
 		}
+		return err
 	}
 
-	return err
+	return nil
 }
 
 func checkIfResourceDeleted(resourceName string, resourceNamespace string) bool {


### PR DESCRIPTION
It's correct but make people confuse.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.
* [ ] Optional. I've added My organization is added to the USERS.md.
* [ ] I've signed the CLA and required builds are green. 
