### PR TITLE
Updating the getting started docs to refer to argo-server instead of argo-ui. 

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -191,7 +191,7 @@ NOTE: artifact download and webconsole is not supported using this method
 ### Method 3: Expose a LoadBalancer
 Update the argo-ui service to be of type `LoadBalancer`.
 ```
-kubectl patch svc argo-ui -n argo -p '{"spec": {"type": "LoadBalancer"}}'
+kubectl patch svc argo-server -n argo -p '{"spec": {"type": "LoadBalancer"}}'
 ```
 Then wait for the external IP to be made available:
 ```


### PR DESCRIPTION
As I understand argo-ui is replaced by argo server. This is not updated in the getting started documents. In order to make the docs up to date I suggest we refer to the argo-server instead of the argo-ui. 

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.
* [ ] Optional. I've added My organization is added to the USERS.md.
* [ ] I've signed the CLA and required builds are green. 