### PR TITLE
fix(error handling): use Errorf instead of New when throwing errors with formatted text

### DIFF
--- a/workflow/common/serviceaccount.go
+++ b/workflow/common/serviceaccount.go
@@ -14,7 +14,7 @@ func GetServiceAccountTokenName(clientset kubernetes.Interface, namespace, name 
 		return "", err
 	}
 	if len(serviceAccount.Secrets) == 0 {
-		return "", errors.Errorf("Service account %s/%s does not have any token", serviceAccount.Namespace, serviceAccount.Name)
+		return "", errors.Errorf("", "Service account %s/%s does not have any token", serviceAccount.Namespace, serviceAccount.Name)
 	}
 	return serviceAccount.Secrets[0].Name, nil
 }

--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -100,7 +100,7 @@ func ContainerLogStream(config *rest.Config, namespace string, pod string, conta
 	case "http":
 		u.Scheme = "ws"
 	default:
-		return nil, errors.Errorf("Malformed URL %s", u.String())
+		return nil, errors.Errorf("", "Malformed URL %s", u.String())
 	}
 
 	log.Info(u.String())

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1202,7 +1202,7 @@ func (woc *wfOperationCtx) createPVCs() error {
 		}
 		pvc, err := pvcClient.Create(&pvcTmpl)
 		if err != nil && apierr.IsAlreadyExists(err) {
-			woc.log.Infof("%s pvc has already exists. Workflow is re-using it", pvcTmpl.Name)
+			woc.log.Infof("%s pvc already exists. Workflow is re-using it", pvcTmpl.Name)
 			pvc, err = pvcClient.Get(pvcTmpl.Name, metav1.GetOptions{})
 			if err != nil {
 				return err
@@ -1216,7 +1216,7 @@ func (woc *wfOperationCtx) createPVCs() error {
 				}
 			}
 			if !hasOwnerReference {
-				return errors.New(errors.CodeForbidden, "%s pvc has already exists with different ownerreference")
+				return errors.Errorf(errors.CodeForbidden, "%s pvc already exists with different ownerreference", pvcTmpl.Name)
 			}
 		}
 

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -129,7 +129,7 @@ func (we *WorkflowExecutor) LoadArtifacts() error {
 				log.Warnf("Ignoring optional artifact '%s' which was not supplied", art.Name)
 				continue
 			} else {
-				return errors.New("required artifact %s not supplied", art.Name)
+				return errors.Errorf("","required artifact %s not supplied", art.Name)
 			}
 		}
 		artDriver, err := we.InitDriver(&art)

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -129,7 +129,7 @@ func (we *WorkflowExecutor) LoadArtifacts() error {
 				log.Warnf("Ignoring optional artifact '%s' which was not supplied", art.Name)
 				continue
 			} else {
-				return errors.Errorf("","required artifact %s not supplied", art.Name)
+				return errors.Errorf("", "required artifact %s not supplied", art.Name)
 			}
 		}
 		artDriver, err := we.InitDriver(&art)


### PR DESCRIPTION
I got an error "%s pvc has already exists with different ownerreference" when trying to deploy my workflow and couldn't find out what PVC was causing the error, so I fixed the formatting of the error message. I also searched for other similar issues in the codebase and changed them too.
I wasn't sure if it would be correct to always return code `errors.CodeNotFound`, so I left them empty ("") for now.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.
* [ ] Optional. I've added My organization is added to the USERS.md.
* [x] I've signed the CLA and required builds are green. 
