### PR TITLE
fix: Fix WorkflowTemplate icons to be more cohesive

### DIFF
--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -48,12 +48,12 @@ const navItems = [
     {
         title: 'Workflow Templates',
         path: workflowTemplatesUrl,
-        iconClassName: 'fas fa-object-group'
+        iconClassName: 'fa fa-window-maximize'
     },
     {
         title: 'Cluster Workflow Templates',
         path: clusterWorkflowTemplatesUrl,
-        iconClassName: 'fa fa-clone'
+        iconClassName: 'fa fa-window-restore'
     },
     {
         title: 'Cron Workflows',


### PR DESCRIPTION
Before:
<img width="236" alt="image" src="https://user-images.githubusercontent.com/614838/78588584-bffcde80-77f3-11ea-8fd0-75cdb0d779ab.png">

After:
<img width="236" alt="image" src="https://user-images.githubusercontent.com/614838/78588617-cab77380-77f3-11ea-9114-b2fce192a1d7.png">

Top is WorkflowTemplate, bottom is ClusterWorkflowTemplate

