### PR TITLE
feat(UI): Improve Workflow Template Submission UX

### DIFF
--- a/ui/src/app/shared/components/resource-submit.tsx
+++ b/ui/src/app/shared/components/resource-submit.tsx
@@ -51,6 +51,15 @@ export class ResourceSubmit<T> extends React.Component<ResourceSubmitProps<T>, R
                                 ) : (
                                     <p />
                                 )}
+
+                                {/* Workflow-level parameters*/}
+                                {(this.props.resourceName === 'Workflow') &&
+                                formikApi.values.resource &&
+                                formikApi.values.resource.spec &&
+                                formikApi.values.resource.spec.arguments &&
+                                formikApi.values.resource.spec.arguments.parameters &&
+                                this.renderParameterFields('Workflow Parameters', 'resource.spec.arguments', formikApi.values.resource.spec.arguments.parameters, formikApi)}
+
                                 <button type='button' className='argo-button argo-button--sm' id='uploadWf' onClick={() => document.getElementById('file').click()}>
                                     Upload {this.props.resourceName}{' '}
                                 </button>
@@ -108,14 +117,6 @@ export class ResourceSubmit<T> extends React.Component<ResourceSubmitProps<T>, R
                                     onFocus={e => (e.currentTarget.style.height = e.currentTarget.scrollHeight + 'px')}
                                     autoFocus={true}
                                 />
-
-                                {/* Workflow-level parameters*/}
-                                {this.props.resourceName === 'Workflow' &&
-                                    formikApi.values.resource &&
-                                    formikApi.values.resource.spec &&
-                                    formikApi.values.resource.spec.arguments &&
-                                    formikApi.values.resource.spec.arguments.parameters &&
-                                    this.renderParameterFields('Workflow Parameters', 'resource.spec.arguments', formikApi.values.resource.spec.arguments.parameters, formikApi)}
                             </div>
                         </form>
                     )}
@@ -142,7 +143,7 @@ export class ResourceSubmit<T> extends React.Component<ResourceSubmitProps<T>, R
 
     private renderParameterFields(sectionTitle: string, path: string, parameters: models.Parameter[], formikApi: any): JSX.Element {
         return (
-            <div className='white-box__details' style={{paddingTop: '50px'}}>
+            <div className='white-box__details' style={{paddingTop: '10px'}}>
                 <h5>{sectionTitle}</h5>
                 {parameters.map((param: models.Parameter, index: number) => {
                     if (param != null) {

--- a/ui/src/app/workflow-templates/components/workflow-template-details/workflow-template-details.tsx
+++ b/ui/src/app/workflow-templates/components/workflow-template-details/workflow-template-details.tsx
@@ -127,6 +127,16 @@ export class WorkflowTemplateDetails extends BasePage<RouteComponentProps<any>, 
             });
     }
 
+    private templateDefaultParameters(template: models.Template) {
+        if (!!template.inputs && !!template.inputs.parameters) {
+            const parametersWithPlaceholder =
+                template.inputs.parameters.map(p => (p.value === undefined) ? {...p, value: '!!! NEEDS TO BE SET'} : p);
+            return {root: {parameters: parametersWithPlaceholder}};
+        } else {
+            return {};
+        }
+    }
+
     private getWorkflow(template: models.WorkflowTemplate): models.Workflow {
         return {
             metadata: {
@@ -136,12 +146,13 @@ export class WorkflowTemplateDetails extends BasePage<RouteComponentProps<any>, 
             spec: {
                 entrypoint: template.spec.templates[0].name,
                 templates: template.spec.templates.map(t => ({
-                    name: t.name,
-                    templateRef: {
-                        name: template.metadata.name,
-                        template: t.name
-                    }
-                }))
+                        name: t.name,
+                        templateRef: {
+                            name: template.metadata.name,
+                            template: t.name
+                        },
+                        ...this.templateDefaultParameters(t)
+                    }))
             }
         };
     }

--- a/ui/src/app/workflow-templates/components/workflow-template-details/workflow-template-details.tsx
+++ b/ui/src/app/workflow-templates/components/workflow-template-details/workflow-template-details.tsx
@@ -137,7 +137,7 @@ export class WorkflowTemplateDetails extends BasePage<RouteComponentProps<any>, 
         }
     }
 
-    private getWorkflow(template: models.WorkflowTemplate): models.Workflow {
+    private getWorkflowClassic(template: models.WorkflowTemplate): models.Workflow {
         return {
             metadata: {
                 generateName: template.metadata.name + '-',
@@ -155,5 +155,24 @@ export class WorkflowTemplateDetails extends BasePage<RouteComponentProps<any>, 
                     }))
             }
         };
+    }
+
+    private getWorkflowWithEntrypoint(template: models.WorkflowTemplate): models.Workflow {
+        return {
+            metadata: {
+                generateName: template.metadata.name + '-',
+                namespace: template.metadata.namespace
+            },
+            spec: template.spec
+        };
+    }
+
+    private getWorkflow(template: models.WorkflowTemplate): models.Workflow {
+        /* If a WorkflowTemplate has an entrypoint, we can treat it just like a regular Workflow */
+        if (!!template.spec.entrypoint) {
+            return this.getWorkflowWithEntrypoint(template)
+        } else {
+            return this.getWorkflowClassic(template);
+        }
     }
 }


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [X] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.
* [ ] Optional. I've added My organization is added to the USERS.md.
* [ ] I've signed the CLA and required builds are green. 

A client asked me today if it was possible to submit a stored workflow by simply giving input parameters in the UI. This PR addresses that use-case for both `WorkflowTemplates` without `entrypoint` (ie. all pre 2.7) and new regular `Workflows` that are stored as `WorkflowTemplates`.

### Workflow Templates without entrypoint
Test WorkflowTemplate:
```yaml
apiVersion: argoproj.io/v1alpha1
kind: WorkflowTemplate
metadata:
  name: test-template-classic
spec:
  templates:
  - name: whalesay
    inputs:
      parameters:
      - name: message
        value: Testing 123
      - name: name
    container:
      name: main
      image: 'docker/whalesay:latest'
      command:
      - cowsay
      args:
      - "{{inputs.parameters.message}} from {{inputs.parameters.name}}"
```

The submit panel now looks like:
![Screen Shot 2020-04-07 at 23 23 19](https://user-images.githubusercontent.com/192223/78741244-e0798580-7926-11ea-857e-3508f9282a1a.png)

Input parameters are retrieved for each template in the `WorkflowTemplate` and added to the generated submission template. A placeholder is placed in values for parameters without default values. This to make template submission easier, without needing to manually type out the correct syntax and indent in the YAML editor.

The existence of the`!!! NEEDS TO BE SET` placeholder can be debated. I added it because I find it easier to have it there and edit it then having the user type out `value:` and indent it to set it. The downside with having it is that if someone submits the workflow as is, the placeholder value will be submitted.

### Workflow Templates with Entrypoint
Test WorkflowTemplate:
```yaml
apiVersion: argoproj.io/v1alpha1
kind: WorkflowTemplate
metadata:
  name: test-template-entrypoint
spec:
  entrypoint: whalesay
  arguments:
    parameters:
      - name: message
        value: hello world
      - name: name
        value: Peter
  templates:
    - name: whalesay
      arguments: {}
      inputs:
        parameters:
          - name: message
          - name: name
      outputs: {}
      metadata: {}
      container:
        name: main
        image: 'docker/whalesay:latest'
        command:
          - cowsay
        args:
          - '{{inputs.parameters.message}} from {{inputs.parameters.name}}'
```

The submit panel now looks like:
![Screen Shot 2020-04-07 at 23 28 55](https://user-images.githubusercontent.com/192223/78741533-8f1dc600-7927-11ea-9bab-dd97d217ed09.png)

WorkflowTemplates that define an entrypoint can be treated as a regular Workflow. For classic WorkflowTemplates without entrypoint, a generator generates a Workflow spec that references the WorkflowTemplate in the WorkflowTemplate submit UI. This is however not necessary if the WorkflowTemplate defines an entrypoint, and by loading the WorkflowTemplate into the submission form directly the user can get access to the argument input fields.

The Workflow Parameters input boxes have also been moved to the top of the form. When uploading a workflow, or submitting a template, it is more likely that one just wants to submit the workflow by simply modifying parameter values. This also makes Workflow / WorkflowTemplate submissions less scary for users not familiar with the Workflow YAML itself, as they can simply focus on the top part of the screen and ignore the YAML edit box below.

A future improvement could include an option to hide the YAML editor completely from the UI, ie. where one wants to give access to the UI to people who are allowed to manage Workflow execution but not modify Workflows.

I am requesting input on the styling and paddings here, I think it could look a bit better.

I have not done anything with `ClusterWorkflowTemplates`. It seems as there is a lot of duplication between `ClusterWorkflowTemplateDetails` and `WorkflowTemplateDetails`. These should likely be refactored to be the same component. I am happy to copy my changes over to `ClusterWorkflowTemplateDetails ` or try to attack the refactor.

Each change is implemented in it's own atomic commit for easier review.