### PR TITLE
feat(UI): Move Workflow parameters to top of submit

### DIFF
--- a/ui/src/app/shared/components/resource-submit.tsx
+++ b/ui/src/app/shared/components/resource-submit.tsx
@@ -51,6 +51,15 @@ export class ResourceSubmit<T> extends React.Component<ResourceSubmitProps<T>, R
                                 ) : (
                                     <p />
                                 )}
+
+                                {/* Workflow-level parameters*/}
+                                {this.props.resourceName === 'Workflow' &&
+                                    formikApi.values.resource &&
+                                    formikApi.values.resource.spec &&
+                                    formikApi.values.resource.spec.arguments &&
+                                    formikApi.values.resource.spec.arguments.parameters &&
+                                    this.renderParameterFields('Workflow Parameters', 'resource.spec.arguments', formikApi.values.resource.spec.arguments.parameters, formikApi)}
+
                                 <button type='button' className='argo-button argo-button--sm' id='uploadWf' onClick={() => document.getElementById('file').click()}>
                                     Upload {this.props.resourceName}{' '}
                                 </button>
@@ -108,14 +117,6 @@ export class ResourceSubmit<T> extends React.Component<ResourceSubmitProps<T>, R
                                     onFocus={e => (e.currentTarget.style.height = e.currentTarget.scrollHeight + 'px')}
                                     autoFocus={true}
                                 />
-
-                                {/* Workflow-level parameters*/}
-                                {this.props.resourceName === 'Workflow' &&
-                                    formikApi.values.resource &&
-                                    formikApi.values.resource.spec &&
-                                    formikApi.values.resource.spec.arguments &&
-                                    formikApi.values.resource.spec.arguments.parameters &&
-                                    this.renderParameterFields('Workflow Parameters', 'resource.spec.arguments', formikApi.values.resource.spec.arguments.parameters, formikApi)}
                             </div>
                         </form>
                     )}
@@ -142,7 +143,7 @@ export class ResourceSubmit<T> extends React.Component<ResourceSubmitProps<T>, R
 
     private renderParameterFields(sectionTitle: string, path: string, parameters: models.Parameter[], formikApi: any): JSX.Element {
         return (
-            <div className='white-box__details' style={{paddingTop: '50px'}}>
+            <div className='white-box__details' style={{paddingTop: '10px'}}>
                 <h5>{sectionTitle}</h5>
                 {parameters.map((param: models.Parameter, index: number) => {
                     if (param != null) {


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [X] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlike to be merged.
* [x] Optional. I've added My organization is added to the USERS.md.
* [x] I've signed the CLA and required builds are green. 

When uploading a workflow, or submittint a template, it is more likely that one just wants to submit the workflow by simply modifying parameter values. This also makes Workflow / WorkflowTemplate submissisons less scary for users not familiar with the Worklow YAML itself, as they can simply focus on the top part of the screen and ignore the YAML edit box below.

A future improvement could include an option to hide the YAML editor completely from the UI, ie. where one wants to give access to the UI to people who are allowed to manage Workflow execution but not modify Workflows.

I am requesting input on the styling and paddings here, I think it could look a bit better.

![](https://user-images.githubusercontent.com/192223/78741533-8f1dc600-7927-11ea-9bab-dd97d217ed09.png)

This commit was broken out from https://github.com/argoproj/argo/pull/2635