### PR TITLE
chore: update running-locally.md - corrects protoc install command

### DIFF
--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -6,7 +6,7 @@
 * Yarn. `brew install yarn`
 * Docker
 * [Kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md)
-* [protoc](http://google.github.io/proto-lens/installing-protoc.html) `brew install protoc`
+* [protoc](http://google.github.io/proto-lens/installing-protoc.html) `brew install protobuf`
 * `jq`
 * [Swagger codegen](https://swagger.io/docs/open-source-tools/swagger-codegen/) `brew install swagger-codegen`
 * Kubernetes Cluster (we recommend Docker for Desktop + K3D, as this will allow you to test RBAC set-up, and is also fast)


### PR DESCRIPTION
According to the doc which is currently linked in - one is to install protoc via `brew install protobuf`, and not via `brew install protoc`.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to USERS.md.
