### PR TITLE
feat(manifests): add name on workflow-controller-metrics service port

### DIFF
--- a/manifests/base/workflow-controller/workflow-controller-metrics-service.yaml
+++ b/manifests/base/workflow-controller/workflow-controller-metrics-service.yaml
@@ -6,6 +6,7 @@ spec:
   selector:
     app: workflow-controller
   ports:
-    - port: 9090
+    - name: metrics
+      port: 9090
       targetPort: 9090
       protocol: TCP

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -371,7 +371,8 @@ metadata:
   name: workflow-controller-metrics
 spec:
   ports:
-  - port: 9090
+  - name: metrics
+    port: 9090
     protocol: TCP
     targetPort: 9090
   selector:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -269,7 +269,8 @@ metadata:
   name: workflow-controller-metrics
 spec:
   ports:
-  - port: 9090
+  - name: metrics
+    port: 9090
     protocol: TCP
     targetPort: 9090
   selector:

--- a/manifests/quick-start-mysql.yaml
+++ b/manifests/quick-start-mysql.yaml
@@ -451,7 +451,8 @@ metadata:
   name: workflow-controller-metrics
 spec:
   ports:
-  - port: 9090
+  - name: metrics
+    port: 9090
     protocol: TCP
     targetPort: 9090
   selector:

--- a/manifests/quick-start-no-db.yaml
+++ b/manifests/quick-start-no-db.yaml
@@ -409,7 +409,8 @@ metadata:
   name: workflow-controller-metrics
 spec:
   ports:
-  - port: 9090
+  - name: metrics
+    port: 9090
     protocol: TCP
     targetPort: 9090
   selector:

--- a/manifests/quick-start-postgres.yaml
+++ b/manifests/quick-start-postgres.yaml
@@ -451,7 +451,8 @@ metadata:
   name: workflow-controller-metrics
 spec:
   ports:
-  - port: 9090
+  - name: metrics
+    port: 9090
     protocol: TCP
     targetPort: 9090
   selector:


### PR DESCRIPTION
While adding a name is optional from a Kubernetes standpoint since there
is only one port listed, the named port makes using Prometheus easier.
There's a targetPort option for Prometheus' ServiceMonitor Custom
Resource, but this targetPort doesn't relate to the service's
targetPort, but in fact the containers' targetPort pointed at by the
service [1]. And since the workflow-controller deployment doesn't
actually explicitly list the ports the targetPort configuration on a
ServiceMonitor does nothing. So having the named port on the service's
port makes it much easier to use for Prometheus.

1 - https://github.com/coreos/prometheus-operator/issues/2515

I'm not actually sure how to use this service with Prometheus-operator without this named port. I considered this commit a feature, but might actually be a fix. Please let me know if it's preferred for me to use fix instead of feat for this.

Checklist:

* [ ] ~~Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.~~
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [ ] ~~I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.~~
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] ~~My organization is added to USERS.md.~~
