### PR TITLE
feat: add local variable pod.retryAttempt (see #2808, #2898)

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -33,6 +33,7 @@ The following variables are made available to reference various metadata of a wo
 | Variable | Description|
 |----------|------------|
 | `pod.name` | Pod name of the container/script |
+| `pod.retryAttempt` | The retry attempt number of the container/script if retryStrategy is specified |
 | `inputs.artifacts.<NAME>.path` | Local path of the input artifact |
 | `outputs.artifacts.<NAME>.path` | Local path of the output artifact |
 | `outputs.parameters.<NAME>.path` | Local path of the output parameter |

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -33,7 +33,7 @@ The following variables are made available to reference various metadata of a wo
 | Variable | Description|
 |----------|------------|
 | `pod.name` | Pod name of the container/script |
-| `pod.retryAttempt` | The retry attempt number of the container/script if retryStrategy is specified |
+| `retryAttempt` | The retry attempt number of the container/script if retryStrategy is specified |
 | `inputs.artifacts.<NAME>.path` | Local path of the input artifact |
 | `outputs.artifacts.<NAME>.path` | Local path of the output artifact |
 | `outputs.parameters.<NAME>.path` | Local path of the output parameter |

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -33,7 +33,7 @@ The following variables are made available to reference various metadata of a wo
 | Variable | Description|
 |----------|------------|
 | `pod.name` | Pod name of the container/script |
-| `retryAttempt` | The retry attempt number of the container/script if retryStrategy is specified |
+| `retries` | The retry number of the container/script if retryStrategy is specified |
 | `inputs.artifacts.<NAME>.path` | Local path of the input artifact |
 | `outputs.artifacts.<NAME>.path` | Local path of the output artifact |
 | `outputs.parameters.<NAME>.path` | Local path of the output parameter |

--- a/examples/retry-with-steps.yaml
+++ b/examples/retry-with-steps.yaml
@@ -21,4 +21,4 @@ spec:
       image: python:alpine3.6
       command: [python, -c]
       # fail with a 66% probability
-      args: ["import random; import sys; print('pod.retryAttempt: {{pod.retryAttempt}}'); exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]
+      args: ["import random; import sys; print('retryAttempt: {{retryAttempt}}'); exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]

--- a/examples/retry-with-steps.yaml
+++ b/examples/retry-with-steps.yaml
@@ -21,4 +21,4 @@ spec:
       image: python:alpine3.6
       command: [python, -c]
       # fail with a 66% probability
-      args: ["import random; import sys; exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]
+      args: ["import random; import sys; print('attempt: {{pod.retryAttempt}}'); exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]

--- a/examples/retry-with-steps.yaml
+++ b/examples/retry-with-steps.yaml
@@ -21,4 +21,4 @@ spec:
       image: python:alpine3.6
       command: [python, -c]
       # fail with a 66% probability
-      args: ["import random; import sys; print('attempt: {{pod.retryAttempt}}'); exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]
+      args: ["import random; import sys; print('pod.retryAttempt: {{pod.retryAttempt}}'); exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]

--- a/examples/retry-with-steps.yaml
+++ b/examples/retry-with-steps.yaml
@@ -21,4 +21,4 @@ spec:
       image: python:alpine3.6
       command: [python, -c]
       # fail with a 66% probability
-      args: ["import random; import sys; print('retryAttempt: {{retryAttempt}}'); exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]
+      args: ["import random; import sys; print('retries: {{retries}}'); exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -133,7 +133,7 @@ const (
 	// LocalVarPodName is a step level variable that references the name of the pod
 	LocalVarPodName = "pod.name"
 	// LocalVarPodRetryAttempt is a step level variable that references the retry attempt number if retryStrategy is specified
-	LocalVarPodRetryAttempt = "pod.retryAttempt"
+	LocalVarPodRetryAttempt = "retryAttempt"
 
 	KubeConfigDefaultMountPath    = "/kube/config"
 	KubeConfigDefaultVolumeName   = "kubeconfig"

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -132,6 +132,8 @@ const (
 	GlobalVarWorkflowParameters = "workflow.parameters"
 	// LocalVarPodName is a step level variable that references the name of the pod
 	LocalVarPodName = "pod.name"
+	// LocalVarPodRetryAttempt is a step level variable that references the retry attempt number if retryStrategy is specified
+	LocalVarPodRetryAttempt = "pod.retryAttempt"
 
 	KubeConfigDefaultMountPath    = "/kube/config"
 	KubeConfigDefaultVolumeName   = "kubeconfig"

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -132,8 +132,8 @@ const (
 	GlobalVarWorkflowParameters = "workflow.parameters"
 	// LocalVarPodName is a step level variable that references the name of the pod
 	LocalVarPodName = "pod.name"
-	// LocalVarRetryAttempt is a step level variable that references the retry attempt number if retryStrategy is specified
-	LocalVarRetryAttempt = "retryAttempt"
+	// LocalVarRetries is a step level variable that references the retries number if retryStrategy is specified
+	LocalVarRetries = "retries"
 
 	KubeConfigDefaultMountPath    = "/kube/config"
 	KubeConfigDefaultVolumeName   = "kubeconfig"

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -132,8 +132,8 @@ const (
 	GlobalVarWorkflowParameters = "workflow.parameters"
 	// LocalVarPodName is a step level variable that references the name of the pod
 	LocalVarPodName = "pod.name"
-	// LocalVarPodRetryAttempt is a step level variable that references the retry attempt number if retryStrategy is specified
-	LocalVarPodRetryAttempt = "retryAttempt"
+	// LocalVarRetryAttempt is a step level variable that references the retry attempt number if retryStrategy is specified
+	LocalVarRetryAttempt = "retryAttempt"
 
 	KubeConfigDefaultMountPath    = "/kube/config"
 	KubeConfigDefaultVolumeName   = "kubeconfig"

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1476,9 +1476,9 @@ func (woc *wfOperationCtx) executeTemplate(nodeName string, orgTmpl wfv1.Templat
 			if processedTmpl.IsPodType() {
 				localParams[common.LocalVarPodName] = woc.wf.NodeID(nodeName)
 			}
-			localParams[common.LocalVarPodRetryAttempt] = strconv.Itoa(len(retryParentNode.Children))
-
 			// Inject the retryAttempt number
+			localParams[common.LocalVarRetryAttempt] = strconv.Itoa(len(retryParentNode.Children))
+
 			processedTmpl, err = common.SubstituteParams(processedTmpl, map[string]string{}, localParams)
 			if err != nil {
 				return woc.initializeNodeOrMarkError(node, nodeName, wfv1.NodeTypeSkipped, templateScope, orgTmpl, opts.boundaryID, err), err

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1467,8 +1467,7 @@ func (woc *wfOperationCtx) executeTemplate(nodeName string, orgTmpl wfv1.Templat
 			node = lastChildNode
 		} else {
 			// Create a new child node and append it to the retry node.
-			childrenLength := strconv.Itoa(len(retryParentNode.Children))
-			nodeName = fmt.Sprintf("%s(%s)", retryNodeName, childrenLength)
+			nodeName = fmt.Sprintf("%s(%d)", retryNodeName, len(retryParentNode.Children))
 			woc.addChildNode(retryNodeName, nodeName)
 			node = nil
 
@@ -1477,8 +1476,9 @@ func (woc *wfOperationCtx) executeTemplate(nodeName string, orgTmpl wfv1.Templat
 			if processedTmpl.IsPodType() {
 				localParams[common.LocalVarPodName] = woc.wf.NodeID(nodeName)
 			}
+			localParams[common.LocalVarPodRetryAttempt] = strconv.Itoa(len(retryParentNode.Children))
+
 			// Inject the retryAttempt number
-			localParams[common.LocalVarPodRetryAttempt] = childrenLength
 			processedTmpl, err = common.SubstituteParams(processedTmpl, map[string]string{}, localParams)
 			if err != nil {
 				return woc.initializeNodeOrMarkError(node, nodeName, wfv1.NodeTypeSkipped, templateScope, orgTmpl, opts.boundaryID, err), err

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1467,8 +1467,8 @@ func (woc *wfOperationCtx) executeTemplate(nodeName string, orgTmpl wfv1.Templat
 			node = lastChildNode
 		} else {
 			// Create a new child node and append it to the retry node.
-			childrenLength := len(retryParentNode.Children)
-			nodeName = fmt.Sprintf("%s(%d)", retryNodeName, childrenLength)
+			childrenLength := strconv.Itoa(len(retryParentNode.Children))
+			nodeName = fmt.Sprintf("%s(%s)", retryNodeName, childrenLength)
 			woc.addChildNode(retryNodeName, nodeName)
 			node = nil
 
@@ -1478,7 +1478,7 @@ func (woc *wfOperationCtx) executeTemplate(nodeName string, orgTmpl wfv1.Templat
 				localParams[common.LocalVarPodName] = woc.wf.NodeID(nodeName)
 			}
 			// Inject the retryAttempt number
-			localParams[common.LocalVarPodRetryAttempt] = strconv.Itoa(childrenLength)
+			localParams[common.LocalVarPodRetryAttempt] = childrenLength
 			processedTmpl, err = common.SubstituteParams(processedTmpl, map[string]string{}, localParams)
 			if err != nil {
 				return woc.initializeNodeOrMarkError(node, nodeName, wfv1.NodeTypeSkipped, templateScope, orgTmpl, opts.boundaryID, err), err

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1477,7 +1477,7 @@ func (woc *wfOperationCtx) executeTemplate(nodeName string, orgTmpl wfv1.Templat
 				localParams[common.LocalVarPodName] = woc.wf.NodeID(nodeName)
 			}
 			// Inject the retryAttempt number
-			localParams[common.LocalVarRetryAttempt] = strconv.Itoa(len(retryParentNode.Children))
+			localParams[common.LocalVarRetries] = strconv.Itoa(len(retryParentNode.Children))
 
 			processedTmpl, err = common.SubstituteParams(processedTmpl, map[string]string{}, localParams)
 			if err != nil {

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -561,7 +561,7 @@ func TestBackoffMessage(t *testing.T) {
 	assert.Equal(t, "", newRetryNode.Message)
 }
 
-var retryAttemptVariableTemplate = `
+var retriesVariableTemplate = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
@@ -575,14 +575,14 @@ spec:
     container:
       image: docker/whalesay:latest
       command: [sh, -c]
-      args: ["cowsay {{retryAttempt}}"]
+      args: ["cowsay {{retries}}"]
 `
 
-func TestRetryAttemptVariable(t *testing.T) {
+func TestRetriesVariable(t *testing.T) {
 	cancel, controller := newController()
 	defer cancel()
 	wfcset := controller.wfclientset.ArgoprojV1alpha1().Workflows("")
-	wf := unmarshalWF(retryAttemptVariableTemplate)
+	wf := unmarshalWF(retriesVariableTemplate)
 	wf, err := wfcset.Create(wf)
 	assert.Nil(t, err)
 	wf, err = wfcset.Get(wf.ObjectMeta.Name, metav1.GetOptions{})
@@ -607,7 +607,7 @@ func TestRetryAttemptVariable(t *testing.T) {
 	}
 }
 
-var stepsRetryAttemptVariableTemplate = `
+var stepsRetriesVariableTemplate = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
@@ -622,25 +622,25 @@ spec:
       - - name: whalesay-success
           arguments:
             parameters:
-            - name: message
-              value: "{{retryAttempt}}"
+            - name: retries
+              value: "{{retries}}"
           template: whalesay
 
   - name: whalesay
     inputs:
       parameters:
-        - name: message
+        - name: retries
     container:
       image: docker/whalesay:latest
       command: [sh, -c]
-      args: ["cowsay {{inputs.parameters.message}}"]
+      args: ["cowsay {{inputs.parameters.retries}}"]
 `
 
-func TestStepsRetryAttemptVariable(t *testing.T) {
+func TestStepsRetriesVariable(t *testing.T) {
 	cancel, controller := newController()
 	defer cancel()
 	wfcset := controller.wfclientset.ArgoprojV1alpha1().Workflows("")
-	wf := unmarshalWF(stepsRetryAttemptVariableTemplate)
+	wf := unmarshalWF(stepsRetriesVariableTemplate)
 	wf, err := wfcset.Create(wf)
 	assert.Nil(t, err)
 	wf, err = wfcset.Get(wf.ObjectMeta.Name, metav1.GetOptions{})

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -561,6 +561,111 @@ func TestBackoffMessage(t *testing.T) {
 	assert.Equal(t, "", newRetryNode.Message)
 }
 
+var retryAttemptVariableTemplate = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: whalesay
+spec:
+  entrypoint: whalesay
+  templates:
+  - name: whalesay
+    retryStrategy:
+      limit: 10
+    container:
+      image: docker/whalesay:latest
+      command: [sh, -c]
+      args: ["cowsay {{pod.retryAttempt}}"]
+`
+
+func TestRetryAttemptVariable(t *testing.T) {
+	cancel, controller := newController()
+	defer cancel()
+	wfcset := controller.wfclientset.ArgoprojV1alpha1().Workflows("")
+	wf := unmarshalWF(retryAttemptVariableTemplate)
+	wf, err := wfcset.Create(wf)
+	assert.Nil(t, err)
+	wf, err = wfcset.Get(wf.ObjectMeta.Name, metav1.GetOptions{})
+	assert.Nil(t, err)
+
+	iterations := 10
+	for i := 1; i <= iterations; i++ {
+		if i != 1 {
+			makePodsPhase(t, apiv1.PodFailed, controller.kubeclientset, wf.ObjectMeta.Namespace)
+			wf, err = wfcset.Get(wf.ObjectMeta.Name, metav1.GetOptions{})
+			assert.Nil(t, err)
+		}
+		woc := newWorkflowOperationCtx(wf, controller)
+		woc.operate()
+	}
+
+	pods, err := controller.kubeclientset.CoreV1().Pods("").List(metav1.ListOptions{})
+	assert.Nil(t, err)
+	assert.Equal(t, iterations, len(pods.Items))
+	for i := 0; i < iterations; i++ {
+		assert.Equal(t, fmt.Sprintf("cowsay %d", i), pods.Items[i].Spec.Containers[1].Args[0])
+	}
+}
+
+var stepsRetryAttemptVariableTemplate = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: whalesay
+spec:
+  entrypoint: step-retry
+  templates:
+  - name: step-retry
+    retryStrategy:
+      limit: 10
+    steps:
+      - - name: whalesay-success
+          arguments:
+            parameters:
+            - name: message
+              value: "{{pod.retryAttempt}}"
+          template: whalesay
+
+  - name: whalesay
+    inputs:
+      parameters:
+        - name: message
+    container:
+      image: docker/whalesay:latest
+      command: [sh, -c]
+      args: ["cowsay {{inputs.parameters.message}}"]
+`
+
+func TestStepsRetryAttemptVariable(t *testing.T) {
+	cancel, controller := newController()
+	defer cancel()
+	wfcset := controller.wfclientset.ArgoprojV1alpha1().Workflows("")
+	wf := unmarshalWF(stepsRetryAttemptVariableTemplate)
+	wf, err := wfcset.Create(wf)
+	assert.Nil(t, err)
+	wf, err = wfcset.Get(wf.ObjectMeta.Name, metav1.GetOptions{})
+	assert.Nil(t, err)
+
+	iterations := 10
+	for i := 1; i <= iterations; i++ {
+		if i != 1 {
+			makePodsPhase(t, apiv1.PodFailed, controller.kubeclientset, wf.ObjectMeta.Namespace)
+			wf, err = wfcset.Get(wf.ObjectMeta.Name, metav1.GetOptions{})
+			assert.Nil(t, err)
+		}
+		// move to next retry step
+		woc := newWorkflowOperationCtx(wf, controller)
+		woc.operate()
+	}
+
+	pods, err := controller.kubeclientset.CoreV1().Pods("").List(metav1.ListOptions{})
+	assert.Nil(t, err)
+	assert.Equal(t, iterations, len(pods.Items))
+	for i := 0; i < iterations; i++ {
+		assert.Equal(t, fmt.Sprintf("cowsay %d", i), pods.Items[i].Spec.Containers[1].Args[0])
+	}
+}
+
 func TestAssessNodeStatus(t *testing.T) {
 	daemoned := true
 	tests := []struct {
@@ -2686,7 +2791,7 @@ metadata:
   name: artifact-repo-config-ref
 spec:
   entrypoint: whalesay
-  poddisruptionbudget: 
+  poddisruptionbudget:
     minavailable: 100%
   templates:
   - name: whalesay

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -575,7 +575,7 @@ spec:
     container:
       image: docker/whalesay:latest
       command: [sh, -c]
-      args: ["cowsay {{pod.retryAttempt}}"]
+      args: ["cowsay {{retryAttempt}}"]
 `
 
 func TestRetryAttemptVariable(t *testing.T) {
@@ -588,7 +588,7 @@ func TestRetryAttemptVariable(t *testing.T) {
 	wf, err = wfcset.Get(wf.ObjectMeta.Name, metav1.GetOptions{})
 	assert.Nil(t, err)
 
-	iterations := 10
+	iterations := 5
 	for i := 1; i <= iterations; i++ {
 		if i != 1 {
 			makePodsPhase(t, apiv1.PodFailed, controller.kubeclientset, wf.ObjectMeta.Namespace)
@@ -623,7 +623,7 @@ spec:
           arguments:
             parameters:
             - name: message
-              value: "{{pod.retryAttempt}}"
+              value: "{{retryAttempt}}"
           template: whalesay
 
   - name: whalesay
@@ -646,7 +646,7 @@ func TestStepsRetryAttemptVariable(t *testing.T) {
 	wf, err = wfcset.Get(wf.ObjectMeta.Name, metav1.GetOptions{})
 	assert.Nil(t, err)
 
-	iterations := 10
+	iterations := 5
 	for i := 1; i <= iterations; i++ {
 		if i != 1 {
 			makePodsPhase(t, apiv1.PodFailed, controller.kubeclientset, wf.ObjectMeta.Namespace)

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -319,8 +319,8 @@ func (ctx *templateValidationCtx) validateTemplate(tmpl *wfv1.Template, tmplCtx 
 		scope[common.LocalVarPodName] = placeholderGenerator.NextPlaceholder()
 	}
 	if tmpl.RetryStrategy != nil {
-		localParams[common.LocalVarRetryAttempt] = placeholderGenerator.NextPlaceholder()
-		scope[common.LocalVarRetryAttempt] = placeholderGenerator.NextPlaceholder()
+		localParams[common.LocalVarRetries] = placeholderGenerator.NextPlaceholder()
+		scope[common.LocalVarRetries] = placeholderGenerator.NextPlaceholder()
 	}
 	if tmpl.IsLeaf() {
 		for _, art := range tmpl.Outputs.Artifacts {

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -318,6 +318,10 @@ func (ctx *templateValidationCtx) validateTemplate(tmpl *wfv1.Template, tmplCtx 
 		localParams[common.LocalVarPodName] = placeholderGenerator.NextPlaceholder()
 		scope[common.LocalVarPodName] = placeholderGenerator.NextPlaceholder()
 	}
+	if tmpl.RetryStrategy != nil {
+		localParams[common.LocalVarPodRetryAttempt] = placeholderGenerator.NextPlaceholder()
+		scope[common.LocalVarPodRetryAttempt] = placeholderGenerator.NextPlaceholder()
+	}
 	if tmpl.IsLeaf() {
 		for _, art := range tmpl.Outputs.Artifacts {
 			if art.Path != "" {

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -319,8 +319,8 @@ func (ctx *templateValidationCtx) validateTemplate(tmpl *wfv1.Template, tmplCtx 
 		scope[common.LocalVarPodName] = placeholderGenerator.NextPlaceholder()
 	}
 	if tmpl.RetryStrategy != nil {
-		localParams[common.LocalVarPodRetryAttempt] = placeholderGenerator.NextPlaceholder()
-		scope[common.LocalVarPodRetryAttempt] = placeholderGenerator.NextPlaceholder()
+		localParams[common.LocalVarRetryAttempt] = placeholderGenerator.NextPlaceholder()
+		scope[common.LocalVarRetryAttempt] = placeholderGenerator.NextPlaceholder()
 	}
 	if tmpl.IsLeaf() {
 		for _, art := range tmpl.Outputs.Artifacts {


### PR DESCRIPTION
- add `pod.retryAttempt` that reports the retry attempt number starting at 0 for first attempt and increasing by 1 each attempt.
- only executes on nodes with `retryStrategy` defined.
- updated the `examples/retry-with-steps.yaml` to demonstrate usage.
- updated the `docs/variables.md` to describe variable.

See #2808 and #2898 for enhancement request.

Checklist:

* [x] Either (a) I've created an [enhancement proposal]
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to USERS.md. -- N/A
