### PR TITLE
feat(controller): Only invoke workflow reconciliation if there are "significant" changes to the pod.

### DIFF
--- a/workflow/controller/significant.go
+++ b/workflow/controller/significant.go
@@ -1,0 +1,60 @@
+package controller
+
+import apiv1 "k8s.io/api/core/v1"
+
+/*
+These are tho only fields that we ever look at significant in, some are immutable:
+metadata:
+  name*
+  namespace
+  labels: {}
+  annotations: {}
+  deletionTimestamp
+spec:
+  serviceAccountName
+  nodeName
+status:
+  phase
+  message
+  podIp
+  initContainerStatuses: []
+  containerStatuses: []
+  conditions: []
+*/
+func significantPodChange(from *apiv1.Pod, to *apiv1.Pod) bool {
+	return from.Spec.NodeName != to.Spec.NodeName ||
+		from.Status.Phase != to.Status.Phase ||
+		from.Status.Message != to.Status.Message ||
+		from.Status.PodIP != to.Status.PodIP ||
+		significantContainerStatusesChange(from.Status.ContainerStatuses, to.Status.ContainerStatuses) ||
+		significantContainerStatusesChange(from.Status.InitContainerStatuses, to.Status.InitContainerStatuses)
+}
+
+func significantContainerStatusesChange(from []apiv1.ContainerStatus, to []apiv1.ContainerStatus) bool {
+	if len(from) != len(to) {
+		return true
+	}
+	statuses := map[string]apiv1.ContainerStatus{}
+	for _, s := range from {
+		statuses[s.Name] = s
+	}
+	for _, s := range to {
+		if significantContainerStatusChange(statuses[s.Name], s) {
+			return true
+		}
+	}
+	return false
+}
+
+func significantContainerStatusChange(from apiv1.ContainerStatus, to apiv1.ContainerStatus) bool {
+	return from.Ready != to.Ready || significantContainerStateChange(from.State, to.State)
+}
+
+func significantContainerStateChange(from apiv1.ContainerState, to apiv1.ContainerState) bool {
+	// waiting has two significant fields and either could potentially change
+	return to.Waiting != nil && (from.Waiting == nil || from.Waiting.Message != to.Waiting.Message || from.Waiting.Reason != to.Waiting.Reason) ||
+		// running only has one field which is immutable -  so any change is significant
+		(to.Running != nil && from.Running == nil) ||
+		// I'm assuming this field is immutable - so any change is significant
+		(to.Terminated != nil && from.Terminated == nil)
+}

--- a/workflow/controller/significant_test.go
+++ b/workflow/controller/significant_test.go
@@ -1,0 +1,54 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Test_significantPodChange(t *testing.T) {
+	assert.False(t, significantPodChange(&corev1.Pod{}, &corev1.Pod{}), "No change")
+	t.Run("Spec", func(t *testing.T) {
+		assert.True(t, significantPodChange(&corev1.Pod{}, &corev1.Pod{Spec: corev1.PodSpec{NodeName: "from"}}), "Node name change")
+
+	})
+	t.Run("Status", func(t *testing.T) {
+		assert.True(t, significantPodChange(&corev1.Pod{}, &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodRunning}}), "Phase change")
+		assert.True(t, significantPodChange(&corev1.Pod{}, &corev1.Pod{Status: corev1.PodStatus{PodIP: "my-ip"}}), "Pod IP change")
+	})
+	t.Run("ContainerStatuses", func(t *testing.T) {
+		assert.True(t, significantPodChange(&corev1.Pod{}, &corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{}}}}), "Number of container status changes")
+		assert.True(t, significantPodChange(
+			&corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{}}}},
+			&corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{Ready: true}}}},
+		), "Ready of container status changes")
+		assert.True(t, significantPodChange(
+			&corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{}}}},
+			&corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{}}}}}},
+		), "Waiting of container status changes")
+		assert.True(t, significantPodChange(
+			&corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{}}}}}},
+			&corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "my-reason"}}}}}},
+		), "Waiting reason of container status changes")
+		assert.True(t, significantPodChange(
+			&corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{}}}}}},
+			&corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Message: "my-message"}}}}}},
+		), "Waiting message of container status changes")
+		assert.True(t, significantPodChange(
+			&corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{}}}}}},
+			&corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Message: "my-message"}}}}}},
+		), "Waiting message of container status changes")
+		assert.True(t, significantPodChange(
+			&corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{}}}},
+			&corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}}}},
+		), "Running container status changes")
+		assert.True(t, significantPodChange(
+			&corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{}}}},
+			&corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{}}}}}},
+		), "Terminate container status changes")
+	})
+	t.Run("InitContainerStatuses", func(t *testing.T) {
+		assert.True(t, significantPodChange(&corev1.Pod{}, &corev1.Pod{Status: corev1.PodStatus{InitContainerStatuses: []corev1.ContainerStatus{{}}}}), "Number of container status changes")
+	})
+}


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to USERS.md.

# Outcome

A 15% improvement when running `large-workflow`. This maybe much higher when running workflows with long running pods.

Fixes #2909 
