### PR TITLE
fix(examples): Error with unknown flag: --show-all

### DIFF
--- a/examples/k8s-orchestration.yaml
+++ b/examples/k8s-orchestration.yaml
@@ -69,7 +69,7 @@ spec:
       image: argoproj/argoexec:latest
       command: [sh, -c]
       args: ["
-        for i in `kubectl get pods -l controller-uid={{inputs.parameters.job-uid}} -o name --show-all`; do 
+        for i in `kubectl get pods -l controller-uid={{inputs.parameters.job-uid}} -o name`; do 
           kubectl logs $i;
         done
       "]


### PR DESCRIPTION
This is a bugfix for one of the examples `k8s-orchestration.yaml` where the `print-generated-numbers` pod has the error `Error: unknown flag: --show-all`

Checklist:

* [x] (b) this is a bug fix
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to USERS.md.
