### PR TITLE
fix: Consider Shutdown when assesing DAG Phase for incomplete Retry node

### DIFF
--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -277,6 +277,17 @@ const (
 	ShutdownStrategyStop      ShutdownStrategy = "Stop"
 )
 
+func (s ShutdownStrategy) ShouldExecute(isOnExitPod bool) bool {
+	switch s {
+	case ShutdownStrategyTerminate:
+		return false
+	case ShutdownStrategyStop:
+		return isOnExitPod
+	default:
+		return true
+	}
+}
+
 type ParallelSteps struct {
 	Steps []WorkflowStep `protobuf:"bytes,1,rep,name=steps"`
 }

--- a/pkg/apis/workflow/v1alpha1/workflow_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types_test.go
@@ -63,3 +63,10 @@ func TestWorkflowConditions_UpsertConditionMessage(t *testing.T) {
 	wfCond.UpsertConditionMessage(WorkflowCondition{Type: WorkflowConditionCompleted, Message: "world!"})
 	assert.Equal(t, "Hello, world!", wfCond[0].Message)
 }
+
+func TestShutdownStrategy_ShouldExecute(t *testing.T) {
+	assert.False(t, ShutdownStrategyTerminate.ShouldExecute(true))
+	assert.False(t, ShutdownStrategyTerminate.ShouldExecute(false))
+	assert.False(t, ShutdownStrategyStop.ShouldExecute(false))
+	assert.True(t, ShutdownStrategyStop.ShouldExecute(true))
+}

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -138,7 +138,9 @@ func (d *dagContext) assessDAGPhase(targetTasks []string, nodes map[string]wfv1.
 		if unsuccessfulPhase == "" && !(isRetryAttempt(node, nodes) || d.getTaskFromNode(&node).ContinuesOn(node.Phase)) {
 			unsuccessfulPhase = node.Phase
 		}
-		if node.Type == wfv1.NodeTypeRetry && d.hasMoreRetries(&node) {
+		// If the node is a Retry node and has more retry attempts and is not shutting down, do not fail the task as a whole
+		// and allow the remaining retries to be executed
+		if node.Type == wfv1.NodeTypeRetry && d.hasMoreRetries(&node) && d.wf.Spec.Shutdown.ShouldExecute(d.onExitTemplate) {
 			retriesExhausted = false
 		}
 	}

--- a/workflow/controller/dag_test.go
+++ b/workflow/controller/dag_test.go
@@ -653,3 +653,240 @@ func TestDAGWithParamAndGlobalParam(t *testing.T) {
 	woc.operate()
 	assert.Equal(t, wfv1.NodeRunning, woc.wf.Status.Phase)
 }
+
+var terminatingDAGWithRetryStrategyNodes = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: dag-diamond-xfww2
+spec:
+  arguments: {}
+  entrypoint: diamond
+  shutdown: Terminate
+  templates:
+  - arguments: {}
+    dag:
+      tasks:
+      - arguments: {}
+        name: A
+        template: echo
+      - arguments: {}
+        dependencies:
+        - A
+        name: B
+        template: echo
+      - arguments: {}
+        dependencies:
+        - A
+        name: C
+        template: echo
+      - arguments: {}
+        dependencies:
+        - B
+        - C
+        name: D
+        template: echo
+    inputs: {}
+    metadata: {}
+    name: diamond
+    outputs: {}
+  - arguments: {}
+    container:
+      args:
+      - sleep 10
+      command:
+      - sh
+      - -c
+      image: alpine:3.7
+      name: ""
+      resources: {}
+    inputs: {}
+    metadata: {}
+    name: echo
+    outputs: {}
+    retryStrategy:
+      limit: 4
+status:
+  finishedAt: null
+  nodes:
+    dag-diamond-xfww2:
+      children:
+      - dag-diamond-xfww2-1488588956
+      displayName: dag-diamond-xfww2
+      finishedAt: null
+      id: dag-diamond-xfww2
+      name: dag-diamond-xfww2
+      phase: Running
+      startedAt: "2020-05-06T16:15:38Z"
+      templateName: diamond
+      templateScope: local/dag-diamond-xfww2
+      type: DAG
+    dag-diamond-xfww2-990947287:
+      boundaryID: dag-diamond-xfww2
+      children:
+      - dag-diamond-xfww2-1522144194
+      - dag-diamond-xfww2-1538921813
+      displayName: A(0)
+      finishedAt: "2020-05-06T16:15:50Z"
+      hostNodeName: minikube
+      id: dag-diamond-xfww2-990947287
+      name: dag-diamond-xfww2.A(0)
+      outputs:
+        artifacts:
+        - archiveLogs: true
+          name: main-logs
+          s3:
+            accessKeySecret:
+              key: accesskey
+              name: my-minio-cred
+            bucket: my-bucket
+            endpoint: minio:9000
+            insecure: true
+            key: dag-diamond-xfww2/dag-diamond-xfww2-990947287/main.log
+            secretKeySecret:
+              key: secretkey
+              name: my-minio-cred
+      phase: Succeeded
+      resourcesDuration:
+        cpu: 21
+        memory: 0
+      startedAt: "2020-05-06T16:15:38Z"
+      templateName: echo
+      templateScope: local/dag-diamond-xfww2
+      type: Pod
+    dag-diamond-xfww2-1488588956:
+      boundaryID: dag-diamond-xfww2
+      children:
+      - dag-diamond-xfww2-990947287
+      displayName: A
+      finishedAt: "2020-05-06T16:15:51Z"
+      id: dag-diamond-xfww2-1488588956
+      name: dag-diamond-xfww2.A
+      outputs:
+        artifacts:
+        - archiveLogs: true
+          name: main-logs
+          s3:
+            accessKeySecret:
+              key: accesskey
+              name: my-minio-cred
+            bucket: my-bucket
+            endpoint: minio:9000
+            insecure: true
+            key: dag-diamond-xfww2/dag-diamond-xfww2-990947287/main.log
+            secretKeySecret:
+              key: secretkey
+              name: my-minio-cred
+      phase: Succeeded
+      startedAt: "2020-05-06T16:15:38Z"
+      templateName: echo
+      templateScope: local/dag-diamond-xfww2
+      type: Retry
+    dag-diamond-xfww2-1522144194:
+      boundaryID: dag-diamond-xfww2
+      children:
+      - dag-diamond-xfww2-2043927737
+      displayName: C
+      finishedAt: "2020-05-06T16:15:59Z"
+      id: dag-diamond-xfww2-1522144194
+      message: Stopped with strategy 'Terminate'
+      name: dag-diamond-xfww2.C
+      phase: Failed
+      startedAt: "2020-05-06T16:15:51Z"
+      templateName: echo
+      templateScope: local/dag-diamond-xfww2
+      type: Retry
+    dag-diamond-xfww2-1538921813:
+      boundaryID: dag-diamond-xfww2
+      children:
+      - dag-diamond-xfww2-3629114292
+      displayName: B
+      finishedAt: "2020-05-06T16:15:59Z"
+      id: dag-diamond-xfww2-1538921813
+      message: Stopped with strategy 'Terminate'
+      name: dag-diamond-xfww2.B
+      phase: Failed
+      startedAt: "2020-05-06T16:15:52Z"
+      templateName: echo
+      templateScope: local/dag-diamond-xfww2
+      type: Retry
+    dag-diamond-xfww2-2043927737:
+      boundaryID: dag-diamond-xfww2
+      displayName: C(0)
+      finishedAt: "2020-05-06T16:15:58Z"
+      hostNodeName: minikube
+      id: dag-diamond-xfww2-2043927737
+      message: terminated
+      name: dag-diamond-xfww2.C(0)
+      outputs:
+        artifacts:
+        - archiveLogs: true
+          name: main-logs
+          s3:
+            accessKeySecret:
+              key: accesskey
+              name: my-minio-cred
+            bucket: my-bucket
+            endpoint: minio:9000
+            insecure: true
+            key: dag-diamond-xfww2/dag-diamond-xfww2-2043927737/main.log
+            secretKeySecret:
+              key: secretkey
+              name: my-minio-cred
+      phase: Failed
+      resourcesDuration:
+        cpu: 11
+        memory: 0
+      startedAt: "2020-05-06T16:15:51Z"
+      templateName: echo
+      templateScope: local/dag-diamond-xfww2
+      type: Pod
+    dag-diamond-xfww2-3629114292:
+      boundaryID: dag-diamond-xfww2
+      displayName: B(0)
+      finishedAt: "2020-05-06T16:15:58Z"
+      hostNodeName: minikube
+      id: dag-diamond-xfww2-3629114292
+      message: terminated
+      name: dag-diamond-xfww2.B(0)
+      outputs:
+        artifacts:
+        - archiveLogs: true
+          name: main-logs
+          s3:
+            accessKeySecret:
+              key: accesskey
+              name: my-minio-cred
+            bucket: my-bucket
+            endpoint: minio:9000
+            insecure: true
+            key: dag-diamond-xfww2/dag-diamond-xfww2-3629114292/main.log
+            secretKeySecret:
+              key: secretkey
+              name: my-minio-cred
+      phase: Failed
+      resourcesDuration:
+        cpu: 9
+        memory: 0
+      startedAt: "2020-05-06T16:15:52Z"
+      templateName: echo
+      templateScope: local/dag-diamond-xfww2
+      type: Pod
+  phase: Running
+  startedAt: "2020-05-06T16:15:38Z"
+`
+
+// This tests that a DAG with retry strategy in its tasks fails successfully when terminated
+func TestTerminatingDAGWithRetryStrategyNodes(t *testing.T) {
+	cancel, controller := newController()
+	defer cancel()
+	wfcset := controller.wfclientset.ArgoprojV1alpha1().Workflows("")
+
+	wf := unmarshalWF(terminatingDAGWithRetryStrategyNodes)
+	wf, err := wfcset.Create(wf)
+	assert.NoError(t, err)
+	woc := newWorkflowOperationCtx(wf, controller)
+
+	woc.operate()
+	assert.Equal(t, wfv1.NodeFailed, woc.wf.Status.Phase)
+}

--- a/workflow/controller/exec_control.go
+++ b/workflow/controller/exec_control.go
@@ -29,7 +29,7 @@ func (woc *wfOperationCtx) applyExecutionControl(pod *apiv1.Pod, wfNodesLock *sy
 		if woc.wf.Spec.Shutdown != "" {
 			// Only delete pods that are not part of an onExit handler if we are "Stopping" or all pods if we are "Terminating"
 			_, onExitPod := pod.Labels[common.LabelKeyOnExit]
-			if woc.wf.Spec.Shutdown == wfv1.ShutdownStrategyTerminate || (woc.wf.Spec.Shutdown == wfv1.ShutdownStrategyStop && !onExitPod) {
+			if !woc.wf.Spec.Shutdown.ShouldExecute(onExitPod) {
 				woc.log.Infof("Deleting Pending pod %s/%s as part of workflow shutdown with strategy: %s", pod.Namespace, pod.Name, woc.wf.Spec.Shutdown)
 				err := woc.controller.kubeclientset.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{})
 				if err == nil {


### PR DESCRIPTION
Fixes #2956 

Issue was that a DAG would not be marked as failed until all of its retries got exhausted. However, if a Workflow is Shutdown before this happens, the DAG would be classified as Running indefinitely.

This fix only allows a DAG to be marked as running before all of its retries got exhausted if its nodes would execute under the current (or lack of) ShutdownStrategy.