### PR TITLE
fix: Begin counting maxDuration from first child start

### DIFF
--- a/workflow/controller/exec_control.go
+++ b/workflow/controller/exec_control.go
@@ -75,7 +75,7 @@ func (woc *wfOperationCtx) applyExecutionControl(pod *apiv1.Pod, wfNodesLock *sy
 	var newDeadline *time.Time
 	if woc.wf.Spec.Shutdown != "" {
 		_, onExitPod := pod.Labels[common.LabelKeyOnExit]
-		if woc.wf.Spec.Shutdown == wfv1.ShutdownStrategyTerminate || (woc.wf.Spec.Shutdown == wfv1.ShutdownStrategyStop && !onExitPod) {
+		if !woc.wf.Spec.Shutdown.ShouldExecute(onExitPod) {
 			newDeadline = &time.Time{}
 		}
 	} else {

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -647,6 +647,7 @@ func (woc *wfOperationCtx) processNodeRetries(node *wfv1.NodeStatus, retryStrate
 		return woc.markNodePhase(node.Name, lastChildNode.Phase, message), true, nil
 	}
 
+	maxDurationDeadline := time.Time{}
 	if retryStrategy.Backoff != nil {
 		// Process max duration limit
 		if retryStrategy.Backoff.MaxDuration != "" && len(node.Children) > 0 {
@@ -658,7 +659,8 @@ func (woc *wfOperationCtx) processNodeRetries(node *wfv1.NodeStatus, retryStrate
 			if err != nil {
 				return nil, false, fmt.Errorf("Failed to find first child of node " + node.Name)
 			}
-			if time.Now().After(firstChildNode.FinishedAt.Add(maxDuration)) {
+			maxDurationDeadline = firstChildNode.StartedAt.Add(maxDuration)
+			if time.Now().After(maxDurationDeadline) {
 				woc.log.Infoln("Max duration limit exceeded. Failing...")
 				return woc.markNodePhase(node.Name, lastChildNode.Phase, "Max duration limit exceeded"), true, nil
 			}
@@ -668,6 +670,7 @@ func (woc *wfOperationCtx) processNodeRetries(node *wfv1.NodeStatus, retryStrate
 		if retryStrategy.Backoff.Duration == "" {
 			return nil, false, fmt.Errorf("no base duration specified for retryStrategy")
 		}
+
 		baseDuration, err := parseStringToDuration(retryStrategy.Backoff.Duration)
 		if err != nil {
 			return nil, false, err
@@ -679,6 +682,12 @@ func (woc *wfOperationCtx) processNodeRetries(node *wfv1.NodeStatus, retryStrate
 			timeToWait = baseDuration * time.Duration(math.Pow(float64(retryStrategy.Backoff.Factor), float64(len(node.Children))))
 		}
 		waitingDeadline := lastChildNode.FinishedAt.Add(timeToWait)
+
+		// If the waiting deadline is after the max duration deadline, then it's futile to wait until then. Stop early
+		if !maxDurationDeadline.IsZero() && waitingDeadline.After(maxDurationDeadline) {
+			woc.log.Infoln("Backoff would exceed max duration limit. Failing...")
+			return woc.markNodePhase(node.Name, lastChildNode.Phase, "Backoff would exceed max duration limit"), true, nil
+		}
 
 		// See if we have waited past the deadline
 		if time.Now().Before(waitingDeadline) {

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -3268,6 +3268,12 @@ status:
 // proper finishedTime tag.
 func TestMaxDurationOnErroredFirstNode(t *testing.T) {
 	wf := unmarshalWF(maxDurationOnErroredFirstNode)
+
+	// Simulate node failed just now
+	node := wf.Status.Nodes["echo-wngc4-1641470511"]
+	node.StartedAt = metav1.Time{Time: time.Now().Add(-1 * time.Second)}
+	wf.Status.Nodes["echo-wngc4-1641470511"] = node
+
 	woc := newWoc(*wf)
 	woc.operate()
 	assert.Equal(t, wfv1.NodeRunning, woc.wf.Status.Phase)


### PR DESCRIPTION
Fixes #2901 

MaxDuration now counts from first node start instead of first node finish. It is more reliable and makes more sense given the spec

Also adds a short-circuit feature that would fail a retry if waiting for the current backoff would exceed the max duration, saving the time it would have spent waiting.