### PR TITLE
fix: Consider metrics that were created and completed in the same operation

### DIFF
--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -99,8 +99,7 @@ func (woc *wfOperationCtx) executeSteps(nodeName string, tmplCtx *templateresolu
 			failMessage := fmt.Sprintf("step group %s was unsuccessful: %s", sgNode.ID, sgNode.Message)
 			woc.log.Info(failMessage)
 			woc.updateOutboundNodes(nodeName, tmpl)
-			_ = woc.markNodePhase(nodeName, wfv1.NodeFailed, sgNode.Message)
-			return node, nil
+			return woc.markNodePhase(nodeName, wfv1.NodeFailed, sgNode.Message), nil
 		}
 
 		// Add all outputs of each step in the group to the scope


### PR DESCRIPTION
There was a slight bug in the inference logic that would not emit metrics for a node that was created and completed all within the same operation. This fixes that.