### PR TITLE
fix: Remove unnecessary panic

### DIFF
--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -161,5 +161,5 @@ func UnstructuredHasCompletedLabel(obj interface{}) bool {
 	if wf, ok := obj.(*unstructured.Unstructured); ok {
 		return wf.GetLabels()[LabelKeyCompleted] == "true"
 	}
-	panic("obj passed is not an Unstructured")
+	return false
 }

--- a/workflow/common/common_test.go
+++ b/workflow/common/common_test.go
@@ -31,5 +31,5 @@ func TestUnstructuredHasCompletedLabel(t *testing.T) {
 	assert.False(t, UnstructuredHasCompletedLabel(falseLabel))
 
 	unknownObject := "hello"
-	assert.Panics(t, func() { UnstructuredHasCompletedLabel(unknownObject) })
+	assert.False(t, UnstructuredHasCompletedLabel(unknownObject))
 }


### PR DESCRIPTION
Fixes: #3122

It might be possible to receive a valid unstructured workflow that fails a cast. `getWfPriority` already accounts for this:

https://github.com/argoproj/argo/blob/6e5dd2e19a3094f88e6f927f786f866eccc5f500/workflow/controller/controller.go#L525-L528

We do not want to panic if this happens as the controller itself will resolve the Workflow and – failing that – it will output a graceful error.
