### PR TITLE
chore: Move default metrics server port/path to consts

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -721,11 +721,11 @@ func (wfc *WorkflowController) getMetricsServerConfig() (metrics.ServerConfig, m
 	// Metrics config
 	path := wfc.Config.MetricsConfig.Path
 	if path == "" {
-		path = "/metrics"
+		path = metrics.DefaultMetricsServerPath
 	}
 	port := wfc.Config.MetricsConfig.Port
 	if port == "" {
-		port = "9090"
+		port = metrics.DefaultMetricsServerPort
 	}
 	metricsConfig := metrics.ServerConfig{
 		Enabled:      wfc.Config.MetricsConfig.Enabled == nil || *wfc.Config.MetricsConfig.Enabled,

--- a/workflow/metrics/metrics.go
+++ b/workflow/metrics/metrics.go
@@ -12,6 +12,8 @@ import (
 const (
 	argoNamespace      = "argo"
 	workflowsSubsystem = "workflows"
+	DefaultMetricsServerPort = "9090"
+	DefaultMetricsServerPath = "/metrics"
 )
 
 type ServerConfig struct {

--- a/workflow/metrics/metrics_test.go
+++ b/workflow/metrics/metrics_test.go
@@ -14,13 +14,13 @@ import (
 func TestServerConfig_SameServerAs(t *testing.T) {
 	a := ServerConfig{
 		Enabled: true,
-		Path:    "/metrics",
-		Port:    "9090",
+		Path:    DefaultMetricsServerPath,
+		Port:    DefaultMetricsServerPort,
 	}
 	b := ServerConfig{
 		Enabled: true,
-		Path:    "/metrics",
-		Port:    "9090",
+		Path:    DefaultMetricsServerPath,
+		Port:    DefaultMetricsServerPort,
 	}
 
 	assert.True(t, a.SameServerAs(b))
@@ -34,7 +34,7 @@ func TestServerConfig_SameServerAs(t *testing.T) {
 	b.Port = "9091"
 	assert.False(t, a.SameServerAs(b))
 
-	b.Port = "9090"
+	b.Port = DefaultMetricsServerPort
 	b.Path = "/telemetry"
 	assert.False(t, a.SameServerAs(b))
 }
@@ -42,8 +42,8 @@ func TestServerConfig_SameServerAs(t *testing.T) {
 func TestMetrics(t *testing.T) {
 	config := ServerConfig{
 		Enabled: true,
-		Path:    "/metrics",
-		Port:    "9090",
+		Path:    DefaultMetricsServerPath,
+		Port:    DefaultMetricsServerPort,
 	}
 	m := New(config, config)
 
@@ -105,8 +105,8 @@ func TestErrors(t *testing.T) {
 func TestMetricGC(t *testing.T) {
 	config := ServerConfig{
 		Enabled: true,
-		Path:    "/metrics",
-		Port:    "9090",
+		Path:    DefaultMetricsServerPath,
+		Port:    DefaultMetricsServerPort,
 		TTL:     1 * time.Second,
 	}
 	m := New(config, config)


### PR DESCRIPTION
Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
