### PR TITLE
feat(metrics): Report controller error counters via metrics. Closes #3034

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -133,7 +133,7 @@ func (wfc *WorkflowController) runTTLController(ctx context.Context) {
 }
 
 func (wfc *WorkflowController) runCronController(ctx context.Context) {
-	cronController := cron.NewCronController(wfc.wfclientset, wfc.restConfig, wfc.namespace, wfc.GetManagedNamespace(), wfc.Config.InstanceID)
+	cronController := cron.NewCronController(wfc.wfclientset, wfc.restConfig, wfc.namespace, wfc.GetManagedNamespace(), wfc.Config.InstanceID, &wfc.metrics)
 	cronController.Run(ctx)
 }
 

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -163,6 +163,7 @@ func (woc *wfOperationCtx) operate() {
 			} else {
 				woc.markWorkflowPhase(wfv1.NodeError, true, fmt.Sprintf("%v", r))
 			}
+			woc.controller.metrics.OperationPanic()
 			woc.log.Errorf("Recovered from panic: %+v\n%s", r, debug.Stack())
 		}
 	}()

--- a/workflow/cron/controller.go
+++ b/workflow/cron/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/argoproj/argo/pkg/client/informers/externalversions"
 	extv1alpha1 "github.com/argoproj/argo/pkg/client/informers/externalversions/workflow/v1alpha1"
 	"github.com/argoproj/argo/workflow/common"
+	"github.com/argoproj/argo/workflow/metrics"
 	"github.com/argoproj/argo/workflow/util"
 )
 
@@ -40,6 +41,7 @@ type Controller struct {
 	cronWfInformer     extv1alpha1.CronWorkflowInformer
 	cronWfQueue        workqueue.RateLimitingInterface
 	restConfig         *rest.Config
+	metrics            *metrics.Metrics
 }
 
 const (
@@ -54,6 +56,7 @@ func NewCronController(
 	namespace string,
 	managedNamespace string,
 	instanceId string,
+	metrics *metrics.Metrics,
 ) *Controller {
 	return &Controller{
 		wfClientset:        wfclientset,
@@ -66,6 +69,7 @@ func NewCronController(
 		nameEntryIDMapLock: &sync.Mutex{},
 		wfQueue:            workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		cronWfQueue:        workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		metrics:            metrics,
 	}
 }
 
@@ -142,7 +146,7 @@ func (cc *Controller) processNextCronItem() bool {
 		return true
 	}
 
-	cronWorkflowOperationCtx, err := newCronWfOperationCtx(cronWf, cc.wfClientset, cc.wfLister)
+	cronWorkflowOperationCtx, err := newCronWfOperationCtx(cronWf, cc.wfClientset, cc.wfLister, cc.metrics)
 	if err != nil {
 		log.Error(err)
 		return true

--- a/workflow/cron/operator_test.go
+++ b/workflow/cron/operator_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo/pkg/client/clientset/versioned/fake"
+	"github.com/argoproj/argo/workflow/metrics"
 	"github.com/argoproj/argo/workflow/util"
 )
 
@@ -167,6 +168,7 @@ func TestCronWorkflowConditionSubmissionError(t *testing.T) {
 	assert.NoError(t, err)
 
 	cs := fake.NewSimpleClientset()
+	testMetrics := metrics.New(metrics.ServerConfig{}, metrics.ServerConfig{})
 	woc := &cronWfOperationCtx{
 		wfClientset: cs,
 		wfClient:    cs.ArgoprojV1alpha1().Workflows(""),
@@ -174,6 +176,7 @@ func TestCronWorkflowConditionSubmissionError(t *testing.T) {
 		wfLister:    &fakeLister{},
 		cronWf:      &cronWf,
 		log:         logrus.WithFields(logrus.Fields{}),
+		metrics:     &testMetrics,
 	}
 	woc.Run()
 

--- a/workflow/metrics/util.go
+++ b/workflow/metrics/util.go
@@ -150,6 +150,22 @@ func getWorkflowPhaseGauges() map[wfv1.NodePhase]prometheus.Gauge {
 	}
 }
 
+func getErrorCounters() map[ErrorCause]prometheus.Counter {
+	getOptsByPahse := func(phase ErrorCause) prometheus.CounterOpts {
+		return prometheus.CounterOpts{
+			Namespace:   argoNamespace,
+			Subsystem:   workflowsSubsystem,
+			Name:        "error_count",
+			Help:        "Number of errors encountered by the controller by cause",
+			ConstLabels: map[string]string{"cause": string(phase)},
+		}
+	}
+	return map[ErrorCause]prometheus.Counter{
+		ErrorCauseOperationPanic:              prometheus.NewCounter(getOptsByPahse(ErrorCauseOperationPanic)),
+		ErrorCauseCronWorkflowSubmissionError: prometheus.NewCounter(getOptsByPahse(ErrorCauseCronWorkflowSubmissionError)),
+	}
+}
+
 func IsValidMetricName(name string) bool {
 	return model.IsValidMetricName(model.LabelValue(name))
 }


### PR DESCRIPTION
Closes: #3034

Currently only supports:

* Operation panics
* CronWorkflow submission errors

This interface should only be used for errors that are impossible to surface with custom metrics