### PR TITLE
chore: Make lint should not depend on static files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,7 @@ $(GOPATH)/bin/golangci-lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v1.23.8
 
 .PHONY: lint
-lint: server/static/files.go $(GOPATH)/bin/golangci-lint
+lint: $(GOPATH)/bin/golangci-lint
 	# Tidy Go modules
 	go mod tidy
 	# Lint Go files


### PR DESCRIPTION
Static files builds the UI, which can take a while and impact productivity -- especially since it's common to run `make lint` to only lint Go changes. Furthermore, it doesn't seem like either of the UI or Go linters work on the static files, so depending on them seems unnecessary. Please correct me if I'm wrong.