### PR TITLE
build: Fix path to staticfiles and goreman binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ $(GOPATH)/bin/staticfiles:
 
 server/static/files.go: $(GOPATH)/bin/staticfiles ui/dist/app/index.html
 	# Pack UI into a Go file.
-	staticfiles -o server/static/files.go ui/dist/app
+	$(GOPATH)/bin/staticfiles -o server/static/files.go ui/dist/app
 
 dist/argo-linux-amd64: GOARGS = GOOS=linux GOARCH=amd64
 dist/argo-darwin-amd64: GOARGS = GOOS=darwin GOARCH=amd64
@@ -371,7 +371,7 @@ start: status stop install controller cli executor-image $(GOPATH)/bin/goreman
 	grep '127.0.0.1 *minio' /etc/hosts
 	grep '127.0.0.1 *postgres' /etc/hosts
 	grep '127.0.0.1 *mysql' /etc/hosts
-	env ALWAYS_OFFLOAD_NODE_STATUS=$(ALWAYS_OFFLOAD_NODE_STATUS) LOG_LEVEL=$(LOG_LEVEL) VERSION=$(VERSION) AUTH_MODE=$(AUTH_MODE) goreman -set-ports=false -logtime=false start
+	env ALWAYS_OFFLOAD_NODE_STATUS=$(ALWAYS_OFFLOAD_NODE_STATUS) LOG_LEVEL=$(LOG_LEVEL) VERSION=$(VERSION) AUTH_MODE=$(AUTH_MODE) $(GOPATH)/bin/goreman -set-ports=false -logtime=false start
 
 
 .PHONY: wait


### PR DESCRIPTION
This PR fixes the following two errors while running `make start` which are caused by incorrect paths to these two binaries:

```
# Pack UI into a Go file.
staticfiles -o server/static/files.go ui/dist/app
/bin/bash: staticfiles: command not found
make: *** [Makefile:182: server/static/files.go] Error 127
➜  argo git:(master) ✗ go get bou.ke/staticfiles
go: finding bou.ke/staticfiles latest
```

```
grep '127.0.0.1 *mysql' /etc/hosts
127.0.0.1 mysql
env ALWAYS_OFFLOAD_NODE_STATUS=false LOG_LEVEL=debug VERSION=latest AUTH_MODE=hybrid goreman -set-ports=false -logtime=false start
env: goreman: No such file or directory
make: *** [Makefile:374: start] Error 127
```

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
