### PR TITLE
build: Only check Dex in hosts file when SSO is enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -374,7 +374,9 @@ start: status stop install controller cli executor-image $(GOPATH)/bin/goreman
 	kubectl -n argo wait --for=condition=Ready pod --all -l app --timeout 2m
 	./hack/port-forward.sh
 	# Check dex, minio, postgres and mysql are in hosts file
+ifeq ($(AUTH_MODE),sso)
 	grep '127.0.0.1 *dex' /etc/hosts
+endif
 	grep '127.0.0.1 *minio' /etc/hosts
 	grep '127.0.0.1 *postgres' /etc/hosts
 	grep '127.0.0.1 *mysql' /etc/hosts


### PR DESCRIPTION
SSO support is added in https://github.com/argoproj/argo/pull/2745 but this check should be optional.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
