### PR TITLE
feat(sso): Allow reading SSO clientID from a secret.

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -63,6 +63,7 @@ Currently, the following organizations are **officially** using Argo Workflows:
 1. [Ravelin](https://www.ravelin.com/)
 1. [Red Hat](https://www.redhat.com/en)
 1. [Riskified](https://www.riskified.com)
+1. [Sage (Sage AI Labs)](https://sage.com/)
 1. [SAP Fieldglass](https://www.fieldglass.com/)
 1. [SAP Hybris](https://cx.sap.com/)
 1. [SegmentStream](https://segmentstream.com)

--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -200,7 +200,7 @@ data:
       issuer: https://issuer.root.url/
       # This is name of the secret and the key in it that contain OIDC client
       # ID issued to the application by the provider (required).
-      clientID:
+      clientId:
         name: client-id-secret
         key: client-id-key
       # This is name of the secret and the key in it that contain OIDC client

--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -193,3 +193,22 @@ data:
         ttlStrategy:
           secondsAfterSuccess: 5
         parallelism: 3
+
+    # SSO Configuration for the Argo server.
+    sso:
+      # This is the root URL of the OIDC provider (required).
+      issuer: https://issuer.root.url/
+      # This is name of the secret and the key in it that contain OIDC client
+      # ID issued to the application by the provider (required).
+      clientID:
+        name: client-id-secret
+        key: client-id-key
+      # This is name of the secret and the key in it that contain OIDC client
+      # secret issued to the application by the provider (required).
+      clientSecret:
+        name: client-secret-secret
+        key: client-secret-key
+      # This is the redirect URL supplied to the provider (required). It must
+      # be in the form <argo-server-root-url>/oauth2/callback. It must be
+      # browser-accessible.
+      redirectUrl: https://argo-server/oauth2/callback

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/lib/pq v1.3.0 // indirect
 	github.com/mailru/easyjson v0.7.1 // indirect
 	github.com/mattn/go-colorable v0.1.4 // indirect
+	github.com/mattn/goreman v0.3.5 // indirect
 	github.com/minio/minio-go v6.0.14+incompatible // indirect
 	github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/lib/pq v1.3.0 // indirect
 	github.com/mailru/easyjson v0.7.1 // indirect
 	github.com/mattn/go-colorable v0.1.4 // indirect
-	github.com/mattn/goreman v0.3.5 // indirect
+	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/minio/minio-go v6.0.14+incompatible // indirect
 	github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -283,8 +283,6 @@ github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGAR
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
-github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
-github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -343,8 +341,6 @@ github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW1
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/mattn/goreman v0.3.5 h1:cY6wBfPs+uUIsVPsVjtsG7FH/XAEfQS9/Zu+V4+bRqE=
-github.com/mattn/goreman v0.3.5/go.mod h1:ahZuLhEo4pfYmf56GLNu/pjTxfeE389h43IHKMXz2Ys=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/minio/minio-go v6.0.14+incompatible h1:fnV+GD28LeqdN6vT2XdGKW8Qe/IfjJDswNVuni6km9o=

--- a/go.sum
+++ b/go.sum
@@ -283,6 +283,8 @@ github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGAR
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -337,8 +339,12 @@ github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaa
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
+github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/goreman v0.3.5 h1:cY6wBfPs+uUIsVPsVjtsG7FH/XAEfQS9/Zu+V4+bRqE=
+github.com/mattn/goreman v0.3.5/go.mod h1:ahZuLhEo4pfYmf56GLNu/pjTxfeE389h43IHKMXz2Ys=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/minio/minio-go v6.0.14+incompatible h1:fnV+GD28LeqdN6vT2XdGKW8Qe/IfjJDswNVuni6km9o=
@@ -601,6 +607,7 @@ golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/manifests/quick-start-mysql.yaml
+++ b/manifests/quick-start-mysql.yaml
@@ -437,9 +437,9 @@ data:
         key: password
   sso: |
     issuer: http://dex:5556/dex
-    clientIdSecret:
+    clientID:
       name: argo-server-sso
-      key: clientId
+      key: clientID
     clientSecret:
       name: argo-server-sso
       key: clientSecret
@@ -469,7 +469,7 @@ metadata:
     app.kubernetes.io/part-of: argo
   name: argo-server-sso
 stringData:
-  clientId: argo-server
+  clientID: argo-server
   clientSecret: ZXhhbXBsZS1hcHAtc2VjcmV0
 ---
 apiVersion: v1

--- a/manifests/quick-start-mysql.yaml
+++ b/manifests/quick-start-mysql.yaml
@@ -437,7 +437,7 @@ data:
         key: password
   sso: |
     issuer: http://dex:5556/dex
-    clientID:
+    clientId:
       name: argo-server-sso
       key: clientID
     clientSecret:

--- a/manifests/quick-start-mysql.yaml
+++ b/manifests/quick-start-mysql.yaml
@@ -437,7 +437,9 @@ data:
         key: password
   sso: |
     issuer: http://dex:5556/dex
-    clientId: argo-server
+    clientIdSecret:
+      name: argo-server-sso
+      key: clientId
     clientSecret:
       name: argo-server-sso
       key: clientSecret
@@ -467,6 +469,7 @@ metadata:
     app.kubernetes.io/part-of: argo
   name: argo-server-sso
 stringData:
+  clientId: argo-server
   clientSecret: ZXhhbXBsZS1hcHAtc2VjcmV0
 ---
 apiVersion: v1

--- a/manifests/quick-start-no-db.yaml
+++ b/manifests/quick-start-no-db.yaml
@@ -418,7 +418,9 @@ data:
     port: 9090
   sso: |
     issuer: http://dex:5556/dex
-    clientId: argo-server
+    clientIdSecret:
+      name: argo-server-sso
+      key: clientId
     clientSecret:
       name: argo-server-sso
       key: clientSecret
@@ -436,6 +438,7 @@ metadata:
     app.kubernetes.io/part-of: argo
   name: argo-server-sso
 stringData:
+  clientId: argo-server
   clientSecret: ZXhhbXBsZS1hcHAtc2VjcmV0
 ---
 apiVersion: v1

--- a/manifests/quick-start-no-db.yaml
+++ b/manifests/quick-start-no-db.yaml
@@ -418,7 +418,7 @@ data:
     port: 9090
   sso: |
     issuer: http://dex:5556/dex
-    clientID:
+    clientId:
       name: argo-server-sso
       key: clientID
     clientSecret:

--- a/manifests/quick-start-no-db.yaml
+++ b/manifests/quick-start-no-db.yaml
@@ -418,9 +418,9 @@ data:
     port: 9090
   sso: |
     issuer: http://dex:5556/dex
-    clientIdSecret:
+    clientID:
       name: argo-server-sso
-      key: clientId
+      key: clientID
     clientSecret:
       name: argo-server-sso
       key: clientSecret
@@ -438,7 +438,7 @@ metadata:
     app.kubernetes.io/part-of: argo
   name: argo-server-sso
 stringData:
-  clientId: argo-server
+  clientID: argo-server
   clientSecret: ZXhhbXBsZS1hcHAtc2VjcmV0
 ---
 apiVersion: v1

--- a/manifests/quick-start-postgres.yaml
+++ b/manifests/quick-start-postgres.yaml
@@ -437,9 +437,9 @@ data:
         key: password
   sso: |
     issuer: http://dex:5556/dex
-    clientIdSecret:
+    clientID:
       name: argo-server-sso
-      key: clientId
+      key: clientID
     clientSecret:
       name: argo-server-sso
       key: clientSecret
@@ -469,7 +469,7 @@ metadata:
     app.kubernetes.io/part-of: argo
   name: argo-server-sso
 stringData:
-  clientId: argo-server
+  clientID: argo-server
   clientSecret: ZXhhbXBsZS1hcHAtc2VjcmV0
 ---
 apiVersion: v1

--- a/manifests/quick-start-postgres.yaml
+++ b/manifests/quick-start-postgres.yaml
@@ -437,7 +437,7 @@ data:
         key: password
   sso: |
     issuer: http://dex:5556/dex
-    clientID:
+    clientId:
       name: argo-server-sso
       key: clientID
     clientSecret:

--- a/manifests/quick-start-postgres.yaml
+++ b/manifests/quick-start-postgres.yaml
@@ -437,7 +437,9 @@ data:
         key: password
   sso: |
     issuer: http://dex:5556/dex
-    clientId: argo-server
+    clientIdSecret:
+      name: argo-server-sso
+      key: clientId
     clientSecret:
       name: argo-server-sso
       key: clientSecret
@@ -467,6 +469,7 @@ metadata:
     app.kubernetes.io/part-of: argo
   name: argo-server-sso
 stringData:
+  clientId: argo-server
   clientSecret: ZXhhbXBsZS1hcHAtc2VjcmV0
 ---
 apiVersion: v1

--- a/manifests/quick-start/base/argo-server-sso-secret.yaml
+++ b/manifests/quick-start/base/argo-server-sso-secret.yaml
@@ -3,4 +3,5 @@ apiVersion: v1
 metadata:
   name: argo-server-sso
 stringData:
+  clientId: argo-server
   clientSecret: ZXhhbXBsZS1hcHAtc2VjcmV0

--- a/manifests/quick-start/base/argo-server-sso-secret.yaml
+++ b/manifests/quick-start/base/argo-server-sso-secret.yaml
@@ -3,5 +3,5 @@ apiVersion: v1
 metadata:
   name: argo-server-sso
 stringData:
-  clientId: argo-server
+  clientID: argo-server
   clientSecret: ZXhhbXBsZS1hcHAtc2VjcmV0

--- a/manifests/quick-start/base/overlays/workflow-controller-configmap.yaml
+++ b/manifests/quick-start/base/overlays/workflow-controller-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 data:
   sso : |
     issuer: http://dex:5556/dex
-    clientID:
+    clientId:
       name: argo-server-sso
       key: clientID
     clientSecret:

--- a/manifests/quick-start/base/overlays/workflow-controller-configmap.yaml
+++ b/manifests/quick-start/base/overlays/workflow-controller-configmap.yaml
@@ -2,7 +2,9 @@ apiVersion: v1
 data:
   sso : |
     issuer: http://dex:5556/dex
-    clientId: argo-server
+    clientIdSecret:
+      name: argo-server-sso
+      key: clientId
     clientSecret:
       name: argo-server-sso
       key: clientSecret

--- a/manifests/quick-start/base/overlays/workflow-controller-configmap.yaml
+++ b/manifests/quick-start/base/overlays/workflow-controller-configmap.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 data:
   sso : |
     issuer: http://dex:5556/dex
-    clientIdSecret:
+    clientID:
       name: argo-server-sso
-      key: clientId
+      key: clientID
     clientSecret:
       name: argo-server-sso
       key: clientSecret

--- a/server/auth/sso/sso.go
+++ b/server/auth/sso/sso.go
@@ -56,12 +56,12 @@ type providerInterface interface {
 
 type providerFactory func(ctx context.Context, issuer string) (providerInterface, error)
 
-func providerFactoryOidc(ctx context.Context, issuer string) (providerInterface, error) {
+func providerFactoryOIDC(ctx context.Context, issuer string) (providerInterface, error) {
 	return oidc.NewProvider(ctx, issuer)
 }
 
 func New(c Config, secretsIf corev1.SecretInterface, baseHRef string, secure bool) (Interface, error) {
-	return newSso(providerFactoryOidc, c, secretsIf, baseHRef, secure)
+	return newSso(providerFactoryOIDC, c, secretsIf, baseHRef, secure)
 }
 
 func newSso(

--- a/server/auth/sso/sso.go
+++ b/server/auth/sso/sso.go
@@ -40,7 +40,7 @@ type sso struct {
 
 type Config struct {
 	Issuer       string                  `json:"issuer"`
-	ClientID     apiv1.SecretKeySelector `json:"clientID"`
+	ClientID     apiv1.SecretKeySelector `json:"clientId"`
 	ClientSecret apiv1.SecretKeySelector `json:"clientSecret"`
 	RedirectURL  string                  `json:"redirectUrl"`
 }

--- a/server/auth/sso/sso.go
+++ b/server/auth/sso/sso.go
@@ -103,11 +103,11 @@ func newSso(
 	}
 	clientID := clientIDObj.Data[c.ClientID.Key]
 	if clientID == nil {
-		return nil, fmt.Errorf("Key %s missing in secret %s", c.ClientID.Key, c.ClientID.Name)
+		return nil, fmt.Errorf("key %s missing in secret %s", c.ClientID.Key, c.ClientID.Name)
 	}
 	clientSecret := clientSecretObj.Data[c.ClientSecret.Key]
 	if clientSecret == nil {
-		return nil, fmt.Errorf("Key %s missing in secret %s", c.ClientSecret.Key, c.ClientSecret.Name)
+		return nil, fmt.Errorf("key %s missing in secret %s", c.ClientSecret.Key, c.ClientSecret.Name)
 	}
 
 	config := &oauth2.Config{

--- a/server/auth/sso/sso.go
+++ b/server/auth/sso/sso.go
@@ -66,7 +66,13 @@ func New(c Config, secretsIf corev1.SecretInterface, baseHRef string, secure boo
 	return newSso(providerFactoryOidc, c, secretsIf, baseHRef, secure)
 }
 
-func newSso(factory providerFactory, c Config, secretsIf corev1.SecretInterface, baseHRef string, secure bool) (Interface, error) {
+func newSso(
+	factory providerFactory,
+	c Config,
+	secretsIf corev1.SecretInterface,
+	baseHRef string,
+	secure bool,
+) (Interface, error) {
 	if c.Issuer == "" {
 		return nil, fmt.Errorf("issuer empty")
 	}

--- a/server/auth/sso/sso_test.go
+++ b/server/auth/sso/sso_test.go
@@ -100,5 +100,5 @@ func TestLoadSsoClientIdFromSecretNoKeyFails(t *testing.T) {
 	}
 	_, err := newSso(fakeOidcFactory, config, fakeClient, "/", false)
 	require.Error(t, err)
-	assert.Regexp(t, "Key nonexistent missing in secret argo-sso-secret", err.Error())
+	assert.Regexp(t, "key nonexistent missing in secret argo-sso-secret", err.Error())
 }

--- a/server/auth/sso/sso_test.go
+++ b/server/auth/sso/sso_test.go
@@ -1,0 +1,110 @@
+package sso
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/coreos/go-oidc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const testNamespace = "argo"
+
+type fakeOidcProvider struct{}
+
+func (fakeOidcProvider) Endpoint() oauth2.Endpoint {
+	return oauth2.Endpoint{}
+}
+
+func (fakeOidcProvider) Verifier(config *oidc.Config) *oidc.IDTokenVerifier {
+	return nil
+}
+
+func fakeOidcFactory(ctx context.Context, issuer string) (providerInterface, error) {
+	return fakeOidcProvider{}, nil
+}
+
+func encodeSecretValue(value string) []byte {
+	src := []byte(value)
+	dst := make([]byte, base64.StdEncoding.EncodedLen(len(src)))
+	base64.StdEncoding.Encode(dst, src)
+	return dst
+}
+func decodeSecretValue(t *testing.T, value string) string {
+	result, err := base64.StdEncoding.DecodeString(value)
+	require.NoError(t, err)
+	return string(result)
+}
+
+func getSecretKeySelector(secret, key string) *apiv1.SecretKeySelector {
+	return &apiv1.SecretKeySelector{
+		LocalObjectReference: apiv1.LocalObjectReference{
+			Name: secret,
+		},
+		Key: key,
+	}
+}
+
+var ssoConfigSecret = &apiv1.Secret{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: testNamespace,
+		Name:      "argo-sso-secret",
+	},
+	Type: apiv1.SecretTypeOpaque,
+	Data: map[string][]byte{
+		"client-id":     encodeSecretValue("sso-client-id-value"),
+		"client-secret": encodeSecretValue("sso-client-secret-value"),
+	},
+}
+
+func TestLoadSsoClientIdDirectly(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset(ssoConfigSecret).CoreV1().Secrets(testNamespace)
+	config := Config{
+		Issuer:         "https://test-issuer",
+		ClientID:       "sso-client-id-direct-value",
+		ClientIDSecret: nil,
+		ClientSecret:   *getSecretKeySelector("argo-sso-secret", "client-secret"),
+		RedirectURL:    "https://dummy",
+	}
+	ssoInterface, err := newSso(fakeOidcFactory, config, fakeClient, "/", false)
+	require.NoError(t, err)
+	ssoObject := ssoInterface.(*sso)
+	assert.Equal(t, "sso-client-id-direct-value", ssoObject.config.ClientID)
+	assert.Equal(t, "sso-client-secret-value", decodeSecretValue(t, ssoObject.config.ClientSecret))
+}
+
+func TestLoadSsoClientIdFromSecret(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset(ssoConfigSecret).CoreV1().Secrets(testNamespace)
+	config := Config{
+		Issuer:         "https://test-issuer",
+		ClientID:       "",
+		ClientIDSecret: getSecretKeySelector("argo-sso-secret", "client-id"),
+		ClientSecret:   *getSecretKeySelector("argo-sso-secret", "client-secret"),
+		RedirectURL:    "https://dummy",
+	}
+	ssoInterface, err := newSso(fakeOidcFactory, config, fakeClient, "/", false)
+	require.NoError(t, err)
+	ssoObject := ssoInterface.(*sso)
+	assert.Equal(t, "sso-client-id-value", ssoObject.config.ClientID)
+	assert.Equal(t, "sso-client-secret-value", decodeSecretValue(t, ssoObject.config.ClientSecret))
+}
+
+func TestLoadSsoClientIdFromSecretAndDirectFails(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset(ssoConfigSecret).CoreV1().Secrets(testNamespace)
+	config := Config{
+		Issuer:         "https://test-issuer",
+		ClientID:       "sso-client-id-direct-value",
+		ClientIDSecret: getSecretKeySelector("argo-sso-secret", "client-id"),
+		ClientSecret:   *getSecretKeySelector("argo-sso-secret", "client-secret"),
+		RedirectURL:    "https://dummy",
+	}
+	_, err := newSso(fakeOidcFactory, config, fakeClient, "/", false)
+	require.Error(t, err)
+	assert.Regexp(t, "only one of .* must be specified", err.Error())
+}

--- a/server/auth/sso/sso_test.go
+++ b/server/auth/sso/sso_test.go
@@ -2,7 +2,6 @@ package sso
 
 import (
 	"context"
-	"encoding/base64"
 	"testing"
 
 	"github.com/coreos/go-oidc"
@@ -30,20 +29,8 @@ func fakeOidcFactory(ctx context.Context, issuer string) (providerInterface, err
 	return fakeOidcProvider{}, nil
 }
 
-func encodeSecretValue(value string) []byte {
-	src := []byte(value)
-	dst := make([]byte, base64.StdEncoding.EncodedLen(len(src)))
-	base64.StdEncoding.Encode(dst, src)
-	return dst
-}
-func decodeSecretValue(t *testing.T, value string) string {
-	result, err := base64.StdEncoding.DecodeString(value)
-	require.NoError(t, err)
-	return string(result)
-}
-
-func getSecretKeySelector(secret, key string) *apiv1.SecretKeySelector {
-	return &apiv1.SecretKeySelector{
+func getSecretKeySelector(secret, key string) apiv1.SecretKeySelector {
+	return apiv1.SecretKeySelector{
 		LocalObjectReference: apiv1.LocalObjectReference{
 			Name: secret,
 		},
@@ -58,53 +45,60 @@ var ssoConfigSecret = &apiv1.Secret{
 	},
 	Type: apiv1.SecretTypeOpaque,
 	Data: map[string][]byte{
-		"client-id":     encodeSecretValue("sso-client-id-value"),
-		"client-secret": encodeSecretValue("sso-client-secret-value"),
+		"client-id":     []byte("sso-client-id-value"),
+		"client-secret": []byte("sso-client-secret-value"),
 	},
-}
-
-func TestLoadSsoClientIdDirectly(t *testing.T) {
-	fakeClient := fake.NewSimpleClientset(ssoConfigSecret).CoreV1().Secrets(testNamespace)
-	config := Config{
-		Issuer:         "https://test-issuer",
-		ClientID:       "sso-client-id-direct-value",
-		ClientIDSecret: nil,
-		ClientSecret:   *getSecretKeySelector("argo-sso-secret", "client-secret"),
-		RedirectURL:    "https://dummy",
-	}
-	ssoInterface, err := newSso(fakeOidcFactory, config, fakeClient, "/", false)
-	require.NoError(t, err)
-	ssoObject := ssoInterface.(*sso)
-	assert.Equal(t, "sso-client-id-direct-value", ssoObject.config.ClientID)
-	assert.Equal(t, "sso-client-secret-value", decodeSecretValue(t, ssoObject.config.ClientSecret))
 }
 
 func TestLoadSsoClientIdFromSecret(t *testing.T) {
 	fakeClient := fake.NewSimpleClientset(ssoConfigSecret).CoreV1().Secrets(testNamespace)
 	config := Config{
-		Issuer:         "https://test-issuer",
-		ClientID:       "",
-		ClientIDSecret: getSecretKeySelector("argo-sso-secret", "client-id"),
-		ClientSecret:   *getSecretKeySelector("argo-sso-secret", "client-secret"),
-		RedirectURL:    "https://dummy",
+		Issuer:       "https://test-issuer",
+		ClientID:     getSecretKeySelector("argo-sso-secret", "client-id"),
+		ClientSecret: getSecretKeySelector("argo-sso-secret", "client-secret"),
+		RedirectURL:  "https://dummy",
 	}
 	ssoInterface, err := newSso(fakeOidcFactory, config, fakeClient, "/", false)
 	require.NoError(t, err)
 	ssoObject := ssoInterface.(*sso)
 	assert.Equal(t, "sso-client-id-value", ssoObject.config.ClientID)
-	assert.Equal(t, "sso-client-secret-value", decodeSecretValue(t, ssoObject.config.ClientSecret))
+	assert.Equal(t, "sso-client-secret-value", ssoObject.config.ClientSecret)
 }
 
-func TestLoadSsoClientIdFromSecretAndDirectFails(t *testing.T) {
+func TestLoadSsoClientIdFromDifferentSecret(t *testing.T) {
+	clientIDSecret := &apiv1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      "other-secret",
+		},
+		Type: apiv1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"client-id": []byte("sso-client-id-value"),
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(ssoConfigSecret, clientIDSecret).CoreV1().Secrets(testNamespace)
+	config := Config{
+		Issuer:       "https://test-issuer",
+		ClientID:     getSecretKeySelector("other-secret", "client-id"),
+		ClientSecret: getSecretKeySelector("argo-sso-secret", "client-secret"),
+		RedirectURL:  "https://dummy",
+	}
+	ssoInterface, err := newSso(fakeOidcFactory, config, fakeClient, "/", false)
+	require.NoError(t, err)
+	ssoObject := ssoInterface.(*sso)
+	assert.Equal(t, "sso-client-id-value", ssoObject.config.ClientID)
+}
+
+func TestLoadSsoClientIdFromSecretNoKeyFails(t *testing.T) {
 	fakeClient := fake.NewSimpleClientset(ssoConfigSecret).CoreV1().Secrets(testNamespace)
 	config := Config{
-		Issuer:         "https://test-issuer",
-		ClientID:       "sso-client-id-direct-value",
-		ClientIDSecret: getSecretKeySelector("argo-sso-secret", "client-id"),
-		ClientSecret:   *getSecretKeySelector("argo-sso-secret", "client-secret"),
-		RedirectURL:    "https://dummy",
+		Issuer:       "https://test-issuer",
+		ClientID:     getSecretKeySelector("argo-sso-secret", "nonexistent"),
+		ClientSecret: getSecretKeySelector("argo-sso-secret", "client-secret"),
+		RedirectURL:  "https://dummy",
 	}
 	_, err := newSso(fakeOidcFactory, config, fakeClient, "/", false)
 	require.Error(t, err)
-	assert.Regexp(t, "only one of .* must be specified", err.Error())
+	assert.Regexp(t, "Key nonexistent missing in secret argo-sso-secret", err.Error())
 }


### PR DESCRIPTION
This change adds support for reading the SSO client ID value from a secret, just like the client secret is read already. That will make it easier to provide that the client ID value externally, via facilities like external secrets, which in turn makes rotating secrets much easier.

Besides adding unit tests, tested this by running `make start AUTH_MODE=sso` and verifying the login process with dex and its sample app.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
