### PR TITLE
feat: Tick CLI Workflow watch even if there are no new events

### DIFF
--- a/cmd/argo/commands/watch.go
+++ b/cmd/argo/commands/watch.go
@@ -79,7 +79,7 @@ func watchWorkflow(wfName string, getArgs getFlags) {
 			// If we get a new event, update our workflow
 			wf = event.Object
 			if wf == nil {
-				break
+				return
 			}
 		case <-ticker.C:
 			// If we don't, refresh the workflow screen every second

--- a/cmd/argo/commands/watch.go
+++ b/cmd/argo/commands/watch.go
@@ -65,7 +65,6 @@ func watchWorkflow(wfName string, getArgs getFlags) {
 				log.Debug("Re-establishing workflow watch")
 				stream, err = serviceClient.WatchWorkflows(ctx, req)
 				errors.CheckError(err)
-				continue
 			}
 			errors.CheckError(err)
 			wfEventChan <- event
@@ -83,7 +82,7 @@ func watchWorkflow(wfName string, getArgs getFlags) {
 				break
 			}
 		case <-ticker.C:
-			// If we don't, print workflow again every second
+			// If we don't, refresh the workflow screen every second
 		}
 
 		printWorkflowStatus(wf, getArgs)


### PR DESCRIPTION
Currently if we are watching a Workflow on the CLI and there are no new events from it, we don't refresh the screen. Since the screen contains a duration in seconds, we may perhaps be giving the impression that Workflow execution has stalled:

```
Name:                steps-vhd7c
Namespace:           argo
ServiceAccount:      default
Status:              Running
Created:             Thu Jun 11 11:51:33 -0700 (9 seconds ago)
Started:             Thu Jun 11 11:51:33 -0700 (9 seconds ago)
Duration:            9 seconds

STEP            TEMPLATE           PODNAME                 DURATION  MESSAGE
 ● steps-vhd7c  hello-hello-hello
 └---● hello1   whalesay           steps-vhd7c-3181874478  9s
```

If this screen does not refresh, it could give the impression that execution has stalled since `Duration: 9 seconds` is not refreshing.

With this change, if there are no new events at every second, we simply refresh the screen with updated durations.