### PR TITLE
fix(controller): set pod finish timestamp when it is deleted

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -25,6 +25,7 @@ Currently, the following organizations are **officially** using Argo Workflows:
 1. [CoreFiling](https://www.corefiling.com/)
 1. [Cratejoy](https://www.cratejoy.com/)
 1. [CoreWeave Cloud](https://www.coreweave.com)
+1. [Cruise](https://getcruise.com/)
 1. [CyberAgent](https://www.cyberagent.co.jp/en/)
 1. [Cyrus Biotechnology](https://cyrusbio.com/)
 1. [Datadog](https://www.datadoghq.com/)

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -563,7 +563,7 @@ func TestBackoffMessage(t *testing.T) {
 	firstNode.FinishedAt = metav1.Time{Time: time.Now().Add(-6 * time.Second)}
 	woc.wf.Status.Nodes[firstNode.ID] = *firstNode
 	lastNode := getChildNodeIndex(retryNode, woc.wf.Status.Nodes, -1)
-	lastNode.StartedAt = metav1.Time{Time: time.Now().Add(-1 * time.Second)}
+	lastNode.StartedAt = metav1.Time{Time: time.Now().Add(-3 * time.Second)}
 	lastNode.FinishedAt = metav1.Time{Time: time.Now().Add(-1 * time.Second)}
 	woc.wf.Status.Nodes[lastNode.ID] = *lastNode
 
@@ -576,7 +576,7 @@ func TestBackoffMessage(t *testing.T) {
 	firstNode.StartedAt = metav1.Time{Time: time.Now().Add(-9 * time.Second)}
 	firstNode.FinishedAt = metav1.Time{Time: time.Now().Add(-7 * time.Second)}
 	woc.wf.Status.Nodes[firstNode.ID] = *firstNode
-	lastNode.StartedAt = metav1.Time{Time: time.Now().Add(-2 * time.Second)}
+	lastNode.StartedAt = metav1.Time{Time: time.Now().Add(-4 * time.Second)}
 	lastNode.FinishedAt = metav1.Time{Time: time.Now().Add(-2 * time.Second)}
 	woc.wf.Status.Nodes[lastNode.ID] = *lastNode
 
@@ -586,25 +586,12 @@ func TestBackoffMessage(t *testing.T) {
 	// Message should not change
 	assert.Equal(t, "Backoff for 4 seconds", newRetryNode.Message)
 
-	// Advance time one second, and simulate a pod-deleted error by clearing FinishedAt
-	firstNode.StartedAt = metav1.Time{Time: time.Now().Add(-10 * time.Second)}
-	firstNode.FinishedAt = metav1.Time{Time: time.Now().Add(-8 * time.Second)}
-	woc.wf.Status.Nodes[firstNode.ID] = *firstNode
-	lastNode.StartedAt = metav1.Time{Time: time.Now().Add(-3 * time.Second)}
-	woc.wf.Status.Nodes[lastNode.ID] = *lastNode
-
-	newRetryNode, proceed, err = woc.processNodeRetries(retryNode, *woc.wf.Spec.Templates[0].RetryStrategy)
-	assert.NoError(t, err)
-	assert.False(t, proceed)
-	// Message should not change
-	assert.Equal(t, "Backoff for 4 seconds", newRetryNode.Message)
-
-	// Advance time 2 seconds
+	// Advance time 3 seconds
 	firstNode.StartedAt = metav1.Time{Time: time.Now().Add(-12 * time.Second)}
 	firstNode.FinishedAt = metav1.Time{Time: time.Now().Add(-10 * time.Second)}
 	woc.wf.Status.Nodes[firstNode.ID] = *firstNode
-	lastNode.StartedAt = metav1.Time{Time: time.Now().Add(-5 * time.Second)}
-	lastNode.FinishedAt = metav1.Time{Time: time.Now().Add(-3 * time.Second)}
+	lastNode.StartedAt = metav1.Time{Time: time.Now().Add(-7 * time.Second)}
+	lastNode.FinishedAt = metav1.Time{Time: time.Now().Add(-5 * time.Second)}
 	woc.wf.Status.Nodes[lastNode.ID] = *lastNode
 
 	newRetryNode, proceed, err = woc.processNodeRetries(retryNode, *woc.wf.Spec.Templates[0].RetryStrategy)

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -563,7 +563,7 @@ func TestBackoffMessage(t *testing.T) {
 	firstNode.FinishedAt = metav1.Time{Time: time.Now().Add(-6 * time.Second)}
 	woc.wf.Status.Nodes[firstNode.ID] = *firstNode
 	lastNode := getChildNodeIndex(retryNode, woc.wf.Status.Nodes, -1)
-	lastNode.StartedAt = metav1.Time{Time: time.Now().Add(-3 * time.Second)}
+	lastNode.StartedAt = metav1.Time{Time: time.Now().Add(-1 * time.Second)}
 	lastNode.FinishedAt = metav1.Time{Time: time.Now().Add(-1 * time.Second)}
 	woc.wf.Status.Nodes[lastNode.ID] = *lastNode
 
@@ -576,7 +576,7 @@ func TestBackoffMessage(t *testing.T) {
 	firstNode.StartedAt = metav1.Time{Time: time.Now().Add(-9 * time.Second)}
 	firstNode.FinishedAt = metav1.Time{Time: time.Now().Add(-7 * time.Second)}
 	woc.wf.Status.Nodes[firstNode.ID] = *firstNode
-	lastNode.StartedAt = metav1.Time{Time: time.Now().Add(-4 * time.Second)}
+	lastNode.StartedAt = metav1.Time{Time: time.Now().Add(-2 * time.Second)}
 	lastNode.FinishedAt = metav1.Time{Time: time.Now().Add(-2 * time.Second)}
 	woc.wf.Status.Nodes[lastNode.ID] = *lastNode
 
@@ -586,12 +586,25 @@ func TestBackoffMessage(t *testing.T) {
 	// Message should not change
 	assert.Equal(t, "Backoff for 4 seconds", newRetryNode.Message)
 
-	// Advance time 3 seconds
+	// Advance time one second, and simulate a pod-deleted error by clearing FinishedAt
+	firstNode.StartedAt = metav1.Time{Time: time.Now().Add(-10 * time.Second)}
+	firstNode.FinishedAt = metav1.Time{Time: time.Now().Add(-8 * time.Second)}
+	woc.wf.Status.Nodes[firstNode.ID] = *firstNode
+	lastNode.StartedAt = metav1.Time{Time: time.Now().Add(-3 * time.Second)}
+	woc.wf.Status.Nodes[lastNode.ID] = *lastNode
+
+	newRetryNode, proceed, err = woc.processNodeRetries(retryNode, *woc.wf.Spec.Templates[0].RetryStrategy)
+	assert.NoError(t, err)
+	assert.False(t, proceed)
+	// Message should not change
+	assert.Equal(t, "Backoff for 4 seconds", newRetryNode.Message)
+
+	// Advance time 2 seconds
 	firstNode.StartedAt = metav1.Time{Time: time.Now().Add(-12 * time.Second)}
 	firstNode.FinishedAt = metav1.Time{Time: time.Now().Add(-10 * time.Second)}
 	woc.wf.Status.Nodes[firstNode.ID] = *firstNode
-	lastNode.StartedAt = metav1.Time{Time: time.Now().Add(-7 * time.Second)}
-	lastNode.FinishedAt = metav1.Time{Time: time.Now().Add(-5 * time.Second)}
+	lastNode.StartedAt = metav1.Time{Time: time.Now().Add(-5 * time.Second)}
+	lastNode.FinishedAt = metav1.Time{Time: time.Now().Add(-3 * time.Second)}
 	woc.wf.Status.Nodes[lastNode.ID] = *lastNode
 
 	newRetryNode, proceed, err = woc.processNodeRetries(retryNode, *woc.wf.Spec.Templates[0].RetryStrategy)


### PR DESCRIPTION
Summary
----
Fixes #2901

When a node fails due to a pod-deleted error (see code [here](https://github.com/argoproj/argo/blob/a7d8546cf9515ea70d686b8c669bf0a1d9b7538d/workflow/controller/operator.go#L833)), `FinishedAt` is unavailable and retry backoff doesn't work as expected. Backoff is crucial to handle the pod-deleted error since it usually happens when the cluster is under pressure.

This PR sets `FinishedAt` to system time when the pod is deleted. 

Tests
----
Verified with our internal load test:
* 3600 workflows
* 2 workflows created per second

Before: finishedAt is null, and workflow success rate is 66.1%.
```
foo-pipeline-xhwq8-3799176537:
  boundaryID: foo-pipeline-xhwq8-2284472225
  displayName: echo(2)
  finishedAt: null
  id: foo-pipeline-xhwq8-3799176537
  message: pod deleted
  name: foo-pipeline-xhwq8.exit-handler-1.echo(2)
  phase: Error
  startedAt: "2020-06-14T18:07:54Z"
  templateName: echo
  type: Pod
```

After: finishedAt is available, and workflow success rate is 95.7%.
```
foo-pipeline-nltcq-2896542097:
  boundaryID: foo-pipeline-nltcq-1123147699
  displayName: sleep(0)
  finishedAt: "2020-06-18T18:29:11Z"
  id: foo-pipeline-nltcq-2896542097
  message: pod deleted
  name: foo-pipeline-nltcq.exit-handler-1.sleep(0)
  phase: Error
  startedAt: "2020-06-18T18:23:37Z"
  templateName: sleep
  type: Pod
```

Checklist
----
* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

