### PR TITLE
fix(jqFilter)!: remove extra quotes around output parameter value

### DIFF
--- a/test/e2e/functional/output-jqfilter-parameters.yaml
+++ b/test/e2e/functional/output-jqfilter-parameters.yaml
@@ -1,0 +1,103 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: output-jqfilter-parameters-
+spec:
+  entrypoint: main
+  templates:
+
+  # main template that:
+  #   * create a configmap with json payload
+  #   * extract data using jqFilter from it
+  #   * compare the output parameters are what we expect
+  - name: main
+    steps:
+    - - name: create-param
+        template: create-param
+
+    - - name: get-param
+        template: get-param
+
+    - - name: check-param-one-value
+        template: check-param
+        arguments:
+          parameters:
+          - name: key
+            value: "{{steps.get-param.outputs.parameters.one_value}}"
+          - name: value
+            value: "foo"
+      - name: check-param-one-dict
+        template: check-param
+        arguments:
+          parameters:
+          - name: key
+            value: "{{steps.get-param.outputs.parameters.one_dict}}"
+          - name: value
+            value: |
+              {"foo":"bar"}
+      - name: check-param-one-list
+        template: check-param
+        arguments:
+          parameters:
+          - name: key
+            value: "{{steps.get-param.outputs.parameters.one_list}}"
+          - name: value
+            value: |
+              [{"foo":"bar"}]
+
+  # check that key and value parameters are aligned
+  - name: check-param
+    inputs:
+      parameters:
+      - name: key
+      - name: value
+    container:
+      image: argoproj/argoexec:latest
+      command: [sh, -c]
+      args: ["
+        echo '<{{inputs.parameters.key}}>' > /tmp/input;
+        echo '<{{inputs.parameters.value}}>' > /tmp/expected;
+        diff /tmp/input /tmp/expected;
+      "]
+
+  # extract parameters from a configmap json payload using jqFilter
+  - name: get-param
+    resource:
+      action: get
+      manifest: |
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: cm-output-jqfilter-parameters
+    outputs:
+      parameters:
+      - name: one_value
+        valueFrom:
+          jqFilter: '.data.some | fromjson | .one_value'
+      - name: one_dict
+        valueFrom:
+          jqfilter: '.data.some | fromjson | .one_dict'
+      - name: one_list
+        valueFrom:
+          jqfilter: '.data.some | fromjson | .one_list'
+
+  # create a configmap with json payload
+  - name: create-param
+    resource:
+      action: create
+      manifest: |
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: cm-output-jqfilter-parameters
+        data:
+          some: |
+            {
+              "one_value": "foo",
+              "one_dict": {"foo":"bar"},
+              "one_list": [
+                {
+                  "foo":"bar"
+                }
+              ]
+            }

--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -330,7 +330,7 @@ func (we *WorkflowExecutor) SaveResourceParameters(resourceNamespace string, res
 			if resourceNamespace != "" {
 				resArgs = append(resArgs, "-n", resourceNamespace)
 			}
-			cmdStr := fmt.Sprintf("kubectl get %s -o json | jq -c '%s'", strings.Join(resArgs, " "), param.ValueFrom.JQFilter)
+			cmdStr := fmt.Sprintf("kubectl get %s -o json | jq -rc '%s'", strings.Join(resArgs, " "), param.ValueFrom.JQFilter)
 			cmd = exec.Command("sh", "-c", cmdStr)
 		} else {
 			continue


### PR DESCRIPTION
When playing with jqFilter, the return value begins with double quotes and ends in double quotes, also followed by a newline: i.e.:

```
 "parameter value"\n
```

Related PR : argoproj#1232

This commit ensure we do not insert extra double quotes and trailing new line when using
valueFrom: jqFilter to set the value of an output parameter for
resource templates.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).