### PR TITLE
feat: Append previous workflow name as label to resubmitted workflow

### DIFF
--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -57,6 +57,8 @@ const (
 	LabelKeyWorkflow = workflow.WorkflowFullName + "/workflow"
 	// LabelKeyPhase is a label applied to workflows to indicate the current phase of the workflow (for filtering purposes)
 	LabelKeyPhase = workflow.WorkflowFullName + "/phase"
+	// LabelKeyPreviousWorkflowName is a label applied to resubmitted workflows
+	LabelKeyPreviousWorkflowName = workflow.WorkflowFullName + "/resubmitted-from-workflow"
 	// LabelKeyCronWorkflow is a label applied to Workflows that are started by a CronWorkflow
 	LabelKeyCronWorkflow = workflow.WorkflowFullName + "/cron-workflow"
 	// LabelKeyWorkflowTemplate is a label applied to Workflows that are submitted from Workflowtemplate
@@ -145,7 +147,6 @@ const (
 
 	KubeConfigDefaultMountPath    = "/kube/config"
 	KubeConfigDefaultVolumeName   = "kubeconfig"
-	PreviousWorkflowNameLabelKey  = "workflows.argoproj.io/resubmitted-from-workflow"
 	ServiceAccountTokenMountPath  = "/var/run/secrets/kubernetes.io/serviceaccount"
 	ServiceAccountTokenVolumeName = "exec-sa-token"
 	SecretVolMountPath            = "/argo/secret"

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -145,6 +145,7 @@ const (
 
 	KubeConfigDefaultMountPath    = "/kube/config"
 	KubeConfigDefaultVolumeName   = "kubeconfig"
+	PreviousWorkflowNameLabelKey  = "workflows.argoproj.io/resubmitted-from-workflow"
 	ServiceAccountTokenMountPath  = "/var/run/secrets/kubernetes.io/serviceaccount"
 	ServiceAccountTokenVolumeName = "exec-sa-token"
 	SecretVolMountPath            = "/argo/secret"

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -493,15 +493,18 @@ func FormulateResubmitWorkflow(wf *wfv1.Workflow, memoized bool) (*wfv1.Workflow
 
 	// carry over user labels and annotations from previous workflow.
 	// skip any argoproj.io labels except for the controller instanceID label.
+	if newWF.ObjectMeta.Labels == nil {
+		newWF.ObjectMeta.Labels = make(map[string]string)
+	}
 	for key, val := range wf.ObjectMeta.Labels {
 		if strings.HasPrefix(key, workflow.WorkflowFullName+"/") && key != common.LabelKeyControllerInstanceID {
 			continue
 		}
-		if newWF.ObjectMeta.Labels == nil {
-			newWF.ObjectMeta.Labels = make(map[string]string)
-		}
 		newWF.ObjectMeta.Labels[key] = val
 	}
+	// append an additional label so it's easy for user to see what the original workflow is
+	// that has been resubmitted.
+	newWF.ObjectMeta.Labels["workflows.argoproj.io/previous-workflow-name"] = wf.ObjectMeta.Name
 	for key, val := range wf.ObjectMeta.Annotations {
 		if newWF.ObjectMeta.Annotations == nil {
 			newWF.ObjectMeta.Annotations = make(map[string]string)

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -504,7 +504,7 @@ func FormulateResubmitWorkflow(wf *wfv1.Workflow, memoized bool) (*wfv1.Workflow
 	}
 	// Append an additional label so it's easy for user to see the
 	// name of the original workflow that has been resubmitted.
-	newWF.ObjectMeta.Labels[common.PreviousWorkflowNameLabelKey] = wf.ObjectMeta.Name
+	newWF.ObjectMeta.Labels[common.LabelKeyPreviousWorkflowName] = wf.ObjectMeta.Name
 	for key, val := range wf.ObjectMeta.Annotations {
 		if newWF.ObjectMeta.Annotations == nil {
 			newWF.ObjectMeta.Annotations = make(map[string]string)

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -444,7 +444,10 @@ func updateWorkflowNodeByKey(wfIf v1alpha1.WorkflowInterface, hydrator hydrator.
 	return err
 }
 
-const letters = "abcdefghijklmnopqrstuvwxyz0123456789"
+const (
+	letters                      = "abcdefghijklmnopqrstuvwxyz0123456789"
+	previousWorkflowNameLabelKey = "workflows.argoproj.io/previous-workflow-name"
+)
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
@@ -504,7 +507,7 @@ func FormulateResubmitWorkflow(wf *wfv1.Workflow, memoized bool) (*wfv1.Workflow
 	}
 	// append an additional label so it's easy for user to see what the original workflow is
 	// that has been resubmitted.
-	newWF.ObjectMeta.Labels["workflows.argoproj.io/previous-workflow-name"] = wf.ObjectMeta.Name
+	newWF.ObjectMeta.Labels[previousWorkflowNameLabelKey] = wf.ObjectMeta.Name
 	for key, val := range wf.ObjectMeta.Annotations {
 		if newWF.ObjectMeta.Annotations == nil {
 			newWF.ObjectMeta.Annotations = make(map[string]string)

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -505,8 +505,8 @@ func FormulateResubmitWorkflow(wf *wfv1.Workflow, memoized bool) (*wfv1.Workflow
 		}
 		newWF.ObjectMeta.Labels[key] = val
 	}
-	// append an additional label so it's easy for user to see what the original workflow is
-	// that has been resubmitted.
+	// Append an additional label so it's easy for user to see the
+	// name of the original workflow that has been resubmitted.
 	newWF.ObjectMeta.Labels[previousWorkflowNameLabelKey] = wf.ObjectMeta.Name
 	for key, val := range wf.ObjectMeta.Annotations {
 		if newWF.ObjectMeta.Annotations == nil {

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -444,10 +444,7 @@ func updateWorkflowNodeByKey(wfIf v1alpha1.WorkflowInterface, hydrator hydrator.
 	return err
 }
 
-const (
-	letters                      = "abcdefghijklmnopqrstuvwxyz0123456789"
-	previousWorkflowNameLabelKey = "workflows.argoproj.io/previous-workflow-name"
-)
+const letters = "abcdefghijklmnopqrstuvwxyz0123456789"
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
@@ -507,7 +504,7 @@ func FormulateResubmitWorkflow(wf *wfv1.Workflow, memoized bool) (*wfv1.Workflow
 	}
 	// Append an additional label so it's easy for user to see the
 	// name of the original workflow that has been resubmitted.
-	newWF.ObjectMeta.Labels[previousWorkflowNameLabelKey] = wf.ObjectMeta.Name
+	newWF.ObjectMeta.Labels[common.PreviousWorkflowNameLabelKey] = wf.ObjectMeta.Name
 	for key, val := range wf.ObjectMeta.Annotations {
 		if newWF.ObjectMeta.Annotations == nil {
 			newWF.ObjectMeta.Annotations = make(map[string]string)


### PR DESCRIPTION
Append an additional label so it's easy for user to see the name of the original workflow that has been resubmitted.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
