### PR TITLE
docs: Add additional instructions for installing argo in a kind cluster

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,6 +23,8 @@ kubectl apply -n argo -f https://raw.githubusercontent.com/argoproj/argo/stable/
 
 Namespaced installs as well as installs with MinIO and/or a database built in [are also available](https://github.com/argoproj/argo/tree/stable/manifests).
 
+> NOTE: If you are installing argo in a `kind` cluster, you will need to tweak the `install.yaml` file as suggested in this issue: https://github.com/argoproj/argo/issues/2376
+
 Examples below will assume you've installed argo in the `argo` namespace. If you have not, adjust
 the commands accordingly.
 


### PR DESCRIPTION
Installing argo with the default instructions will result in the examples not working in a kind cluster. The workaround can be found here: https://github.com/argoproj/argo/issues/2376

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [X] (Ticked since not applicable) I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
