### PR TITLE
chore: Use GitHub Actions to build Docker Images to allow publishing Windows Images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,89 @@
+name: Docker Image CI
+
+on:
+  push:
+    tags:
+      - v*
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-linux:
+    name: Build & Push Linux Docker Images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker Login
+        uses: Azure/docker-login@v1
+        with:
+          username: ${{ secrets.DOCKERIO_USERNAME }}
+          password: ${{ secrets.DOCKERIO_PASSWORD }}
+      - name: Build & Push Linux Docker Images
+        env:
+          DOCKERIO_USERNAME: ${{ secrets.DOCKERIO_USERNAME }}
+        run: |
+          docker_org=$DOCKERIO_USERNAME
+          tag=$(basename $GITHUB_REF)
+          targets="workflow-controller argoexec argocli"
+          for target in $targets; do
+            image_name="${docker_org}/${target}:${tag}-linux"
+            docker build --target $target -t $image_name .
+            docker push $image_name
+          done
+
+  build-windows:
+    name: Build & Push Windows Docker Images
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker Login
+        uses: Azure/docker-login@v1
+        with:
+          username: ${{ secrets.DOCKERIO_USERNAME }}
+          password: ${{ secrets.DOCKERIO_PASSWORD }}
+      - name: Build & Push Windows Docker Images
+        env:
+          DOCKERIO_USERNAME: ${{ secrets.DOCKERIO_USERNAME }}
+        run: |
+          docker_org=$DOCKERIO_USERNAME
+          tag=$(basename $GITHUB_REF)
+          targets="argoexec"
+          for target in $targets; do
+            image_name="${docker_org}/${target}:${tag}-windows"
+            docker build --target $target -t $image_name -f Dockerfile.windows .
+            docker push $image_name
+          done
+
+  push-images:
+    name: Push Multiarch Image
+    runs-on: ubuntu-latest
+    needs: [build-linux, build-windows]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker Login
+        uses: Azure/docker-login@v1
+        with:
+          username: ${{ secrets.DOCKERIO_USERNAME }}
+          password: ${{ secrets.DOCKERIO_PASSWORD }}
+      - name: Push Multiarch Image
+        env:
+          DOCKERIO_USERNAME: ${{ secrets.DOCKERIO_USERNAME }}
+        run: |
+          echo $(jq -c '. + { "experimental": "enabled" }' ${DOCKER_CONFIG}/config.json) > ${DOCKER_CONFIG}/config.json
+
+          docker_org=$DOCKERIO_USERNAME
+          tag=$(basename $GITHUB_REF)
+          targets="workflow-controller argoexec argocli"
+          for target in $targets; do
+            image_name="${docker_org}/${target}:${tag}"
+
+            if [ $target = "argoexec" ]; then
+              docker manifest create $image_name ${image_name}-linux ${image_name}-windows
+            else
+              docker manifest create $image_name ${image_name}-linux
+            fi
+
+            docker manifest push $image_name
+          done

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - v*
+    branches:
+      - master
 
 defaults:
   run:
@@ -25,7 +27,12 @@ jobs:
           DOCKERIO_USERNAME: ${{ secrets.DOCKERIO_USERNAME }}
         run: |
           docker_org=$DOCKERIO_USERNAME
+
           tag=$(basename $GITHUB_REF)
+          if [ $tag = "master" ]; then
+            tag="latest"
+          fi
+
           targets="workflow-controller argoexec argocli"
           for target in $targets; do
             image_name="${docker_org}/${target}:${tag}-linux"
@@ -48,7 +55,12 @@ jobs:
           DOCKERIO_USERNAME: ${{ secrets.DOCKERIO_USERNAME }}
         run: |
           docker_org=$DOCKERIO_USERNAME
+
           tag=$(basename $GITHUB_REF)
+          if [ $tag = "master" ]; then
+            tag="latest"
+          fi
+
           targets="argoexec"
           for target in $targets; do
             image_name="${docker_org}/${target}:${tag}-windows"
@@ -74,7 +86,12 @@ jobs:
           echo $(jq -c '. + { "experimental": "enabled" }' ${DOCKER_CONFIG}/config.json) > ${DOCKER_CONFIG}/config.json
 
           docker_org=$DOCKERIO_USERNAME
+
           tag=$(basename $GITHUB_REF)
+          if [ $tag = "master" ]; then
+            tag="latest"
+          fi
+
           targets="workflow-controller argoexec argocli"
           for target in $targets; do
             image_name="${docker_org}/${target}:${tag}"


### PR DESCRIPTION
As mentioned in #2747 Docker Hub Automated Build Hooks don't allow to build Windows images. As v2.9.0 comes with Windows support for argoexec and as you migrated CI to GitHub Actions also, it would make sense to use GitHub Actions also for building the Docker images.

I added a workflow file which builds and pushes the images for Linux (workflow-controller, argoexec, argocli) and Windows (argoexec only) whenever a new tag `v*` is pushed. I used the existing Docker Hub Hooks (https://github.com/argoproj/argo/blob/master/hooks/build) as a base for the scripts. The jobs building and pushing the images are appending `-linux` or `-windows` to the tag, a third job is creating a Manifest and pushes it to allow for multiarch. Example:

1. Tag `v2.9.0` is pushed
1. Job `build-linux` is building and pushing `argoproj/workflow-controller:v2.9.0-linux`, `argoproj/argoexec:v2.9.0-linux` `argoproj/argocli:v2.9.0-linux`
1. Job `build-windows` is building and pushing `argoproj/argoexec:v2.9.0-windows`
1. Job `push-images` is creating and pushing the following image manifest:
   - `argoproj/workflow-controller:v2.9.0` referencing `argoproj/workflow-controller:v2.9.0-linux`
   - `argoproj/argoexec:v2.9.0` referencing `argoproj/argoexec:v2.9.0-linux` and `argoproj/argoexec:v2.9.0-windows` (multiarch)
   - `argoproj/argocli:v2.9.0` referencing `argoproj/argocli:v2.9.0-linux`

You can find an example run for a tag `vtest17` here: https://github.com/lippertmarkus/argo/runs/804344322
Resulting image, e.g. for argoexec: https://hub.docker.com/repository/docker/lippertmarkus/argoexec/tags

You only need to add the following two secrets like described [in the GitHub Actions Help](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets-for-a-repository) before merging:
- `DOCKERIO_USERNAME` = `argoproj`
- `DOCKERIO_PASSWORD` = `<a-docker-hub-pat-token>`

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or **(c) this is a chore**.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged. 
  - not needed
* [x] My builds are green. Try syncing with master if they are not. 

