### PR TITLE
build: Fix path to go-to-protobuf binary

### DIFF
--- a/hack/generate-proto.sh
+++ b/hack/generate-proto.sh
@@ -8,7 +8,7 @@ go get github.com/gogo/protobuf/protoc-gen-gogofast@v1.3.1
 go get github.com/gogo/protobuf/gogoproto@v1.3.1
 go get golang.org/x/tools/cmd/goimports@v0.0.0-20200428211428-0c9eba77bc32
 go install k8s.io/code-generator/cmd/go-to-protobuf
-$GOPATH/bin/go-to-protobuf \
+${GOPATH}/bin/go-to-protobuf \
     --go-header-file=./hack/custom-boilerplate.go.txt \
     --packages=github.com/argoproj/argo/pkg/apis/workflow/v1alpha1 \
     --apimachinery-packages=+k8s.io/apimachinery/pkg/util/intstr,+k8s.io/apimachinery/pkg/api/resource,k8s.io/apimachinery/pkg/runtime/schema,+k8s.io/apimachinery/pkg/runtime,k8s.io/apimachinery/pkg/apis/meta/v1,k8s.io/api/core/v1,k8s.io/api/policy/v1beta1  \

--- a/hack/generate-proto.sh
+++ b/hack/generate-proto.sh
@@ -8,7 +8,7 @@ go get github.com/gogo/protobuf/protoc-gen-gogofast@v1.3.1
 go get github.com/gogo/protobuf/gogoproto@v1.3.1
 go get golang.org/x/tools/cmd/goimports@v0.0.0-20200428211428-0c9eba77bc32
 go install k8s.io/code-generator/cmd/go-to-protobuf
-go-to-protobuf \
+$GOPATH/bin/go-to-protobuf \
     --go-header-file=./hack/custom-boilerplate.go.txt \
     --packages=github.com/argoproj/argo/pkg/apis/workflow/v1alpha1 \
     --apimachinery-packages=+k8s.io/apimachinery/pkg/util/intstr,+k8s.io/apimachinery/pkg/api/resource,k8s.io/apimachinery/pkg/runtime/schema,+k8s.io/apimachinery/pkg/runtime,k8s.io/apimachinery/pkg/apis/meta/v1,k8s.io/api/core/v1,k8s.io/api/policy/v1beta1  \


### PR DESCRIPTION

Avoid error like the following:
```
+ go install k8s.io/code-generator/cmd/go-to-protobuf
+ go-to-protobuf --go-header-file=./hack/custom-boilerplate.go.txt --packages=github.com/argoproj/argo/pkg/apis/workflow/v1alpha1 --apimachinery-packages=+k8s.io/apimachinery/pkg/util/intstr,+k8s.io/apimachinery/pkg/api/resource,k8s.io/apimachinery/pkg/runtime/schema,+k8s.io/apimachinery/pkg/runtime,k8s.io/apimachinery/pkg/apis/meta/v1,k8s.io/api/core/v1,k8s.io/api/policy/v1beta1 --proto-import ./vendor
./hack/generate-proto.sh: line 12: go-to-protobuf: command not found
make: *** [Makefile:281: proto] Error 127
```

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
