### PR TITLE
feat: Handle omitted nodes in DAG enhanced depends logic

### DIFF
--- a/docs/enhanced-depends-logic.md
+++ b/docs/enhanced-depends-logic.md
@@ -24,6 +24,7 @@ available task results is as follows:
 | `.Failed` | Task Failed |
 | `.Errored` | Task Errored |
 | `.Skipped` | Task Skipped |
+| `.Omitted` | Task Omitted |
 | `.Daemoned` | Task is Daemoned and is not Pending |
 
 For convenience, if an omitted task result is equivalent to `(task.Succeeded || task.Skipped || task.Daemoned)`.

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -622,6 +622,7 @@ type TaskResults struct {
 	Failed    bool `json:"Failed"`
 	Errored   bool `json:"Errored"`
 	Skipped   bool `json:"Skipped"`
+	Omitted   bool `json:"Omitted"`
 	Daemoned  bool `json:"Daemoned"`
 }
 
@@ -648,6 +649,7 @@ func (d *dagContext) evaluateDependsLogic(taskName string) (bool, bool, error) {
 			Failed:    depNode.Phase == wfv1.NodeFailed,
 			Errored:   depNode.Phase == wfv1.NodeError,
 			Skipped:   depNode.Phase == wfv1.NodeSkipped,
+			Omitted:   depNode.Phase == wfv1.NodeOmitted,
 			Daemoned:  depNode.IsDaemoned() && depNode.Phase != wfv1.NodePending,
 		}
 	}


### PR DESCRIPTION
A node is initialized with omitted phase when its depends condition not met as in the code below: https://github.com/argoproj/argo/blob/60c86c84c60ac38c5a876d8df5362b5896700d73/workflow/controller/dag.go#L378

However, another node might depend on this omitted node and the current code does not handle this yet.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
