### PR TITLE
feat: Save pagination limit and selected phases/labels to local storage

### DIFF
--- a/ui/src/app/shared/components/checkbox-filter/checkbox-filter.tsx
+++ b/ui/src/app/shared/components/checkbox-filter/checkbox-filter.tsx
@@ -40,7 +40,7 @@ export class CheckboxFilter extends React.Component<Props> {
                                         }}
                                     />{' '}
                                     <label title={item.name} htmlFor={`filter-${this.props.type}-${item.name}`}>
-                                        {item.name} ({item.count})
+                                        {item.name}
                                     </label>
                                 </div>
                             </div>

--- a/ui/src/app/shared/components/pagination-panel.tsx
+++ b/ui/src/app/shared/components/pagination-panel.tsx
@@ -25,7 +25,7 @@ export class PaginationPanel extends React.Component<{pagination: Pagination; on
                 {this.props.pagination.limit ? (
                     <>
                         <span className={'fa fa-exclamation-triangle'} style={{color: '#d7b700'}} />
-                        There is no global Workflow sort when pagination is enabled
+                        Workflows cannot be globally sorted when paginated
                     </>
                 ) : (
                     <span />

--- a/ui/src/app/shared/components/pagination-panel.tsx
+++ b/ui/src/app/shared/components/pagination-panel.tsx
@@ -22,6 +22,14 @@ export class PaginationPanel extends React.Component<{pagination: Pagination; on
                     }>
                     Next page <i className='fa fa-chevron-right' />
                 </button>
+                {this.props.pagination.limit ? (
+                    <>
+                        <span className={'fa fa-exclamation-triangle'} style={{color: '#d7b700'}} />
+                        There is no global Workflow sort when pagination is enabled
+                    </>
+                ) : (
+                    <span />
+                )}
                 <small className='fa-pull-right'>
                     <select
                         className='small'


### PR DESCRIPTION
This PR:

* Saves pagination and label/phase selection preferences in the Workflow List page to local storage

* Adds a warning that Workflows aren't globally sorted when paginating them:
<img width="1018" alt="image" src="https://user-images.githubusercontent.com/614838/85877623-48a07080-b78c-11ea-8363-a41ae67ad945.png">

* Removes the count in the phase selection box since these only display the number of Workflows actually sent to the UI instead of the number of Workflows that exist in the cluster. This could cause some confusion