### PR TITLE
chore: Avoid variable name collision with imported package name

### DIFF
--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -203,9 +203,9 @@ func ApplySubmitOpts(wf *wfv1.Workflow, opts *wfv1.SubmitOpts) error {
 	if opts.ServiceAccount != "" {
 		wf.Spec.ServiceAccountName = opts.ServiceAccount
 	}
-	labels := wf.GetLabels()
-	if labels == nil {
-		labels = make(map[string]string)
+	wfLabels := wf.GetLabels()
+	if wfLabels == nil {
+		wfLabels = make(map[string]string)
 	}
 	if opts.Labels != "" {
 		passedLabels, err := cmdutil.ParseLabels(opts.Labels)
@@ -213,10 +213,10 @@ func ApplySubmitOpts(wf *wfv1.Workflow, opts *wfv1.SubmitOpts) error {
 			return fmt.Errorf("Expected labels of the form: NAME1=VALUE2,NAME2=VALUE2. Received: %s", opts.Labels)
 		}
 		for k, v := range passedLabels {
-			labels[k] = v
+			wfLabels[k] = v
 		}
 	}
-	wf.SetLabels(labels)
+	wf.SetLabels(wfLabels)
 	if len(opts.Parameters) > 0 || opts.ParameterFile != "" {
 		newParams := make([]wfv1.Parameter, 0)
 		passedParams := make(map[string]bool)


### PR DESCRIPTION
Removes the warning `Variable 'labels' collides with imported package name`. The imported package is `"k8s.io/apimachinery/pkg/labels"`.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
