### PR TITLE
fix(docs): Fix incorrect example of global parameter usage

### DIFF
--- a/examples/global-outputs.yaml
+++ b/examples/global-outputs.yaml
@@ -37,7 +37,7 @@ spec:
 
   # Once exported, global outputs are referenceable in later parts of the workflow.
   # In this example, the consume-globals template is invoked after the generate-globals step, as
-  # well as in the onExit handler. and can reference the globals, my-global-param and my-global-art.
+  # well as in the onExit handler, and can reference the globals, my-global-param and my-global-art.
   - name: consume-globals
     steps:
     - - name: consume-global-param
@@ -50,10 +50,14 @@ spec:
             from: "{{workflow.outputs.artifacts.my-global-art}}"
 
   - name: consume-global-param
+    inputs:
+      parameters:
+        - name: param
+          value: "{{workflow.outputs.parameters.my-global-param}}"
     container:
       image: alpine:3.7
       command: [sh, -c]
-      args: ["echo {{workflow.outputs.parameters.my-global-param}}"]
+      args: ["echo {{inputs.parameters.param}}"]
 
   - name: consume-global-art
     inputs:


### PR DESCRIPTION
The global param needs to be passed as an input, not used directly.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
