### PR TITLE
feat(cli): Allow to view previously terminated container logs

### DIFF
--- a/cmd/argo/commands/logs.go
+++ b/cmd/argo/commands/logs.go
@@ -92,6 +92,7 @@ func NewLogsCommand() *cobra.Command {
 	}
 	command.Flags().StringVarP(&logOptions.Container, "container", "c", "main", "Print the logs of this container")
 	command.Flags().BoolVarP(&logOptions.Follow, "follow", "f", false, "Specify if the logs should be streamed.")
+	command.Flags().BoolVarP(&logOptions.Previous, "previous", "p", false, "Specify if the previously terminated container logs should be returned.")
 	command.Flags().DurationVar(&since, "since", 0, "Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs. Only one of since-time / since may be used.")
 	command.Flags().StringVar(&sinceTime, "since-time", "", "Only return logs after a specific date (RFC3339). Defaults to all logs. Only one of since-time / since may be used.")
 	command.Flags().Int64Var(&tailLines, "tail", -1, "If set, the number of lines from the end of the logs to show. If not specified, logs are shown from the creation of the container or sinceSeconds or sinceTime")

--- a/cmd/argo/commands/submit.go
+++ b/cmd/argo/commands/submit.go
@@ -257,6 +257,7 @@ func waitWatchOrLog(ctx context.Context, serviceClient workflowpkg.WorkflowServi
 			logWorkflow(ctx, serviceClient, namespace, workflow, "", &corev1.PodLogOptions{
 				Container: "main",
 				Follow:    true,
+				Previous:  false,
 			})
 		}
 	}


### PR DESCRIPTION
This is useful when we want to see the snapshot of previously terminated container logs.


Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
