### PR TITLE
fix(docs): Update kubectl proxy URL

### DIFF
--- a/docs/argo-server.md
+++ b/docs/argo-server.md
@@ -84,7 +84,7 @@ Then visit: http://127.0.0.1:8001
 kubectl proxy
 ```
 
-Then visit: http://127.0.0.1:8001/api/v1/namespaces/argo/services/argo-ui/proxy/
+Then visit: http://127.0.0.1:8001/api/v1/namespaces/argo/services/argo-server:web/proxy/
 
 NOTE: artifact download and webconsole is not supported using this method
 


### PR DESCRIPTION
Minor docs update.

After moving from `argo-ui` to the `argo-server` Service, the URL has become outdated.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
