### PR TITLE
feat(ui): Add correct timezone to logs timestamps. Fix #3474

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-controller: ALWAYS_OFFLOAD_NODE_STATUS=${ALWAYS_OFFLOAD_NODE_STATUS} OFFLOAD_NODE_STATUS_TTL=30s WORKFLOW_GC_PERIOD=30s UPPERIO_DB_DEBUG=1 ARCHIVED_WORKFLOW_GC_PERIOD=30s ./dist/workflow-controller --executor-image argoproj/argoexec:${VERSION} --namespaced --loglevel ${LOG_LEVEL}
+controller: ALWAYS_OFFLOAD_NODE_STATUS=${ALWAYS_OFFLOAD_NODE_STATUS} OFFLOAD_NODE_STATUS_TTL=30s WORKFLOW_GC_PERIOD=30s UPPERIO_DB_DEBUG=1 ARCHIVED_WORKFLOW_GC_PERIOD=30s ./dist/workflow-controller --executor-image argoproj/argoexec:${VERSION} --namespaced --loglevel ${LOG_LEVEL} --executor-image-pull-policy IfNotPresent
 argo-server: UPPERIO_DB_DEBUG=1 ./dist/argo --loglevel ${LOG_LEVEL} server --namespaced --auth-mode ${AUTH_MODE} --secure=$SECURE

--- a/ui/src/app/shared/services/workflows-service.ts
+++ b/ui/src/app/shared/services/workflows-service.ts
@@ -132,7 +132,10 @@ export class WorkflowsService {
                 `api/v1/workflows/${workflow.metadata.namespace}/${workflow.metadata.name}/${nodeId}/log` + `?logOptions.container=${container}&logOptions.follow=true`
             )
             .pipe(
-                map(line => JSON.parse(line).result.content),
+                map(line => {
+                    console.log(JSON.parse(line))
+                    return JSON.parse(line).result.content;
+                }),
                 catchError(() => logsFromArtifacts)
             );
     }


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

---

In `ui/src/app/shared/services/workflows-service.ts`:

```typescript
    public getContainerLogs(workflow: Workflow, nodeId: string, container: string, archived: boolean): Observable<string> {
        // we firstly try to get the logs from the API,
        // but if that fails, then we try and get them from the artifacts
        const logsFromArtifacts: Observable<string> = Observable.create((observer: Observer<string>) => {
            requests
                .get(this.getArtifactLogsUrl(workflow, nodeId, container, archived))
                .then(resp => {
                    resp.text.split('\n').forEach(line => observer.next(line));
                })
                .catch(err => observer.error(err));
            // tslint:disable-next-line
            return () => {};
        });
        return requests
            .loadEventSource(
                `api/v1/workflows/${workflow.metadata.namespace}/${workflow.metadata.name}/${nodeId}/log` + `?logOptions.container=${container}&logOptions.follow=true`
            )
            .pipe(
                map(line => {
                    console.log(JSON.parse(line))
                    return JSON.parse(line).result.content;
                }),
                catchError(() => logsFromArtifacts)
            );
    }
```

The object `JSON.parse(line)` contains:

![image](https://user-images.githubusercontent.com/528003/87564131-0765f700-c68e-11ea-80bb-58718838a964.png)

Where the timestamp and log are already concatenated as one string.

A clean way is to have the server returning two keys: one for the timestamp and one with the log content. That would be easier to format the timestamp.

The alternative is to extract the timestamp from the string, format it correctly and then reconstruct the final string to be logged.

Not sure which approach should be taken here.

