### PR TITLE
fix: link to server auth mode docs, adds Tulip as official user

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -74,6 +74,6 @@ Currently, the following organizations are **officially** using Argo Workflows:
 1. [Styra](https://www.styra.com/)
 1. [Threekit](https://www.threekit.com/)
 1. [Tiger Analytics](https://www.tigeranalytics.com/)
+1. [Tulip](https://tulip.com/)
 1. [Wavefront](https://www.wavefront.com/)
 1. [Wellcome Trust](https://wellcome.ac.uk/)
-1. [Tulip](https://tulip.com/)

--- a/USERS.md
+++ b/USERS.md
@@ -76,3 +76,4 @@ Currently, the following organizations are **officially** using Argo Workflows:
 1. [Tiger Analytics](https://www.tigeranalytics.com/)
 1. [Wavefront](https://www.wavefront.com/)
 1. [Wellcome Trust](https://wellcome.ac.uk/)
+1. [Tulip](https://tulip.com/)

--- a/cmd/argo/commands/server.go
+++ b/cmd/argo/commands/server.go
@@ -130,7 +130,7 @@ See %s`, help.ArgoSever),
 	// "-e" for encrypt, like zip
 	command.Flags().BoolVarP(&secure, "secure", "e", false, "Whether or not we should listen on TLS.")
 	command.Flags().BoolVar(&htst, "hsts", true, "Whether or not we should add a HTTP Secure Transport Security header. This only has effect if secure is enabled.")
-	command.Flags().StringArrayVar(&authModes, "auth-mode", []string{"server"}, "API server authentication mode. Any permutation of: client,server,sso")
+	command.Flags().StringArrayVar(&authModes, "auth-mode", []string{"server"}, "API server authentication mode. Any 1 or more length permutation of: client,server,sso")
 	command.Flags().StringVar(&configMap, "configmap", "workflow-controller-configmap", "Name of K8s configmap to retrieve workflow controller configuration")
 	command.Flags().BoolVar(&namespaced, "namespaced", false, "run as namespaced mode")
 	command.Flags().StringVar(&managedNamespace, "managed-namespace", "", "namespace that watches, default to the installation namespace")

--- a/cmd/argo/commands/server.go
+++ b/cmd/argo/commands/server.go
@@ -130,7 +130,7 @@ See %s`, help.ArgoSever),
 	// "-e" for encrypt, like zip
 	command.Flags().BoolVarP(&secure, "secure", "e", false, "Whether or not we should listen on TLS.")
 	command.Flags().BoolVar(&htst, "hsts", true, "Whether or not we should add a HTTP Secure Transport Security header. This only has effect if secure is enabled.")
-	command.Flags().StringArrayVar(&authModes, "auth-mode", []string{"server"}, "API server authentication mode. One of: client|server|sso")
+	command.Flags().StringArrayVar(&authModes, "auth-mode", []string{"server"}, "API server authentication mode. Any permutation of: client,server,sso")
 	command.Flags().StringVar(&configMap, "configmap", "workflow-controller-configmap", "Name of K8s configmap to retrieve workflow controller configuration")
 	command.Flags().BoolVar(&namespaced, "namespaced", false, "run as namespaced mode")
 	command.Flags().StringVar(&managedNamespace, "managed-namespace", "", "namespace that watches, default to the installation namespace")

--- a/docs/argo-server-auth-mode.md
+++ b/docs/argo-server-auth-mode.md
@@ -4,7 +4,6 @@ You can choose which kube config the Argo Server uses:
 
 * "server" - in hosted mode, use the kube config of service account, in local mode, use your local kube config.
 * "client" - requires clients to provide their Kubernetes bearer token and use that.
-* "hybrid" - use the client token if provided, fallback to the server token if note.
 * "sso" - since v2.9, use single sign-on, this will use the same service account as per "server" for RBAC. We expect to change this in the future so that the OAuth claims are mapped to service accounts.
 
 By default, the server will start with auth mode of "server".

--- a/docs/argo-server-auth-mode.md
+++ b/docs/argo-server-auth-mode.md
@@ -7,3 +7,8 @@ You can choose which kube config the Argo Server uses:
 * "sso" - since v2.9, use single sign-on, this will use the same service account as per "server" for RBAC. We expect to change this in the future so that the OAuth claims are mapped to service accounts.
 
 By default, the server will start with auth mode of "server".
+
+To change the server auth mode specify the list as multiple auth-mode flags:
+```
+argo server --auth-mode sso --auth-mode ...
+```

--- a/docs/argo-server-auth-mode.md
+++ b/docs/argo-server-auth-mode.md
@@ -4,7 +4,7 @@ You can choose which kube config the Argo Server uses:
 
 * "server" - in hosted mode, use the kube config of service account, in local mode, use your local kube config.
 * "client" - requires clients to provide their Kubernetes bearer token and use that.
-* "sso" - since v2.9, use single sign-on, this will use the same service account as per "server" for RBAC. We expect to change this in the future so that the OAuth claims are mapped to service accounts.
+* ["sso"](./argo-server-sso.md) - since v2.9, use single sign-on, this will use the same service account as per "server" for RBAC. We expect to change this in the future so that the OAuth claims are mapped to service accounts.
 
 By default, the server will start with auth mode of "server".
 

--- a/docs/cli/argo_server.md
+++ b/docs/cli/argo_server.md
@@ -20,7 +20,7 @@ See https://github.com/argoproj/argo/blob/master/docs/argo-server.md
 ### Options
 
 ```
-      --auth-mode stringArray      API server authentication mode. One of: client|server|sso (default [server])
+      --auth-mode stringArray      API server authentication mode. Any 1 or more length permutation of: client,server,sso (default [server])
       --basehref string            Value for base href in index.html. Used if the server is running behind reverse proxy under subpath different from /. Defaults to the environment variable BASE_HREF. (default "/")
   -b, --browser                    enable automatic launching of the browser [local mode]
       --configmap string           Name of K8s configmap to retrieve workflow controller configuration (default "workflow-controller-configmap")

--- a/ui/src/app/login/components/login.tsx
+++ b/ui/src/app/login/components/login.tsx
@@ -22,7 +22,7 @@ export const Login = () => (
                 </h3>
                 <p>It may not be necessary to be logged in to use Argo Workflows, it depends on how it is configured.</p>
                 <p>
-                    <a href='https://github.com/argoproj/argo/blob/master/docs/argo-server-auth.md'>Learn more</a>.
+                    <a href='https://github.com/argoproj/argo/blob/master/docs/argo-server-auth-mode.md'>Learn more</a>.
                 </p>
             </div>
 


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

