### PR TITLE
build: Clear cmd docs before generating them

### DIFF
--- a/hack/docgen.go
+++ b/hack/docgen.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/spf13/cobra/doc"
 
-	commands "github.com/argoproj/argo/cmd/argo/commands"
+	"github.com/argoproj/argo/cmd/argo/commands"
 )
 
 const sectionHeader = `
@@ -342,10 +342,33 @@ func (c *DocGeneratorContext) generate() string {
 	return out
 }
 
+func removeContents(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = d.Close() }()
+	names, err := d.Readdirnames(-1)
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		err = os.RemoveAll(filepath.Join(dir, name))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func generateDocs() {
 	cmd := commands.NewCommand()
 	cmd.DisableAutoGenTag = true
-	err := doc.GenMarkdownTree(cmd, "docs/cli")
+	err := removeContents("docs/cli")
+	if err != nil {
+		panic(err)
+	}
+	err = doc.GenMarkdownTree(cmd, "docs/cli")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Although very rare, if we were to remove or move a command, the old doc would be persisted. This PR removes all cmd docs before they're generated to ensure that only the desired docs remain.