### PR TITLE
fix: String interpreted as boolean in labels

### DIFF
--- a/examples/hello-world.yaml
+++ b/examples/hello-world.yaml
@@ -3,7 +3,7 @@ kind: Workflow
 metadata:
   generateName: hello-world-
   labels:
-    workflows.argoproj.io/archive-strategy: false
+    workflows.argoproj.io/archive-strategy: "false"
 spec:
   entrypoint: whalesay
   templates:


### PR DESCRIPTION
Running this without quotes results in the following error:
```
error: unable to decode "https://raw.githubusercontent.com/argoproj/argo/master/examples/hello-world.yaml": resource.metadataOnlyObject.ObjectMeta: v1.ObjectMeta.Labels: ReadString: expects " or n, but found f, error found in #10 byte of ...|trategy":false}},"sp|..., bigger context ...|abels":{"workflows.argoproj.io/archive-strategy":false}},"spec":{"entrypoint":"whalesay","templates"|...
```

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
