### PR TITLE
docs: Migrate to homebrew-core (#3567)

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -66,11 +66,16 @@ git push -f origin stable
 
 If this is GA:
 
-* [ ] Update the [Homebrew tap](https://github.com/argoproj/homebrew-tap).
-* [ ] Check Homebrew was successfully updated:
+* [ ] Update the Homebrew formula.
+
+```bash
+brew bump-formula-pr argo --version $VERSION
+```
+
+* [ ] Check that Homebrew was successfully updated after the PR was merged:
  
  ```
- brew upgrade argoproj/tap/argo
+ brew upgrade argo
  argo version
  ```
 


### PR DESCRIPTION
I created formulas for Argo CLI and Argo CD in the official homebrew-core repository (https://github.com/Homebrew/homebrew-core/pull/58259). This change changes the documentation to use that repo instead of your own tap.

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
