### PR TITLE
docs: Correct indentation for codeblocks within bullet-points for "workflow-templates"

### DIFF
--- a/docs/workflow-templates.md
+++ b/docs/workflow-templates.md
@@ -19,33 +19,33 @@ in the past. However, a quick description should clarify each and their differen
 `Workflow`, you must define at least one (but usually more than one) `template` to run. This `template` can be of type
 `container`, `script`, `dag`, `steps`, `resource`, or `suspend` and can be referenced by an `entrypoint` or by other
 `dag`, and `step` templates.
-    
-    Here is an example of a `Workflow` with two `templates`:
-    ```yaml
-    apiVersion: argoproj.io/v1alpha1
-    kind: Workflow
-    metadata:
-      generateName: steps-
-    spec:
-      entrypoint: hello           # We reference our first "template" here
-  
-      templates:
-      - name: hello               # The first "template" in this Workflow, it is referenced by "entrypoint"
-        steps:                    # The type of this "template" is "steps"
-        - - name: hello
-            template: whalesay    # We reference our second "template" here
-            arguments:
-              parameters: [{name: message, value: "hello1"}]
-    
-      - name: whalesay             # The second "template" in this Workflow, it is referenced by "hello"
-        inputs:
-          parameters:
-          - name: message
-        container:                # The type of this "template" is "container"
-          image: docker/whalesay
-          command: [cowsay]
-          args: ["{{inputs.parameters.message}}"]
-    ```
+ 
+Here is an example of a `Workflow` with two `templates`:
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: steps-
+spec:
+  entrypoint: hello           # We reference our first "template" here
+
+  templates:
+  - name: hello               # The first "template" in this Workflow, it is referenced by "entrypoint"
+    steps:                    # The type of this "template" is "steps"
+    - - name: hello
+        template: whalesay    # We reference our second "template" here
+        arguments:
+          parameters: [{name: message, value: "hello1"}]
+
+  - name: whalesay             # The second "template" in this Workflow, it is referenced by "hello"
+    inputs:
+      parameters:
+      - name: message
+    container:                # The type of this "template" is "container"
+      image: docker/whalesay
+      command: [cowsay]
+      args: ["{{inputs.parameters.message}}"]
+```
   
 - A `WorkflowTemplate` is a definition of a `Workflow` that lives in your cluster. Since it is a definition of a `Workflow`
 it also contains `templates`. These `templates` can be referenced from within the `WorkflowTemplate` and from other `Workflows`


### PR DESCRIPTION
The problem can only be seen in the `docs` at https://argoproj.github.io/argo/workflow-templates/
Githubs Markdown flavour does understand codeblocks within bullet points, but the compilation from `Markdown -> html`, seems to have a problem with that.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, **(b) this is a bug fix**, or (c) this is a chore.
* [X] The title of the PR is **(a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed,** and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [X] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
