### PR TITLE
fix(server): Report v1.Status errors. Fixes #3608

### DIFF
--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -7,6 +7,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo/errors"
@@ -168,12 +169,8 @@ func (s *workflowServer) WatchWorkflows(req *workflowpkg.WatchWorkflowsRequest, 
 		select {
 		case <-ctx.Done():
 			return nil
-		case event, ok := <-watch.ResultChan():
-			var wf *wfv1.Workflow
-			if ok {
-				wf, ok = event.Object.(*wfv1.Workflow)
-			}
-			if !ok {
+		case event, open := <-watch.ResultChan():
+			if !open {
 				log.Debug("Re-establishing workflow watch")
 				watch.Stop()
 				watch, err = wfIf.Watch(*opts)
@@ -183,6 +180,11 @@ func (s *workflowServer) WatchWorkflows(req *workflowpkg.WatchWorkflowsRequest, 
 				continue
 			}
 			log.Debug("Received event")
+			wf, ok := event.Object.(*wfv1.Workflow)
+			if !ok {
+				// object is probably probably metav1.Status, `FromObject` can deal with anything
+				return apierr.FromObject(event.Object)
+			}
 			logCtx := log.WithFields(log.Fields{"workflow": wf.Name, "type": event.Type, "phase": wf.Status.Phase})
 			err := s.hydrator.Hydrate(wf)
 			if err != nil {


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

Fixes #3608

I was incorrect in my solution to #3608. Re-establishing a watch can result in an infinite loop and therefore the server consuming 100% CPU. One instance when this happens is when `listOptions.resourceVersion` has "too old resource version" (e.g. old browser window left open). 

This PR does:

* Essentially reverts the original fix.
* Reports `v1.Status` errors as warnings rather than error in the `workflow-logger.go`.
* Return a `v1.Status` error back to the client for workflow watch.