### PR TITLE
build: Disable TLS in dev server

### DIFF
--- a/ui/src/app/webpack.config.js
+++ b/ui/src/app/webpack.config.js
@@ -77,19 +77,19 @@ const config = {
     },
     proxy: {
       "/api": {
-        "target": isProd ? "" : "https://localhost:2746",
+        "target": isProd ? "" : "http://localhost:2746",
         "secure": false
       },
       "/artifacts": {
-        "target": isProd ? "" : "https://localhost:2746",
+        "target": isProd ? "" : "http://localhost:2746",
         "secure": false
       },
       "/artifacts-by-uid": {
-        "target": isProd ? "" : "https://localhost:2746",
+        "target": isProd ? "" : "http://localhost:2746",
         "secure": false
       },
       '/oauth2': {
-        'target': isProd ? '' : 'https://localhost:2746',
+        'target': isProd ? '' : 'http://localhost:2746',
         'secure': false,
       },
     }


### PR DESCRIPTION
Following the changes in https://github.com/argoproj/argo/pull/3618, disable TLS in the dev webpack server