### PR TITLE
fix(executor): Add retry on pods watch to handle timeout.

### DIFF
--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -945,7 +945,6 @@ func (we *WorkflowExecutor) waitMainContainerStart() (string, error) {
 		opts := metav1.ListOptions{
 			FieldSelector: fieldSelector.String(),
 		}
-		log.Infof("Try to start watching")
 
 		var err error
 		var watchIf watch.Interface
@@ -953,13 +952,12 @@ func (we *WorkflowExecutor) waitMainContainerStart() (string, error) {
 		err = wait.ExponentialBackoff(MainContainerStartRetry, func() (bool, error) {
 			watchIf, err = podsIf.Watch(opts)
 			if err != nil {
-				log.Debugf("Error retry watching: %v", err)
+				log.Debugf("Failed to establish watch, retrying: %v", err)
 				return false, nil
 			}
 			return true, nil
 		})
 		if err != nil {
-			log.Warnf("Exponential retry reached: %v", err)
 			return "", errors.InternalWrapErrorf(err, "Failed to establish pod watch: %v", err)
 		}
 		for watchEv := range watchIf.ResultChan() {


### PR DESCRIPTION

Create a retryer for MainContainerStart.
Add exponential retry for watch pod that can cause issue when using k8sapi executor.
With help of @jsenon

Change after review of #3204

Fixes #3007
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
