### PR TITLE
fix: Re-introduce 1 second sleep to reconcile informer

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -517,6 +517,20 @@ func (woc *wfOperationCtx) persistUpdates() {
 
 	woc.log.WithFields(log.Fields{"resourceVersion": woc.wf.ResourceVersion, "phase": woc.wf.Status.Phase}).Info("Workflow update successful")
 
+	// HACK(jessesuen) after we successfully persist an update to the workflow, the informer's
+	// cache is now invalid. It's very common that we will need to immediately re-operate on a
+	// workflow due to queuing by the pod workers. The following sleep gives a *chance* for the
+	// informer's cache to catch up to the version of the workflow we just persisted. Without
+	// this sleep, the next worker to work on this workflow will very likely operate on a stale
+	// object and redo work.
+	//
+	// This line was removed in v2.9.0, but issues arose with the controller picking up outdated versions of workflows,
+	// operating on them, then attempting to update the resources on the cluster. Since the workflows were outdated,
+	// conflicts arose when attempting to update, causing our conflict resolution code to be invoked. The conflict
+	// resolution code was not perfect and workflow information was not correctly persisted, causing undefined behavior.
+	// This line was reintroduced in v2.9.5, and should remain as long as we use our current informer pattern.
+	time.Sleep(1 * time.Second)
+
 	// It is important that we *never* label pods as completed until we successfully updated the workflow
 	// Failing to do so means we can have inconsistent state.
 	// TODO: The completedPods will be labeled multiple times. I think it would be improved in the future.


### PR DESCRIPTION
Fixes: #3665

This line was removed in v2.9.0, but issues arose with the controller picking up outdated versions of workflows, operating on them, then attempting to update the resources on the cluster. Since the workflows were outdated, conflicts arose when attempting to update, causing our conflict resolution code to be invoked. The conflict resolution code was not perfect and workflow information was not correctly persisted, causing undefined behavior.

Testing procedure:

1. Make a build without this line.
2. Run multiple workflows
3. See undefined behavior (hanging pending pods, hanging running nodes, etc.); see the following log:
    ```
    Error updating workflow: Operation cannot be fulfilled on workflows.argoproj.io \""WF_NAME\"": the object has been modified; please apply your changes to the latest version and try again Conflict"
    ```
4. Make a build containing this line.
5. Run multiple workflows
6. See no undefined behavior; don't see the problematic log.