### PR TITLE
fix: Consider all children of TaskGroups in DAGs (alternate solution)

### DIFF
--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -158,12 +158,9 @@ func (d *dagContext) assessDAGPhase(targetTasks []string, nodes wfv1.Nodes) wfv1
 			}
 		}
 
-		if node.Type == wfv1.NodeTypeRetry || node.Type == wfv1.NodeTypeTaskGroup {
+		if node.Type == wfv1.NodeTypeRetry {
 			// A fulfilled Retry node will always reflect the status of its last child node, so its individual attempts don't interest us.
 			// To resume the traversal, we look at the children of the last child node.
-			// A TaskGroup node will always reflect the status of its expanded tasks (mainly it will be Succeeded if and only if all of its
-			// expanded tasks have succeeded), so each individual expanded task doesn't interest us. To resume the traversal, we look at the
-			// children of its last child node (note that this is arbitrary, since all expanded tasks will have the same children).
 			if childNode := getChildNodeIndex(&node, nodes, -1); childNode != nil {
 				uniqueQueue.add(generatePhaseNodes(childNode.Children, branchPhase)...)
 			}

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -120,7 +120,7 @@ func (d *dagContext) getTaskNode(taskName string) *wfv1.NodeStatus {
 // isExpandedNode returns true if this node is a result of a task expansion (i.e. withParam, withItems, etc.)
 // nodeName should be the name of the node, not the task
 func isExpandedNode(nodeName string) bool {
-	return strings.Contains("(", nodeName)
+	return strings.Contains(nodeName, "(")
 }
 
 // assessDAGPhase assesses the overall DAG status


### PR DESCRIPTION
Alternate solution to https://github.com/argoproj/argo/pull/3740

In this case we determine if the children of a `TaskGroup` are expanded nodes, if they are we use the "shortcut" and not if they are not.

Fixes #3739
Fixes https://github.com/argoproj/argo/issues/3780