### PR TITLE
docs: Correct typo in `--instanceid` 

### DIFF
--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -44,7 +44,7 @@ data:
 You'll may need to pass the instance ID to the CLI:
 
 ```
-argo --instance-id i1 submit my-wf.yaml
+argo --instanceid i1 submit my-wf.yaml
 ```
 
 You do not need to have one instance ID per namespace, you could have many or few.


### PR DESCRIPTION
The command line parameter is `--instanceid` not `--instance-id` as mistakenly written in the documentation

Checklist:

* [b ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [b] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
