### PR TITLE
docs: memory base amount denominator documentation

### DIFF
--- a/docs/resource-duration.md
+++ b/docs/resource-duration.md
@@ -20,7 +20,7 @@ Each indicator is divided by a common denominator depending on resource type.
 Each resource type has a denominator used to make large values smaller.
 
  * CPU: `1`
- * Memory: `100Mi`
+ * Memory: `1Gi`
  * Storage: `10Gi`
  * Ephemeral Storage: `10Gi`
  * All others: `1` 


### PR DESCRIPTION
The documentation talks about 100mi as default but 1Gi as denominator. This PR fixes this typo
---

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
