### PR TITLE
ci: Remove external build dependency

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - v*
     branches:
-      - master
+      - fix-build
 
 defaults:
   run:
@@ -19,11 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       # https://github.com/marketplace/actions/docker-buildx
       - name: Set up Docker Buildx
-        id: buildx
         uses: crazy-max/ghaction-docker-buildx@v3
-        with:
-          buildx-version: latest
-          qemu-version: latest
       - name: Docker Login
         uses: Azure/docker-login@v1
         with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,9 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # https://github.com/marketplace/actions/docker-buildx
-      - name: Set up Docker Buildx
-        uses: crazy-max/ghaction-docker-buildx@v3
       - name: Docker Login
         uses: Azure/docker-login@v1
         with:
@@ -28,8 +25,11 @@ jobs:
       - name: Build & Push Linux Docker Images
         env:
           DOCKERIO_ORG: ${{ secrets.DOCKERIO_ORG }}
-        # https://github.com/marketplace/actions/docker-buildx#build-and-push-to-dockerhub
         run: |
+          /usr/bin/docker pull -q multiarch/qemu-user-static:latest
+          /usr/bin/docker run --rm --privileged multiarch/qemu-user-static:latest --reset -p yes --credential yes
+          /usr/bin/docker buildx create --name builder --driver docker-container --use
+          /usr/bin/docker buildx inspect --bootstrap
           tag=$(basename $GITHUB_REF)
           if [ $tag = "master" ]; then
             tag="latest"
@@ -42,6 +42,7 @@ jobs:
               --target $target \
               --tag "${DOCKERIO_ORG}/${target}:${tag}-linux" .
           done
+          /usr/bin/docker buildx rm builder
 
   build-windows:
     name: Build & Push Windows Docker Images

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -32,16 +32,16 @@ jobs:
       - name: Build & Push Linux Docker Images
         env:
           DOCKERIO_ORG: ${{ secrets.DOCKERIO_ORG }}
+        # https://github.com/marketplace/actions/docker-buildx#build-and-push-to-dockerhub
         run: |
           tag=$(basename $GITHUB_REF)
           if [ $tag = "master" ]; then
             tag="latest"
           fi
-
           targets="workflow-controller argoexec argocli"
           for target in $targets; do
             docker buildx build \
-              --push \
+              --output "type=image,push=true" \
               --platform="linux/amd64,linux/arm64,linux/ppc64le,linux/s390x" \
               --target $target \
               --tag "${DOCKERIO_ORG}/${target}:${tag}-linux" .

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - v*
     branches:
-      - fix-build
+      - master
 
 defaults:
   run:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -30,6 +30,7 @@ jobs:
           /usr/bin/docker run --rm --privileged multiarch/qemu-user-static:latest --reset -p yes --credential yes
           /usr/bin/docker buildx create --name builder --driver docker-container --use
           /usr/bin/docker buildx inspect --bootstrap
+
           tag=$(basename $GITHUB_REF)
           if [ $tag = "master" ]; then
             tag="latest"
@@ -38,7 +39,7 @@ jobs:
           for target in $targets; do
             docker buildx build \
               --output "type=image,push=true" \
-              --platform="linux/amd64,linux/arm64,linux/ppc64le,linux/s390x" \
+              --platform="linux/amd64,linux/arm64" \
               --target $target \
               --tag "${DOCKERIO_ORG}/${target}:${tag}-linux" .
           done

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,11 +98,11 @@ RUN git rev-parse HEAD
 ADD hack/image_arch.sh .
 # controller image
 RUN . ./image_arch.sh && make dist/workflow-controller-linux-${IMAGE_ARCH}
-#RUN . ./image_arch.sh && ./dist/workflow-controller-linux-${IMAGE_ARCH} version | grep clean
+RUN . ./image_arch.sh && ./dist/workflow-controller-linux-${IMAGE_ARCH} version | grep clean
 
 # executor image
 RUN . ./image_arch.sh && make dist/argoexec-linux-${IMAGE_ARCH}
-#RUN . ./image_arch.sh && ./dist/argoexec-linux-${IMAGE_ARCH} version | grep clean
+RUN . ./image_arch.sh && ./dist/argoexec-linux-${IMAGE_ARCH} version | grep clean
 
 # cli image
 RUN mkdir -p ui/dist
@@ -111,7 +111,7 @@ COPY --from=argo-ui ui/dist/app ui/dist/app
 RUN touch ui/dist/node_modules.marker
 RUN touch ui/dist/app/index.html
 RUN . ./image_arch.sh && make argo-server.crt argo-server.key dist/argo-linux-${IMAGE_ARCH}
-#RUN . ./image_arch.sh && ./dist/argo-linux-${IMAGE_ARCH} version | grep clean
+RUN . ./image_arch.sh && ./dist/argo-linux-${IMAGE_ARCH} version | grep clean
 
 ####################################################################################################
 # argoexec

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,11 +98,11 @@ RUN git rev-parse HEAD
 ADD hack/image_arch.sh .
 # controller image
 RUN . ./image_arch.sh && make dist/workflow-controller-linux-${IMAGE_ARCH}
-RUN . ./image_arch.sh && ./dist/workflow-controller-linux-${IMAGE_ARCH} version | grep clean
+#RUN . ./image_arch.sh && ./dist/workflow-controller-linux-${IMAGE_ARCH} version | grep clean
 
 # executor image
 RUN . ./image_arch.sh && make dist/argoexec-linux-${IMAGE_ARCH}
-RUN . ./image_arch.sh && ./dist/argoexec-linux-${IMAGE_ARCH} version | grep clean
+#RUN . ./image_arch.sh && ./dist/argoexec-linux-${IMAGE_ARCH} version | grep clean
 
 # cli image
 RUN mkdir -p ui/dist
@@ -111,7 +111,7 @@ COPY --from=argo-ui ui/dist/app ui/dist/app
 RUN touch ui/dist/node_modules.marker
 RUN touch ui/dist/app/index.html
 RUN . ./image_arch.sh && make argo-server.crt argo-server.key dist/argo-linux-${IMAGE_ARCH}
-RUN . ./image_arch.sh && ./dist/argo-linux-${IMAGE_ARCH} version | grep clean
+#RUN . ./image_arch.sh && ./dist/argo-linux-${IMAGE_ARCH} version | grep clean
 
 ####################################################################################################
 # argoexec


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

Closes #2080 

See here: https://github.com/dgiebert/argo/runs/1007023809
And here:
- https://hub.docker.com/repository/docker/dgiebert/argocli
- https://hub.docker.com/repository/docker/dgiebert/workflow-controller
- https://hub.docker.com/repository/docker/dgiebert/argoexec

Seems the external dependency did not correctly set up the environment, and I just extracted the needed steps into the build.
There also seems to be an issue with the other platforms, so reverting back to arm64 + amd64 only