### PR TITLE
feat: Add version and app labels to the Deployment manifests. Closes #3861

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,6 +289,7 @@ proto: $(GOPATH)/bin/go-to-protobuf $(GOPATH)/bin/protoc-gen-gogo $(GOPATH)/bin/
 .PHONY: manifests
 manifests: crds /usr/local/bin/kustomize
 	./hack/update-image-tags.sh manifests/base $(VERSION)
+	./hack/update-versions.sh manifests/base $(VERSION)
 	kustomize build --load_restrictor=none manifests/cluster-install | ./hack/auto-gen-msg.sh > manifests/install.yaml
 	kustomize build --load_restrictor=none manifests/namespace-install | ./hack/auto-gen-msg.sh > manifests/namespace-install.yaml
 	kustomize build --load_restrictor=none manifests/quick-start/minimal | ./hack/auto-gen-msg.sh > manifests/quick-start-minimal.yaml

--- a/USERS.md
+++ b/USERS.md
@@ -27,6 +27,7 @@ Currently, the following organizations are **officially** using Argo Workflows:
 1. [CoreWeave Cloud](https://www.coreweave.com)
 1. [Cruise](https://getcruise.com/)
 1. [CyberAgent](https://www.cyberagent.co.jp/en/)
+1. [Cyndx](https://cyndx.com/)
 1. [Cyrus Biotechnology](https://cyrusbio.com/)
 1. [Datadog](https://www.datadoghq.com/)
 1. [DataStax](https://www.datastax.com/)

--- a/hack/update-versions.sh
+++ b/hack/update-versions.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eu -o pipefail
+
+dir=$1
+version=$2
+
+find "$dir" -type f -name '*.yaml' | while read -r f ; do
+  sed "s|version: latest|version: ${version}|" "$f" > .tmp
+  mv .tmp "$f"
+done

--- a/manifests/base/argo-server/argo-server-deployment.yaml
+++ b/manifests/base/argo-server/argo-server-deployment.yaml
@@ -2,14 +2,19 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: argo-server
+  labels:
+    app: argo-server
+    version: latest
 spec:
   selector:
     matchLabels:
       app: argo-server
+      version: latest
   template:
     metadata:
       labels:
         app: argo-server
+        version: latest
     spec:
       serviceAccountName: argo-server
       containers:

--- a/manifests/base/workflow-controller/workflow-controller-deployment.yaml
+++ b/manifests/base/workflow-controller/workflow-controller-deployment.yaml
@@ -2,14 +2,19 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: workflow-controller
+  labels:
+    app: workflow-controller
+    version: latest
 spec:
   selector:
     matchLabels:
       app: workflow-controller
+      version: latest
   template:
     metadata:
       labels:
         app: workflow-controller
+        version: latest
     spec:
       serviceAccountName: argo
       containers:


### PR DESCRIPTION
Istio strongly recommends defining app and version on deployments.  When viewing the Argo service in Kiali for example it pops up as `argo-server latest` as there is no version defined.

See https://istio.io/latest/docs/ops/deployment/requirements/

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed the CLA.
* ~[ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.~
* [ ] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
