### PR TITLE
fix(executor): Replace default retry in executor with an increased value retryer

### DIFF
--- a/util/retry/retry.go
+++ b/util/retry/retry.go
@@ -20,6 +20,14 @@ var DefaultRetry = wait.Backoff{
 	Jitter:   0.1,
 }
 
+// ExecutorRetry is a retry backoff settings for WorkflowExecutor
+var ExecutorRetry = wait.Backoff{
+	Steps:    8,
+	Duration: 1 * time.Second,
+	Factor:   1.0,
+	Jitter:   0.1,
+}
+
 // IsRetryableKubeAPIError returns if the error is a retryable kubernetes error
 func IsRetryableKubeAPIError(err error) bool {
 	// get original error if it was wrapped

--- a/util/retry/retry.go
+++ b/util/retry/retry.go
@@ -20,14 +20,6 @@ var DefaultRetry = wait.Backoff{
 	Jitter:   0.1,
 }
 
-// ExecutorRetry is a retry backoff settings for WorkflowExecutor
-var ExecutorRetry = wait.Backoff{
-	Steps:    8,
-	Duration: 1 * time.Second,
-	Factor:   1.0,
-	Jitter:   0.1,
-}
-
 // IsRetryableKubeAPIError returns if the error is a retryable kubernetes error
 func IsRetryableKubeAPIError(err error) bool {
 	// get original error if it was wrapped

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -40,11 +40,6 @@ import (
 	os_specific "github.com/argoproj/argo/workflow/executor/os-specific"
 )
 
-const (
-	// This directory temporarily stores the tarballs of the artifacts before uploading
-	tempOutArtDir = "/tmp/argo/outputs/artifacts"
-)
-
 // ExecutorRetry is a retry backoff settings for WorkflowExecutor
 var ExecutorRetry = wait.Backoff{
 	Steps:    8,
@@ -52,6 +47,11 @@ var ExecutorRetry = wait.Backoff{
 	Factor:   1.0,
 	Jitter:   0.1,
 }
+
+const (
+	// This directory temporarily stores the tarballs of the artifacts before uploading
+	tempOutArtDir = "/tmp/argo/outputs/artifacts"
+)
 
 // WorkflowExecutor is program which runs as the init/wait container
 type WorkflowExecutor struct {

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -620,7 +620,7 @@ func (we *WorkflowExecutor) getPod() (*apiv1.Pod, error) {
 	podsIf := we.ClientSet.CoreV1().Pods(we.Namespace)
 	var pod *apiv1.Pod
 	var err error
-	_ = wait.ExponentialBackoff(retry.ExecutorRetry, func() (bool, error) {
+	_ = wait.ExponentialBackoff(ExecutorRetry, func() (bool, error) {
 		pod, err = podsIf.Get(we.PodName, metav1.GetOptions{})
 		if err != nil {
 			log.Warnf("Failed to get pod '%s': %v", we.PodName, err)
@@ -921,7 +921,7 @@ func (we *WorkflowExecutor) Wait() error {
 	annotationUpdatesCh := we.monitorAnnotations(ctx)
 	go we.monitorDeadline(ctx, annotationUpdatesCh)
 
-	_ = wait.ExponentialBackoff(retry.ExecutorRetry, func() (bool, error) {
+	_ = wait.ExponentialBackoff(ExecutorRetry, func() (bool, error) {
 		err = we.RuntimeExecutor.Wait(mainContainerID)
 		if err != nil {
 			log.Warnf("Failed to wait for container id '%s': %v", mainContainerID, err)
@@ -948,7 +948,7 @@ func (we *WorkflowExecutor) waitMainContainerStart() (string, error) {
 		var err error
 		var watchIf watch.Interface
 
-		err = wait.ExponentialBackoff(retry.ExecutorRetry, func() (bool, error) {
+		err = wait.ExponentialBackoff(ExecutorRetry, func() (bool, error) {
 			watchIf, err = podsIf.Watch(opts)
 			if err != nil {
 				log.Debugf("Failed to establish watch, retrying: %v", err)

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -40,13 +40,6 @@ import (
 	os_specific "github.com/argoproj/argo/workflow/executor/os-specific"
 )
 
-var MainContainerStartRetry = wait.Backoff{
-	Steps:    8,
-	Duration: 1 * time.Second,
-	Factor:   1.0,
-	Jitter:   0.1,
-}
-
 const (
 	// This directory temporarily stores the tarballs of the artifacts before uploading
 	tempOutArtDir = "/tmp/argo/outputs/artifacts"
@@ -619,7 +612,7 @@ func (we *WorkflowExecutor) getPod() (*apiv1.Pod, error) {
 	podsIf := we.ClientSet.CoreV1().Pods(we.Namespace)
 	var pod *apiv1.Pod
 	var err error
-	_ = wait.ExponentialBackoff(retry.DefaultRetry, func() (bool, error) {
+	_ = wait.ExponentialBackoff(retry.ExecutorRetry, func() (bool, error) {
 		pod, err = podsIf.Get(we.PodName, metav1.GetOptions{})
 		if err != nil {
 			log.Warnf("Failed to get pod '%s': %v", we.PodName, err)
@@ -920,7 +913,7 @@ func (we *WorkflowExecutor) Wait() error {
 	annotationUpdatesCh := we.monitorAnnotations(ctx)
 	go we.monitorDeadline(ctx, annotationUpdatesCh)
 
-	_ = wait.ExponentialBackoff(retry.DefaultRetry, func() (bool, error) {
+	_ = wait.ExponentialBackoff(retry.ExecutorRetry, func() (bool, error) {
 		err = we.RuntimeExecutor.Wait(mainContainerID)
 		if err != nil {
 			log.Warnf("Failed to wait for container id '%s': %v", mainContainerID, err)
@@ -947,7 +940,7 @@ func (we *WorkflowExecutor) waitMainContainerStart() (string, error) {
 		var err error
 		var watchIf watch.Interface
 
-		err = wait.ExponentialBackoff(MainContainerStartRetry, func() (bool, error) {
+		err = wait.ExponentialBackoff(retry.ExecutorRetry, func() (bool, error) {
 			watchIf, err = podsIf.Watch(opts)
 			if err != nil {
 				log.Debugf("Failed to establish watch, retrying: %v", err)

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -45,6 +45,14 @@ const (
 	tempOutArtDir = "/tmp/argo/outputs/artifacts"
 )
 
+// ExecutorRetry is a retry backoff settings for WorkflowExecutor
+var ExecutorRetry = wait.Backoff{
+	Steps:    8,
+	Duration: 1 * time.Second,
+	Factor:   1.0,
+	Jitter:   0.1,
+}
+
 // WorkflowExecutor is program which runs as the init/wait container
 type WorkflowExecutor struct {
 	PodName            string


### PR DESCRIPTION
Replace default retry in executor with an increased value retryer.

https://github.com/argoproj/argo/pull/3675 added a pod watch retry to handle timeout.
We need to increase this retry value to several other places. e.g. the wait container could timeout requests to etcd during wait.
We are experimenting the following error with argo-workflow 2.10.0. 

```
time="2020-08-28T16:02:23.208Z" level=info msg="Waiting on main container"
time="2020-08-28T16:02:23.702Z" level=info msg="main container started with container ID: 17ec51e28b2a528c7c5238b5858e3d3a19c8c2f599f6c4950690da0f5a5c641a"
time="2020-08-28T16:02:23.702Z" level=info msg="Starting annotations monitor"
time="2020-08-28T16:02:23.709Z" level=info msg="Waiting for container 17ec51e28b2a528c7c5238b5858e3d3a19c8c2f599f6c4950690da0f5a5c641a to complete"
time="2020-08-28T16:02:23.709Z" level=info msg="Starting to wait completion of containerID 17ec51e28b2a528c7c5238b5858e3d3a19c8c2f599f6c4950690da0f5a5c641a ..."
time="2020-08-28T16:02:23.709Z" level=info msg="Starting deadline monitor"
time="2020-08-28T16:07:23.208Z" level=info msg="Alloc=7343 TotalAlloc=42779 Sys=72128 NumGC=11 Goroutines=10"
time="2020-08-28T16:08:05.884Z" level=warning msg="Failed to wait for container id '17ec51e28b2a528c7c5238b5858e3d3a19c8c2f599f6c4950690da0f5a5c641a': etcdserver: request timed out"
time="2020-08-28T16:08:05.884Z" level=error msg="executor error: etcdserver: request timed out"
time="2020-08-28T16:08:05.884Z" level=info msg="No Script output reference in workflow. Capturing script output ignored"
time="2020-08-28T16:08:05.884Z" level=info msg="Capturing script exit code"
time="2020-08-28T16:08:05.884Z" level=info msg="Getting exit code of 17ec51e28b2a528c7c5238b5858e3d3a19c8c2f599f6c4950690da0f5a5c641a"
time="2020-08-28T16:08:05.884Z" level=info msg="Annotations monitor stopped"
time="2020-08-28T16:08:05.907Z" level=info msg="No output parameters"
time="2020-08-28T16:08:05.907Z" level=info msg="No output artifacts"
time="2020-08-28T16:08:05.907Z" level=info msg="Killing sidecars"
time="2020-08-28T16:08:05.911Z" level=info msg="Alloc=6540 TotalAlloc=46240 Sys=72128 NumGC=12 Goroutines=9"
time="2020-08-28T16:08:05.954Z" level=fatal msg="etcdserver: request timed out"
```


Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
