### PR TITLE
fix(docs): Correct indentation to display correctly docs in the website

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -115,11 +115,11 @@ When defining a `histogram`, `buckets` must also be provided (see below).
 Metric names can only contain alphanumeric characters, `_`, and `:`.
 
 ### Metric Spec
- 
- In Argo you can define a metric on the `Workflow` level or on the `Template` level. Here is an example of a `Workflow`
- level Gauge metric that will report the Workflow duration time:
- 
- ```yaml
+
+In Argo you can define a metric on the `Workflow` level or on the `Template` level. Here is an example of a `Workflow`
+level Gauge metric that will report the Workflow duration time:
+
+```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
@@ -136,7 +136,7 @@ spec:
         gauge:                            # The metric type. Available are "gauge", "histogram", and "counter".
           value: "{{workflow.duration}}"  # The value of your metric. It could be an Argo variable (see variables doc) or a literal value
 
-... 
+...
 ```
 
 An example of a `Template`-level Counter metric that will increase a counter every time the step fails:
@@ -185,6 +185,7 @@ A similar example of such a Counter metric that will increase for every step sta
         command: ["python", -c]
         # fail with a 66% probability
         args: ["import random; import sys; exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]
+...
 ```
 
 Finally, an example of a `Template`-level Histogram metric that tracks an internal value:


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

Checklist:

This is is a bug fix.

Fixes: https://github.com/argoproj/argo/issues/3841

* [ ] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged. 
* [ ] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
