### PR TITLE
fix: typo of argo server cli (#3984)

### DIFF
--- a/cmd/argo/commands/server.go
+++ b/cmd/argo/commands/server.go
@@ -55,7 +55,7 @@ See %s`, help.ArgoSever),
 			namespace := client.Namespace()
 
 			kubeConfig := kubernetes.NewForConfigOrDie(config)
-			wflientset := wfclientset.NewForConfigOrDie(config)
+			wfClientSet := wfclientset.NewForConfigOrDie(config)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -100,7 +100,7 @@ See %s`, help.ArgoSever),
 				TLSConfig:               tlsConfig,
 				HSTS:                    htst,
 				Namespace:               namespace,
-				WfClientSet:             wflientset,
+				WfClientSet:             wfClientSet,
 				KubeClientset:           kubeConfig,
 				RestConfig:              config,
 				AuthModes:               modes,


### PR DESCRIPTION
fix: typo of argo server cli (#3984)

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
