### PR TITLE
docs(Windows): Add more information on artifacts and limitations

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -101,6 +101,12 @@ Artifacts work mostly the same way as on Linux. All paths get automatically mapp
         args: ["dir C:\\message"]   # List the C:\message directory
 ```
 
+Remember that [volume mounts on Windows can only target a directory](https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#storage) in the container, and not an individual file.
+
+## Limitations
+
+- Sharing process namespaces [doesn't work on Windows](https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#v1-pod) so you can't use the Process Namespace Sharing (pns) workflow executor.
+
 ## Building the workflow executor image for Windows
 
 To build the workflow executor image for Windows you need a Windows machine running Windows Server 2019 with Docker installed like described [in the docs](https://docs.docker.com/ee/docker-ee/windows/docker-ee/#install-docker-engine---enterprise).

--- a/docs/workflow-executors.md
+++ b/docs/workflow-executors.md
@@ -44,6 +44,7 @@ The executor to be used in your workflows can be changed in [the configmap](./wo
 * Output artifacts can only be saved on volumes (e.g. emptyDir) and not the base image layer (e.g. /tmp)
 
 ## Process Namespace Sharing (pns)
+*PNS can't be used when running Windows containers within your workflow as sharing process namespaces [doesn't work on Windows](https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#v1-pod).*
 
 ### Pros
 


### PR DESCRIPTION
Triggered by https://github.com/argoproj/argo/issues/4009 and https://github.com/argoproj/argo/issues/3682 I added additional information to the docs on artifacts and limitations when using Windows containers.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged. - not needed
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md). - not needed
