### PR TITLE
docs: Update SSO docs to clarify the user must create K8S secrets for holding the OAuth2 values

### DIFF
--- a/docs/argo-server-sso.md
+++ b/docs/argo-server-sso.md
@@ -8,6 +8,8 @@
 
 Firstly, configure the settings [workflow-controller-configmap.yaml](workflow-controller-configmap.yaml) with the correct OAuth 2 values.
 
+Next, create k8s secrets for holding the OAuth2 `client-id` and `client-secret`. You may refer to the kubernetes documentation on [Managing secrets](https://kubernetes.io/docs/tasks/configmap-secret/).
+
 Then, start the Argo Server using the SSO [auth mode](argo-server-auth-mode.md):
 
 ```

--- a/docs/argo-server-sso.md
+++ b/docs/argo-server-sso.md
@@ -8,7 +8,14 @@
 
 Firstly, configure the settings [workflow-controller-configmap.yaml](workflow-controller-configmap.yaml) with the correct OAuth 2 values.
 
-Next, create k8s secrets for holding the OAuth2 `client-id` and `client-secret`. You may refer to the kubernetes documentation on [Managing secrets](https://kubernetes.io/docs/tasks/configmap-secret/).
+Next, create the k8s secrets for holding the OAuth2 `client-id` and `client-secret`. You may refer to the kubernetes documentation on [Managing secrets](https://kubernetes.io/docs/tasks/configmap-secret/). For example by using kubectl with literals:
+```
+kubectl create secret -n argo generic client-id-secret \
+  --from-literal=client-id-key=foo
+
+kubectl create secret -n argo generic client-secret-secret \
+  --from-literal=client-secret-key=bar
+```
 
 Then, start the Argo Server using the SSO [auth mode](argo-server-auth-mode.md):
 


### PR DESCRIPTION
Clarify that the user ought to create k8s secrets to hold the OAuth2 config values.
See related [enhancement proposal](https://github.com/argoproj/argo/issues/4069).

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
