### PR TITLE
fix(executor): windows output artifacts. Fixes #4082

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -19,7 +19,7 @@ RUN iex ((new-object net.webclient).DownloadString('https://chocolatey.org/insta
 
 # install golang, dep and other tools
 RUN choco install golang --version=$env:GOLANG_VERSION ; \
-    choco install make dep docker-cli git.portable
+    choco install make dep docker-cli git.portable 7zip.portable
 
 ####################################################################################################
 # argoexec-base
@@ -41,6 +41,7 @@ RUN mkdir C:\app && \
 
 COPY --from=builder C:/ProgramData/chocolatey/lib/docker-cli/tools/docker.exe C:/app/docker.exe
 COPY --from=builder C:/tools/git C:/app/git
+COPY --from=builder C:/ProgramData/chocolatey/lib/7zip.portable/tools/7z-extra/x64/7za.exe C:/app/7za.exe
 
 # add binaries to path
 USER Administrator

--- a/USERS.md
+++ b/USERS.md
@@ -85,3 +85,4 @@ Currently, the following organizations are **officially** using Argo Workflows:
 1. [Tulip](https://tulip.com/)
 1. [Wavefront](https://www.wavefront.com/)
 1. [Wellcome Trust](https://wellcome.ac.uk/)
+1. [Helio](https://helio.exchange)

--- a/workflow/executor/docker/docker.go
+++ b/workflow/executor/docker/docker.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -36,34 +37,18 @@ func (d *DockerExecutor) GetFileContents(containerID string, sourcePath string) 
 	// content from the tar archive and output into stdout. In this way, we do not need to
 	// create and copy the content into a file from the wait container.
 	dockerCpCmd := fmt.Sprintf("docker cp -a %s:%s - | tar -ax -O", containerID, sourcePath)
-	cmd := exec.Command("sh", "-c", dockerCpCmd)
-	log.Info(cmd.Args)
-	out, err := cmd.Output()
+	out, err := common.RunShellCommand(dockerCpCmd)
 	if err != nil {
-		if exErr, ok := err.(*exec.ExitError); ok {
-			log.Errorf("`%s` stderr:\n%s", cmd.Args, string(exErr.Stderr))
-		}
-		return "", errors.InternalWrapError(err)
+		return "", err
 	}
 	return string(out), nil
 }
 
 func (d *DockerExecutor) CopyFile(containerID string, sourcePath string, destPath string, compressionLevel int) error {
 	log.Infof("Archiving %s:%s to %s", containerID, sourcePath, destPath)
-	var levelFlag string
-	switch compressionLevel {
-	case gzip.NoCompression:
-		// best we can do - if we skip gzip it's a different file
-		levelFlag = "-1"
-	case gzip.DefaultCompression:
-		// use cmd default
-		levelFlag = ""
-	default:
-		// -1 through -9 (or error)
-		levelFlag = "-" + strconv.Itoa(compressionLevel)
-	}
-	dockerCpCmd := fmt.Sprintf("docker cp -a %s:%s - | gzip %s > %s", containerID, sourcePath, levelFlag, destPath)
-	err := common.RunCommand("sh", "-c", dockerCpCmd)
+
+	dockerCpCmd := getDockerCpCmd(containerID, sourcePath, compressionLevel, destPath)
+	_, err := common.RunShellCommand(dockerCpCmd)
 	if err != nil {
 		return err
 	}
@@ -182,7 +167,8 @@ func (d *DockerExecutor) WaitInit() error {
 
 // Wait for the container to complete
 func (d *DockerExecutor) Wait(containerID string) error {
-	return common.RunCommand("docker", "wait", containerID)
+	_, err := common.RunCommand("docker", "wait", containerID)
+	return err
 }
 
 // killContainers kills a list of containerIDs first with a SIGTERM then with a SIGKILL after a grace period
@@ -190,7 +176,7 @@ func (d *DockerExecutor) Kill(containerIDs []string) error {
 	killArgs := append([]string{"kill", "--signal", "TERM"}, containerIDs...)
 	// docker kill will return with an error if a container has terminated already, which is not an error in this case.
 	// We therefore ignore any error. docker wait that follows will re-raise any other error with the container.
-	err := common.RunCommand("docker", killArgs...)
+	_, err := common.RunCommand("docker", killArgs...)
 	if err != nil {
 		log.Warningf("Ignored error from 'docker kill --signal TERM': %s", err)
 	}
@@ -218,4 +204,29 @@ func (d *DockerExecutor) Kill(containerIDs []string) error {
 	}
 	log.Infof("Containers %s killed successfully", containerIDs)
 	return nil
+}
+
+// getDockerCpCmd uses os-specific code to run `docker cp` and gzip/7zip to copy gzipped data from another
+// container.
+func getDockerCpCmd(containerID, sourcePath string, compressionLevel int, destPath string) string {
+	gzipCmd := "gzip %s > %s"
+	levelFlagParam := "-"
+	if runtime.GOOS == "windows" {
+		gzipCmd = "7za.exe a -tgzip -si %s %s"
+		levelFlagParam = "-mx"
+	}
+
+	var levelFlag string
+	switch compressionLevel {
+	case gzip.NoCompression:
+		// best we can do - if we skip gzip it's a different file
+		levelFlag = levelFlagParam + "1"
+	case gzip.DefaultCompression:
+		// use cmd default
+		levelFlag = ""
+	default:
+		// -1 through -9 (or error)
+		levelFlag = levelFlagParam + strconv.Itoa(compressionLevel)
+	}
+	return fmt.Sprintf("docker cp -a %s:%s - | %s", containerID, sourcePath, fmt.Sprintf(gzipCmd, levelFlag, destPath))
 }

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -854,7 +854,7 @@ func untar(tarPath string, destPath string) error {
 	if err != nil {
 		return errors.InternalWrapError(err)
 	}
-	err = common.RunCommand("tar", "-xf", tarPath, "-C", tmpDir)
+	_, err = common.RunCommand("tar", "-xf", tarPath, "-C", tmpDir)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is a preliminary change to fix #4082. 
After this change the following happens:

```
time="2020-09-21T11:59:10.713Z" level=info msg="Saving output artifacts"
time="2020-09-21T11:59:10.714Z" level=info msg="Staging artifact: render-files"
time="2020-09-21T11:59:10.714Z" level=info msg="Copying /render/ from container base image layer to \\tmp\\argo\\outputs\\artifacts\\render-files.tgz"
time="2020-09-21T11:59:10.714Z" level=info msg="Archiving fe5574c11e503bf7d7fe00202990d70f81f7d995867dd02d229623b41909a18b:/render/ to \\tmp\\argo\\outputs\\artifacts\\render-files.tgz"
time="2020-09-21T11:59:10.715Z" level=info msg="cmd /c docker cp -a fe5574c11e503bf7d7fe00202990d70f81f7d995867dd02d229623b41909a18b:/render/ - | gzip -1 > \\tmp\\argo\\outputs\\artifacts\\render-files.tgz"
time="2020-09-21T11:59:10.787Z" level=error msg="`cmd /c docker cp -a fe5574c11e503bf7d7fe00202990d70f81f7d995867dd02d229623b41909a18b:/render/ - | gzip -1 > \\tmp\\argo\\outputs\\artifacts\\render-files.tgz` failed: 'gzip' is not recognized as an internal or external command,\r\noperable program or batch file.\r\n"
time="2020-09-21T11:59:10.787Z" level=error msg="executor error: 'gzip' is not recognized as an internal or external command,\r\noperable program or batch file.\ngithub.com/argoproj/argo/errors.New\n\tC:/Users/ContainerAdministrator/go/src/github.com/argoproj/argo/errors/errors.go:49\ngithub.com/argoproj/argo/errors.InternalError\n\tC:/Users/ContainerAdministrator/go/src/github.com/argoproj/argo/errors/errors.go:60\ngithub.com/argoproj/argo/workflow/common.RunCommand\n\tC:/Users/ContainerAdministrator/go/src/github.com/argoproj/argo/workflow/common/util.go:416\ngithub.com/argoproj/argo/workflow/common.RunShellCommand\n\tC:/Users/ContainerAdministrator/go/src/github.com/argoproj/argo/workflow/common/util_windows.go:7\ngithub.com/argoproj/argo/workflow/executor/docker.(*DockerExecutor).CopyFile\n\tC:/Users/ContainerAdministrator/go/src/github.com/argoproj/argo/workflow/executor/docker/docker.go:61\ngithub.com/argoproj/argo/workflow/executor.(*WorkflowExecutor).stageArchiveFile\n\tC:/Users/ContainerAdministrator/go/src/github.com/argoproj/argo/workflow/executor/executor.go:387\ngithub.com/argoproj/argo/workflow/executor.(*WorkflowExecutor).saveArtifact\n\tC:/Users/ContainerAdministrator/go/src/github.com/argoproj/argo/workflow/executor/executor.go:272\ngithub.com/argoproj/argo/workflow/executor.(*WorkflowExecutor).SaveArtifacts\n\tC:/Users/ContainerAdministrator/go/src/github.com/argoproj/argo/workflow/executor/executor.go:258\ngithub.com/argoproj/argo/cmd/argoexec/commands.waitContainer\n\tC:/Users/ContainerAdministrator/go/src/github.com/argoproj/argo/cmd/argoexec/commands/wait.go:71\ngithub.com/argoproj/argo/cmd/argoexec/commands.NewWaitCommand.func1\n\tC:/Users/ContainerAdministrator/go/src/github.com/argoproj/argo/cmd/argoexec/commands/wait.go:16\ngithub.com/spf13/cobra.(*Command).execute\n\tC:/Users/ContainerAdministrator/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:846\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\tC:/Users/ContainerAdministrator/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950\ngithub.com/spf13/cobra.(*Command).Execute\n\tC:/Users/ContainerAdministrator/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887\nmain.main\n\tC:/Users/ContainerAdministrator/go/src/github.com/argoproj/argo/cmd/argoexec/main.go:17\nruntime.main\n\tc:/go/src/runtime/proc.go:203\nruntime.goexit\n\tc:/go/src/runtime/asm_amd64.s:1357"
time="2020-09-21T11:59:10.787Z" level=info msg="Killing sidecars"
```

So `gzip` obviously doesn't exist on Windows 😄 Will see what to do about this case. Maybe @lippertmarkus has an idea?
Same issue probably with `DockerExecutor#GetFileContents()` which uses `tar`.

Checklist:

* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

