### PR TITLE
fix(ui): Render children of workflow-level onExit. Fixes #3754

### DIFF
--- a/ui/src/app/workflows/components/workflow-dag/workflow-dag.tsx
+++ b/ui/src/app/workflows/components/workflow-dag/workflow-dag.tsx
@@ -310,7 +310,7 @@ export class WorkflowDag extends React.Component<WorkflowDagProps, WorkflowDagRe
             }
             return allNodes[nodeId].children.filter(child => allNodes[child]);
         };
-        const pushChildren = (nodeId: string, isExpanded: boolean): void => {
+        const pushChildren = (nodeId: string, isExpanded: boolean, queue: PrepareNode[]): void => {
             const children: string[] = getChildren(nodeId);
             if (!children) {
                 return;
@@ -349,45 +349,50 @@ export class WorkflowDag extends React.Component<WorkflowDagProps, WorkflowDagRe
             }
         };
 
-        const root: PrepareNode = {
+        const traverse = (root: PrepareNode): void => {
+            const queue: PrepareNode[] = [root];
+            const consideredChildren: Set<string> = new Set<string>();
+            let previousCollapsed: string = '';
+
+            while (queue.length > 0) {
+                const item = queue.pop();
+
+                if (isCollapsedNode(item.nodeName)) {
+                    if (item.nodeName !== previousCollapsed) {
+                        nodes.push(item.nodeName);
+                        edges.push({v: item.parent, w: item.nodeName});
+                        previousCollapsed = item.nodeName;
+                    }
+                    continue;
+                }
+
+                const isExpanded: boolean = this.state.expandNodes.has('*') || this.state.expandNodes.has(item.nodeName);
+                nodes.push(item.nodeName);
+                edges.push({v: item.parent, w: item.nodeName});
+
+                // If we have already considered the children of this node, don't consider them again
+                if (consideredChildren.has(item.nodeName)) {
+                    continue;
+                }
+                consideredChildren.add(item.nodeName);
+
+                const node: NodeStatus = this.props.nodes[item.nodeName];
+                if (!node || node.phase === NODE_PHASE.OMITTED) {
+                    continue;
+                }
+
+                pushChildren(node.id, isExpanded, queue);
+            }
+        };
+
+        const workflowRoot: PrepareNode = {
             nodeName: this.props.workflowName,
             parent: '',
             children: getChildren(this.props.workflowName)
         };
 
-        const queue: PrepareNode[] = [root];
-        const consideredChildren: Set<string> = new Set<string>();
-        let previousCollapsed: string = '';
-
-        while (queue.length > 0) {
-            const item = queue.pop();
-
-            if (isCollapsedNode(item.nodeName)) {
-                if (item.nodeName !== previousCollapsed) {
-                    nodes.push(item.nodeName);
-                    edges.push({v: item.parent, w: item.nodeName});
-                    previousCollapsed = item.nodeName;
-                }
-                continue;
-            }
-
-            const isExpanded: boolean = this.state.expandNodes.has('*') || this.state.expandNodes.has(item.nodeName);
-            nodes.push(item.nodeName);
-            edges.push({v: item.parent, w: item.nodeName});
-
-            // If we have already considered the children of this node, don't consider them again
-            if (consideredChildren.has(item.nodeName)) {
-                continue;
-            }
-            consideredChildren.add(item.nodeName);
-
-            const node: NodeStatus = this.props.nodes[item.nodeName];
-            if (!node || node.phase === NODE_PHASE.OMITTED) {
-                continue;
-            }
-
-            pushChildren(node.id, isExpanded);
-        }
+        // Traverse the workflow from the root node
+        traverse(workflowRoot);
 
         const onExitHandlerNodeId = Object.values(allNodes).find(nodeId => nodeId.name === `${this.props.workflowName}.onExit`);
         if (onExitHandlerNodeId) {
@@ -397,6 +402,13 @@ export class WorkflowDag extends React.Component<WorkflowDagProps, WorkflowDagRe
                     edges.push({v, w: onExitHandlerNodeId.id});
                 }
             });
+            const onExitRoot: PrepareNode = {
+                nodeName: onExitHandlerNodeId.id,
+                parent: '',
+                children: getChildren(onExitHandlerNodeId.id)
+            };
+            // Traverse the onExit tree starting from the onExit node itself
+            traverse(onExitRoot);
         }
         return {nodes, edges};
     }


### PR DESCRIPTION
Fixes: #3754

From `examples/exit-handlers.yaml`

<img width="340" alt="image" src="https://user-images.githubusercontent.com/614838/94574970-94016980-0228-11eb-9f45-6d912f8b737d.png">
