### PR TITLE
chore(build): Use build matrix and cache. Fixes #4062

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,37 +15,52 @@ jobs:
   build-linux:
     name: Build & Push Linux Docker Images
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [linux/amd64, linux/arm64]
+        target: [workflow-controller, argocli, argoexec]
     steps:
       - uses: actions/checkout@v2
-      - name: Docker Login
-        uses: Azure/docker-login@v1
+
+      - name: Set up Docker Buildx
+        uses: crazy-max/ghaction-docker-buildx@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-${{ matrix.platform }}-${{ matrix.target }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.platform }}-${{ matrix.target }}-buildx-
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERIO_USERNAME }}
           password: ${{ secrets.DOCKERIO_PASSWORD }}
-      - name: Build & Push Linux Docker Images
+
+      - name: Docker Buildx
         env:
           DOCKERIO_ORG: ${{ secrets.DOCKERIO_ORG }}
-        # https://github.com/marketplace/actions/docker-buildx#build-and-push-to-dockerhub
+          PLATFORM: ${{ matrix.platform }}
+          TARGET: ${{ matrix.target }}
         run: |
-          /usr/bin/docker pull -q multiarch/qemu-user-static:latest
-          /usr/bin/docker run --rm --privileged multiarch/qemu-user-static:latest --reset -p yes --credential yes
-          /usr/bin/docker buildx create --name builder --driver docker-container --use
-          /usr/bin/docker buildx inspect --bootstrap
-
           tag=$(basename $GITHUB_REF)
           if [ $tag = "master" ]; then
             tag="latest"
           fi
-          targets="workflow-controller argocli"
-          for target in $targets; do
-            docker buildx build \
-              --output "type=image,push=true" \
-              --platform="linux/amd64,linux/arm64" \
-              --target $target \
-              --tag "${DOCKERIO_ORG}/${target}:${tag}-linux" \
-              --tag "${DOCKERIO_ORG}/${target}:${tag}" .
-          done
-          /usr/bin/docker buildx rm builder
+
+          tag_suffix=$(echo $PLATFORM | sed -r "s/\//-/g")
+          image_name="${DOCKERIO_ORG}/${TARGET}:${tag}-${tag_suffix}"
+
+          docker buildx build \
+            --cache-from "type=local,src=/tmp/.buildx-cache" \
+            --cache-to "type=local,dest=/tmp/.buildx-cache" \
+            --output "type=image,push=true" \
+            --platform="${PLATFORM}" \
+            --target $TARGET \
+            --tag $image_name .
 
   build-windows:
     name: Build & Push Windows Docker Images
@@ -76,7 +91,7 @@ jobs:
           done
 
   push-images:
-    name: Build & Push Multiplatform Images
+    name: Push Multiplatform Images
     runs-on: ubuntu-latest
     needs: [build-linux, build-windows]
     steps:
@@ -90,11 +105,6 @@ jobs:
         env:
           DOCKERIO_ORG: ${{ secrets.DOCKERIO_ORG }}
         run: |
-          /usr/bin/docker pull -q multiarch/qemu-user-static:latest
-          /usr/bin/docker run --rm --privileged multiarch/qemu-user-static:latest --reset -p yes --credential yes
-          /usr/bin/docker buildx create --name builder --driver docker-container --use
-          /usr/bin/docker buildx inspect --bootstrap
-
           echo $(jq -c '. + { "experimental": "enabled" }' ${DOCKER_CONFIG}/config.json) > ${DOCKER_CONFIG}/config.json
 
           docker_org=$DOCKERIO_ORG
@@ -103,23 +113,16 @@ jobs:
           if [ $tag = "master" ]; then
             tag="latest"
           fi
-          targets="argoexec"
+
+          targets="workflow-controller argoexec argocli"
           for target in $targets; do
             image_name="${docker_org}/${target}:${tag}"
 
-            docker buildx build \
-              --push \
-              --platform="linux/arm64" \
-              --target ${target} \
-              --tag "${image_name}-linux-arm64" .
-
-            docker buildx build \
-              --push \
-              --platform="linux/amd64" \
-              --target ${target} \
-              --tag "${image_name}-linux-amd64" .
-
-            docker manifest create $image_name ${image_name}-windows ${image_name}-linux-arm64 ${image_name}-linux-amd64
+            if [ $target = "argoexec" ]; then
+              docker manifest create $image_name ${image_name}-linux-arm64 ${image_name}-linux-amd64 ${image_name}-windows
+            else
+              docker manifest create $image_name ${image_name}-linux-arm64 ${image_name}-linux-amd64
+            fi
 
             docker manifest push $image_name
           done


### PR DESCRIPTION
Like mentioned in https://github.com/argoproj/argo/issues/4062#issuecomment-694635885 I did the following to fix #4062:
- Leverage the buildx GitHub action to simplify setup of buildx
- Using a build matrix for building each target (`workflow-controller`, `argocli`, `argoexec`) on each Linux platform (`linux/amd64`, `linux/arm64`) in parallel.
- Using caching for buildx

This brings down the build time to around 40 min. This is still not super fast but better than 2h. The main bottleneck are the ARM64 images which require emulation for building (a single image takes around 39mins vs. 6mins for AMD64).

Could we get native ARM64 machines through CNCF (https://www.cncf.io/services-for-projects/#continuous-integration)? We could use them as self-hosted GitHub runners.

Test run: https://github.com/lippertmarkus/argo/actions/runs/268773685
Images built by this test run, e.g. `argoexec`: https://hub.docker.com/repository/docker/lippertmarkus/argoexec/tags?page=1&ordering=last_updated

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or **(c) this is a chore**.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged. **Not needed.**
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
