### PR TITLE
fix(server): argo-server-role to allow submitting cronworkflows from UI

### DIFF
--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -271,6 +271,7 @@ rules:
   - workfloweventbindings
   - workflowtemplates
   - cronworkflows
+  - cronworkflows/finalizers
   verbs:
   - create
   - get

--- a/manifests/namespace-install/argo-server-rbac/argo-server-role.yaml
+++ b/manifests/namespace-install/argo-server-rbac/argo-server-role.yaml
@@ -50,6 +50,7 @@ rules:
       - workfloweventbindings
       - workflowtemplates
       - cronworkflows
+      - cronworkflows/finalizers
     verbs:
       - create
       - get

--- a/manifests/quick-start-minimal.yaml
+++ b/manifests/quick-start-minimal.yaml
@@ -276,6 +276,7 @@ rules:
   - workfloweventbindings
   - workflowtemplates
   - cronworkflows
+  - cronworkflows/finalizers
   verbs:
   - create
   - get

--- a/manifests/quick-start-mysql.yaml
+++ b/manifests/quick-start-mysql.yaml
@@ -276,6 +276,7 @@ rules:
   - workfloweventbindings
   - workflowtemplates
   - cronworkflows
+  - cronworkflows/finalizers
   verbs:
   - create
   - get

--- a/manifests/quick-start-postgres.yaml
+++ b/manifests/quick-start-postgres.yaml
@@ -276,6 +276,7 @@ rules:
   - workfloweventbindings
   - workflowtemplates
   - cronworkflows
+  - cronworkflows/finalizers
   verbs:
   - create
   - get


### PR DESCRIPTION
Since https://github.com/argoproj/argo/pull/3116 allowed submitting `Cronworkflows` from UI, the `argo-server-role` role has to be updated for namespaced installations to actually allow the operation on kubernetes clusters with more strict RBAC like OpenShift.

Otherwise you'd get similar message to https://github.com/argoproj/argo/issues/922 :
```
time="2020-09-23T14:46:44Z" level=warning msg="finished unary call with code PermissionDenied" error="rpc error: code = PermissionDenied desc = workflows.argoproj.io \"XYZ\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>" grpc.code=PermissionDenied grpc.method=SubmitWorkflow grpc.service=workflow.WorkflowService grpc.start_time="2020-09-23T14:46:44Z" grpc.time_ms=44.759 span.kind=server system=grpc
```
![image](https://user-images.githubusercontent.com/7453394/94035953-0ce56900-fdc4-11ea-8971-d7aab9aa36ed.png)

Surprisingly a finalizer on `cronworkflows` (not for `workflows`) is required to make this work.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
