### PR TITLE
docs: Fix `argo logs` command in examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -46,8 +46,7 @@ In case you want to follow along with this walkthrough, here's a quick overview 
 argo submit hello-world.yaml    # submit a workflow spec to Kubernetes
 argo list                       # list current workflows
 argo get hello-world-xxx        # get info about a specific workflow
-argo logs -w hello-world-xxx    # get logs from all steps in a workflow
-argo logs hello-world-xxx-yyy   # get logs from a specific step in a workflow
+argo logs hello-world-xxx       # print the logs from a workflow
 argo delete hello-world-xxx     # delete workflow
 ```
 


### PR DESCRIPTION
removed `argo logs -w ...` because it has been removed from argo-cli

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
