### PR TITLE
chore(build): Pre-push temporary manifest with linux/amd64. Fixes #4062

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,12 +12,62 @@ defaults:
     shell: bash
 
 jobs:
-  build-linux:
-    name: Build & Push Linux Docker Images
+  build-linux-amd64:
+    name: Build & push linux/amd64
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: [linux/amd64, linux/arm64]
+        platform: [linux/amd64]
+        target: [workflow-controller, argocli, argoexec]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: crazy-max/ghaction-docker-buildx@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-${{ matrix.platform }}-${{ matrix.target }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.platform }}-${{ matrix.target }}-buildx-
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERIO_USERNAME }}
+          password: ${{ secrets.DOCKERIO_PASSWORD }}
+
+      - name: Docker Buildx
+        env:
+          DOCKERIO_ORG: ${{ secrets.DOCKERIO_ORG }}
+          PLATFORM: ${{ matrix.platform }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          tag=$(basename $GITHUB_REF)
+          if [ $tag = "master" ]; then
+            tag="latest"
+          fi
+
+          tag_suffix=$(echo $PLATFORM | sed -r "s/\//-/g")
+          image_name="${DOCKERIO_ORG}/${TARGET}:${tag}-${tag_suffix}"
+
+          docker buildx build \
+            --cache-from "type=local,src=/tmp/.buildx-cache" \
+            --cache-to "type=local,dest=/tmp/.buildx-cache" \
+            --output "type=image,push=true" \
+            --platform="${PLATFORM}" \
+            --target $TARGET \
+            --tag $image_name .
+
+  build-linux-arm64:
+    name: Build & push linux/arm64
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [linux/arm64]
         target: [workflow-controller, argocli, argoexec]
     steps:
       - uses: actions/checkout@v2
@@ -63,7 +113,7 @@ jobs:
             --tag $image_name .
 
   build-windows:
-    name: Build & Push Windows Docker Images
+    name: Build & push windows
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
@@ -90,10 +140,41 @@ jobs:
             docker push $image_name
           done
 
-  push-images:
-    name: Push Multiplatform Images
+  push-linux-amd64-images:
+    name: Push manifest with linux/amd64
     runs-on: ubuntu-latest
-    needs: [build-linux, build-windows]
+    needs: [build-linux-amd64]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker Login
+        uses: Azure/docker-login@v1
+        with:
+          username: ${{ secrets.DOCKERIO_USERNAME }}
+          password: ${{ secrets.DOCKERIO_PASSWORD }}
+      - name: Push Multiarch Image
+        env:
+          DOCKERIO_ORG: ${{ secrets.DOCKERIO_ORG }}
+        run: |
+          echo $(jq -c '. + { "experimental": "enabled" }' ${DOCKER_CONFIG}/config.json) > ${DOCKER_CONFIG}/config.json
+
+          docker_org=$DOCKERIO_ORG
+
+          tag=$(basename $GITHUB_REF)
+          if [ $tag = "master" ]; then
+            tag="latest"
+          fi
+
+          targets="workflow-controller argoexec argocli"
+          for target in $targets; do
+            image_name="${docker_org}/${target}:${tag}"
+            docker manifest create $image_name ${image_name}-linux-amd64
+            docker manifest push $image_name
+          done
+
+  push-images:
+    name: Push manifest with all images
+    runs-on: ubuntu-latest
+    needs: [build-linux-arm64, build-windows, push-linux-amd64-images]
     steps:
       - uses: actions/checkout@v2
       - name: Docker Login


### PR DESCRIPTION
This is pre-pushing a temporary manifest to DockerHub referencing the linux/amd64 images right after those are built so we can release earlier without having to wait for the long-running arm64 image builds. After all images finished building the temporary manifest is overwritten with a new one with references to all images for amd64, arm64 and windows.

Details: 
1. Building and pushing all images for linux/amd64, e.g. `argoproj/argoexec:v2.11-linux-amd64` - this will only take around 6minutes
2. Create and push the manifest and reference only the linux/amd64 images yet, e.g. `argoproj/argoexec:v2.11` referencing only `argoproj/argoexec:v2.11-linux-amd64` for now
3. When all other images for Windows and linux/arm64 finished building after 40mins, we update and push the manifest overwriting the one created before to reference all images now instead of only the linux/amd64 ones, e.g. override `argoproj/argoexec:v2.11` now referencing `argoproj/argoexec:v2.11-linux-amd64`, `argoproj/argoexec:v2.11-linux-arm64`, `argoproj/argoexec:v2.11-windows`

Example run: https://github.com/lippertmarkus/argo/actions/runs/270351664

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or **(c) this is a chore**.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged. **Not needed.**
* [x] My builds are green. Try syncing with master if they are not. 
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
