### PR TITLE
fix(docs): Update k3d command for running argo locally

### DIFF
--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -13,7 +13,7 @@
 We recommend using [K3D](https://k3d.io/) to set up the local Kubernetes cluster since this will allow you to test RBAC set-up and is fast. You can set-up K3D to be part of your default kube config as follows:
 
     cp ~/.kube/config ~/.kube/config.bak
-    cat $(k3d get-kubeconfig --name='k3s-default') >> ~/.kube/config
+    cat $(k3d kubeconfig get k3s-default) >> ~/.kube/config
     
 Alternatively, you can use [Minikube](https://github.com/kubernetes/minikube) to set up the local Kubernetes cluster. Once a local Kubernetes cluster has started via `minikube start`, your kube config will use Minikube's context automatically.
 


### PR DESCRIPTION
In the latest version of k3d, the command for getting a cluster has been updated.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
