### PR TITLE
fix(cli): add validate args in delete command

### DIFF
--- a/cmd/argo/commands/delete.go
+++ b/cmd/argo/commands/delete.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/argoproj/pkg/errors"
 	"github.com/spf13/cobra"
@@ -34,6 +35,11 @@ func NewDeleteCommand() *cobra.Command {
   argo delete @latest
 `,
 		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 0 && !(all || allNamespaces || flags.completed || flags.resubmitted || flags.prefix != "" || flags.labels != "" || flags.finishedAfter != "") {
+				cmd.HelpFunc()(cmd, args)
+				os.Exit(1)
+			}
+
 			ctx, apiClient := client.NewAPIClient()
 			serviceClient := apiClient.NewWorkflowServiceClient()
 			var workflows wfv1.Workflows

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -386,7 +386,7 @@ func (s *CLISuite) TestWorkflowDeleteNothing() {
 		When().
 		SubmitWorkflow().
 		RunCli([]string{"delete"}, func(t *testing.T, output string, err error) {
-			if assert.NoError(t, err) {
+			if assert.EqualError(t, err, "exit status 1") {
 				assert.NotContains(t, output, "deleted")
 			}
 		})


### PR DESCRIPTION
run `argo delete` command without arguments and no output, want output helpfunc. 
```
# argo delete
# echo $?
0
```
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
