### PR TITLE
fix(ui): handle logging disconnects gracefully. Fixes #4117

### DIFF
--- a/ui/src/app/shared/services/workflows-service.ts
+++ b/ui/src/app/shared/services/workflows-service.ts
@@ -1,12 +1,14 @@
-import {Observable, Observer} from 'rxjs';
-
-import {catchError, map} from 'rxjs/operators';
+import {Observable} from 'rxjs';
 import * as models from '../../../models';
-import {Event, Workflow, WorkflowList} from '../../../models';
+import {Event, NodeStatus, Workflow, WorkflowList} from '../../../models';
 import {SubmitOpts} from '../../../models/submit-opts';
 import {Pagination} from '../pagination';
 import requests from './requests';
 import {WorkflowDeleteResponse} from './responses';
+
+function isString(value: any): value is string {
+    return typeof value === 'string';
+}
 
 export class WorkflowsService {
     public create(workflow: Workflow, namespace: string) {
@@ -118,27 +120,58 @@ export class WorkflowsService {
             .then(res => res.body as Workflow);
     }
 
-    public getContainerLogs(workflow: Workflow, nodeId: string, container: string, archived: boolean): Observable<string> {
-        // we firstly try to get the logs from the API,
-        // but if that fails, then we try and get them from the artifacts
-        const logsFromArtifacts: Observable<string> = Observable.create((observer: Observer<string>) => {
-            requests
-                .get(this.getArtifactLogsUrl(workflow, nodeId, container, archived))
-                .then(resp => {
-                    resp.text.split('\n').forEach(line => observer.next(line));
-                })
-                .catch(err => observer.error(err));
-            // tslint:disable-next-line
-            return () => {};
-        });
+    public getContainerLogsFromCluster(workflow: Workflow, nodeId: string, container: string): Observable<string> {
+        const podLogsURL = `api/v1/workflows/${workflow.metadata.namespace}/${workflow.metadata.name}/${nodeId}/log?logOptions.container=${container}&logOptions.follow=true`;
         return requests
-            .loadEventSource(
-                `api/v1/workflows/${workflow.metadata.namespace}/${workflow.metadata.name}/${nodeId}/log` + `?logOptions.container=${container}&logOptions.follow=true`
-            )
-            .pipe(
-                map(line => JSON.parse(line).result.content),
-                catchError(() => logsFromArtifacts)
-            );
+            .loadEventSource(podLogsURL)
+            .map(line => JSON.parse(line).result.content)
+            .filter(isString)
+            .catch(() => {
+                // When an error occurs on an observable, RxJS is hard-coded to unsubscribe from the stream.  In the case
+                // that the connection to the server was interrupted while the node is still pending or running, this is not
+                // correct since we actually want the EventSource to re-connect and continue streaming logs.  In the event
+                // that the pod has completed, then we want to allow the unsubscribe to happen since no additional logs exist.
+                return Observable.fromPromise(this.isWorkflowNodePendingOrRunning(workflow, nodeId)).switchMap(isPendingOrRunning => {
+                    if (isPendingOrRunning) {
+                        return this.getContainerLogsFromCluster(workflow, nodeId, container);
+                    }
+
+                    // If our workflow is completed, then simply complete the Observable since nothing else
+                    // should be omitted
+                    return Observable.empty();
+                });
+            });
+    }
+
+    public async isWorkflowNodePendingOrRunning(workflow: Workflow, nodeId: string) {
+        // We always refresh the workflow rather than inspecting the state locally since it doubles
+        // as a check to determine whether or not the API is currently reachable
+        const updatedWorkflow = await this.get(workflow.metadata.namespace, workflow.metadata.name);
+        return this.isNodePendingOrRunning(updatedWorkflow.status.nodes[nodeId]);
+    }
+
+    public getContainerLogsFromArtifact(workflow: Workflow, nodeId: string, container: string, archived: boolean) {
+        return Observable.of(this.hasArtifactLogs(workflow, nodeId, container))
+            .switchMap(hasArtifactLogs => {
+                if (!hasArtifactLogs) {
+                    throw new Error('no artifact logs are available');
+                }
+
+                return Observable.fromPromise(requests.get(this.getArtifactLogsUrl(workflow, nodeId, container, archived)));
+            })
+            .mergeMap(r => r.text.split('\n'));
+    }
+
+    public getContainerLogs(workflow: Workflow, nodeId: string, container: string, archived: boolean): Observable<string> {
+        const getLogsFromArtifact = () => this.getContainerLogsFromArtifact(workflow, nodeId, container, archived);
+
+        // If our workflow is archived, don't even bother inspecting the cluster for logs since it's likely
+        // that the Workflow and associated pods have been deleted
+        if (archived) {
+            return getLogsFromArtifact();
+        }
+
+        return this.getContainerLogsFromCluster(workflow, nodeId, container).catch(getLogsFromArtifact);
     }
 
     public getArtifactLogsUrl(workflow: Workflow, nodeId: string, container: string, archived: boolean) {
@@ -149,6 +182,20 @@ export class WorkflowsService {
         return archived
             ? `artifacts-by-uid/${workflow.metadata.uid}/${nodeId}/${encodeURIComponent(artifactName)}`
             : `artifacts/${workflow.metadata.namespace}/${workflow.metadata.name}/${nodeId}/${encodeURIComponent(artifactName)}`;
+    }
+
+    private isNodePendingOrRunning(node: NodeStatus) {
+        return node.phase === models.NODE_PHASE.PENDING || node.phase === models.NODE_PHASE.RUNNING;
+    }
+
+    private hasArtifactLogs(workflow: Workflow, nodeId: string, container: string) {
+        const node = workflow.status.nodes[nodeId];
+
+        if (!node || !node.outputs) {
+            return false;
+        }
+
+        return node.outputs.artifacts.findIndex(a => a.name === `${container}-logs`) !== -1;
     }
 
     private queryParams(filter: {namespace?: string; name?: string; phases?: Array<string>; labels?: Array<string>; resourceVersion?: string}) {

--- a/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
+++ b/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 
-import {Subscription} from 'rxjs';
+import {Observable, Subscription} from 'rxjs';
 import * as models from '../../../../models';
+import {ErrorNotice} from '../../../shared/components/error-notice';
 import {services} from '../../../shared/services';
 import {FullHeightLogsViewer} from './full-height-logs-viewer';
 
@@ -21,9 +22,11 @@ interface WorkflowLogsViewerState {
 }
 
 export class WorkflowLogsViewer extends React.Component<WorkflowLogsViewerProps, WorkflowLogsViewerState> {
-    private subscription: Subscription = null;
+    private subscription: Subscription | null = null;
+
     constructor(props: WorkflowLogsViewerProps) {
         super(props);
+
         this.state = {lines: [], loaded: false};
     }
 
@@ -48,13 +51,10 @@ export class WorkflowLogsViewer extends React.Component<WorkflowLogsViewerProps,
                     <i className='fa fa-box' /> {this.props.nodeId}/{this.props.container}
                     {this.state.lines.length > 0 && <small className='muted'> {this.state.lines.length} line(s)</small>}
                 </p>
+
+                {this.state.error && <ErrorNotice error={this.state.error} onReload={() => this.refreshStream()} />}
                 <div className='white-box'>
-                    {this.state.error && (
-                        <p>
-                            <i className='fa fa-exclamation-triangle status-icon--failed' /> Failed to load logs: {this.state.error.message}
-                        </p>
-                    )}
-                    {!this.state.error && this.isWaitingForData() && (
+                    {this.isWaitingForData() && (
                         <p>
                             <i className='fa fa-circle-notch fa-spin' /> Waiting for data...
                         </p>
@@ -65,12 +65,8 @@ export class WorkflowLogsViewer extends React.Component<WorkflowLogsViewerProps,
                             <FullHeightLogsViewer
                                 source={{
                                     key: `${this.props.workflow.metadata.name}-${this.props.container}`,
-                                    loadLogs: () => {
-                                        return services.workflows.getContainerLogs(this.props.workflow, this.props.nodeId, this.props.container, this.props.archived).map(log => {
-                                            return log ? log + '\n' : '';
-                                        });
-                                    },
-                                    shouldRepeat: () => this.isCurrentNodeRunningOrPending()
+                                    loadLogs: () => Observable.from(this.state.lines),
+                                    shouldRepeat: () => false
                                 }}
                             />
                         </div>
@@ -98,15 +94,14 @@ export class WorkflowLogsViewer extends React.Component<WorkflowLogsViewerProps,
 
     private refreshStream(): void {
         this.ensureUnsubscribed();
+
+        this.setState({lines: [], loaded: false, error: undefined});
+
         this.subscription = services.workflows.getContainerLogs(this.props.workflow, this.props.nodeId, this.props.container, this.props.archived).subscribe(
             log => {
                 this.setState(state => {
                     const newState = {...state, loaded: true};
-
-                    if (log) {
-                        newState.lines = newState.lines.concat(log.split('\n'));
-                    }
-
+                    newState.lines.push(log + '\n');
                     return newState;
                 });
             },


### PR DESCRIPTION
When the API finishes streaming logs from a given container, it's normal for
the server to close the connection which results in an error being emitted in the browser.
When one of those errors is received, we check whether or not the node is still pending or
running which allows us to differentiate between a disconnection that happens due to a network
error, and a disconnect that happens due to the completion of log streaming.

Fixes #4117

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
