### PR TITLE
feat(cli): Print 'no resource msg' when `argo list/delete` returns zero workflows

### DIFF
--- a/cmd/argo/commands/delete.go
+++ b/cmd/argo/commands/delete.go
@@ -50,6 +50,12 @@ func NewDeleteCommand() *cobra.Command {
 				errors.CheckError(err)
 				workflows = append(workflows, listed...)
 			}
+
+			if len(workflows) == 0 {
+				fmt.Printf("No resources found\n")
+				return
+			}
+
 			for _, wf := range workflows {
 				if !dryRun {
 					_, err := serviceClient.DeleteWorkflow(ctx, &workflowpkg.WorkflowDeleteRequest{Name: wf.Name, Namespace: wf.Namespace})

--- a/cmd/argo/commands/list_test.go
+++ b/cmd/argo/commands/list_test.go
@@ -17,6 +17,12 @@ import (
 )
 
 func Test_listWorkflows(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		workflows, err := listEmpty(&metav1.ListOptions{}, listFlags{})
+		if assert.NoError(t, err) {
+			assert.Len(t, workflows, 0)
+		}
+	})
 	t.Run("Nothing", func(t *testing.T) {
 		workflows, err := list(&metav1.ListOptions{}, listFlags{})
 		if assert.NoError(t, err) {
@@ -84,6 +90,13 @@ func list(listOptions *metav1.ListOptions, flags listFlags) (wfv1.Workflows, err
 			Labels:            map[string]string{common.LabelKeyPreviousWorkflowName: "foo-"},
 		}},
 	}}, nil)
+	workflows, err := listWorkflows(context.Background(), c, flags)
+	return workflows, err
+}
+
+func listEmpty(listOptions *metav1.ListOptions, flags listFlags) (wfv1.Workflows, error) {
+	c := &workflowmocks.WorkflowServiceClient{}
+	c.On("ListWorkflows", mock.Anything, &workflow.WorkflowListRequest{ListOptions: listOptions}).Return(&wfv1.WorkflowList{Items: wfv1.Workflows{}}, nil)
 	workflows, err := listWorkflows(context.Background(), c, flags)
 	return workflows, err
 }

--- a/util/printer/workflow-printer.go
+++ b/util/printer/workflow-printer.go
@@ -16,6 +16,11 @@ import (
 )
 
 func PrintWorkflows(workflows wfv1.Workflows, out io.Writer, opts PrintOpts) error {
+	if len(workflows) == 0 {
+		_, _ = fmt.Fprintln(out, "No workflows found")
+		return nil
+	}
+
 	switch opts.Output {
 	case "", "wide":
 		printTable(workflows, out, opts)

--- a/util/printer/workflow-printer_test.go
+++ b/util/printer/workflow-printer_test.go
@@ -43,6 +43,14 @@ func TestPrintWorkflows(t *testing.T) {
 			},
 		},
 	}
+
+	var emptyWorkflows wfv1.Workflows
+	t.Run("Empty", func(t *testing.T) {
+		var b bytes.Buffer
+		assert.NoError(t, PrintWorkflows(emptyWorkflows, &b, PrintOpts{}))
+		assert.Equal(t, `No workflows found
+`, b.String())
+	})
 	t.Run("Default", func(t *testing.T) {
 		var b bytes.Buffer
 		assert.NoError(t, PrintWorkflows(workflows, &b, PrintOpts{}))


### PR DESCRIPTION

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
