### PR TITLE
chore(build): re-add #4127 and steps to verify image pull

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,6 +1,7 @@
 name: Docker Image CI
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - v*
@@ -23,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Docker Buildx
-        uses: crazy-max/ghaction-docker-buildx@v3
+        uses: docker/setup-buildx-action@v1
 
       - name: Cache Docker layers
         uses: actions/cache@v2
@@ -72,8 +73,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
-        uses: crazy-max/ghaction-docker-buildx@v3
+        uses: docker/setup-buildx-action@v1
 
       - name: Cache Docker layers
         uses: actions/cache@v2

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,12 +12,62 @@ defaults:
     shell: bash
 
 jobs:
-  build-linux:
-    name: Build & Push Linux Docker Images
+  build-linux-amd64:
+    name: Build & push linux/amd64
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: [linux/amd64, linux/arm64]
+        platform: [linux/amd64]
+        target: [workflow-controller, argocli, argoexec]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: crazy-max/ghaction-docker-buildx@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-${{ matrix.platform }}-${{ matrix.target }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.platform }}-${{ matrix.target }}-buildx-
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERIO_USERNAME }}
+          password: ${{ secrets.DOCKERIO_PASSWORD }}
+
+      - name: Docker Buildx
+        env:
+          DOCKERIO_ORG: ${{ secrets.DOCKERIO_ORG }}
+          PLATFORM: ${{ matrix.platform }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          tag=$(basename $GITHUB_REF)
+          if [ $tag = "master" ]; then
+            tag="latest"
+          fi
+
+          tag_suffix=$(echo $PLATFORM | sed -r "s/\//-/g")
+          image_name="${DOCKERIO_ORG}/${TARGET}:${tag}-${tag_suffix}"
+
+          docker buildx build \
+            --cache-from "type=local,src=/tmp/.buildx-cache" \
+            --cache-to "type=local,dest=/tmp/.buildx-cache" \
+            --output "type=image,push=true" \
+            --platform="${PLATFORM}" \
+            --target $TARGET \
+            --tag $image_name .
+
+  build-linux-arm64:
+    name: Build & push linux/arm64
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [linux/arm64]
         target: [workflow-controller, argocli, argoexec]
     steps:
       - uses: actions/checkout@v2
@@ -63,7 +113,7 @@ jobs:
             --tag $image_name .
 
   build-windows:
-    name: Build & Push Windows Docker Images
+    name: Build & push windows
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
@@ -90,10 +140,41 @@ jobs:
             docker push $image_name
           done
 
-  push-images:
-    name: Push Multiplatform Images
+  push-linux-amd64-images:
+    name: Push manifest with linux/amd64
     runs-on: ubuntu-latest
-    needs: [build-linux, build-windows]
+    needs: [build-linux-amd64]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker Login
+        uses: Azure/docker-login@v1
+        with:
+          username: ${{ secrets.DOCKERIO_USERNAME }}
+          password: ${{ secrets.DOCKERIO_PASSWORD }}
+      - name: Push Multiarch Image
+        env:
+          DOCKERIO_ORG: ${{ secrets.DOCKERIO_ORG }}
+        run: |
+          echo $(jq -c '. + { "experimental": "enabled" }' ${DOCKER_CONFIG}/config.json) > ${DOCKER_CONFIG}/config.json
+
+          docker_org=$DOCKERIO_ORG
+
+          tag=$(basename $GITHUB_REF)
+          if [ $tag = "master" ]; then
+            tag="latest"
+          fi
+
+          targets="workflow-controller argoexec argocli"
+          for target in $targets; do
+            image_name="${docker_org}/${target}:${tag}"
+            docker manifest create $image_name ${image_name}-linux-amd64
+            docker manifest push $image_name
+          done
+
+  push-images:
+    name: Push manifest with all images
+    runs-on: ubuntu-latest
+    needs: [build-linux-arm64, build-windows, push-linux-amd64-images]
     steps:
       - uses: actions/checkout@v2
       - name: Docker Login

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,7 +1,6 @@
 name: Docker Image CI
 
 on:
-  workflow_dispatch:
   push:
     tags:
       - v*
@@ -212,4 +211,58 @@ jobs:
             fi
 
             docker manifest push $image_name
+          done
+  test-images-linux-amd64:
+    name: Try pulling linux/amd64
+    runs-on: ubuntu-latest
+    needs: [push-images]
+    strategy:
+      matrix:
+        platform: [linux/amd64]
+        target: [workflow-controller, argocli, argoexec]
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERIO_USERNAME }}
+          password: ${{ secrets.DOCKERIO_PASSWORD }}
+
+      - name: Docker Buildx
+        env:
+          DOCKERIO_ORG: ${{ secrets.DOCKERIO_ORG }}
+          PLATFORM: ${{ matrix.platform }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          tag=$(basename $GITHUB_REF)
+          if [ $tag = "master" ]; then
+            tag="latest"
+          fi
+
+          image_name="${DOCKERIO_ORG}/${TARGET}:${tag}"
+          docker pull $image_name
+
+  test-images-windows:
+    name: Try pulling windows
+    runs-on: windows-2019
+    needs: [push-images]
+    steps:
+      - name: Docker Login
+        uses: Azure/docker-login@v1
+        with:
+          username: ${{ secrets.DOCKERIO_USERNAME }}
+          password: ${{ secrets.DOCKERIO_PASSWORD }}
+      - name: Try pulling
+        env:
+          DOCKERIO_ORG: ${{ secrets.DOCKERIO_ORG }}
+        run: |
+          docker_org=$DOCKERIO_ORG
+          tag=$(basename $GITHUB_REF)
+          if [ $tag = "master" ]; then
+            tag="latest"
+          fi
+
+          targets="argoexec"
+          for target in $targets; do
+            image_name="${docker_org}/${target}:${tag}"
+            docker pull $image_name
           done


### PR DESCRIPTION
Like discussed the pull error from #4216 seems to be caused by a rare corner-case where the Docker Hub failed somehow when the image was pushed. I don't think a specific change broke it as pulling the `latest`-images did work even before the revert of #4127.

- I re-added the changes from #4127 which you reverted
- I added a step which tries pulling all linux/amd64 and windows images after publishing to avoid such errors in the future

Example run: https://github.com/lippertmarkus/argo/actions/runs/289933647

You may also want to cherry-pick this to `release-2.11`.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or **(c) this is a chore.**
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
