### PR TITLE
docs: Reinstate swagger.md so docs can build.

### DIFF
--- a/docs/swagger.md
+++ b/docs/swagger.md
@@ -1,0 +1,3 @@
+# Argo Server API
+
+[Open the Swagger API docs](https://raw.githubusercontent.com/argoproj/argo/master/api/openapi-spec/swagger.json).


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
* [x] I've signed the CLA.
* [ ] ~~I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.~~
* [ ] My builds are green. Try syncing with master if they are not. 

Our doc are not being deployed due to this warning:

```
WARNING -  Documentation file 'rest-api.md' contains a link to 'swagger.md' which is not found in the documentation files. 
```

https://github.com/argoproj/argo/runs/1216143545?check_suite_focus=true