### PR TITLE
fix(Makefile): removed deprecated k3d cmds. Fixes #4206

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -2,12 +2,12 @@ name: CI
 on:
   push:
     branches:
-      - 'master'
-      - 'release-*'
-      - '!release-2.8'
+      - "master"
+      - "release-*"
+      - "!release-2.8"
   pull_request:
     branches:
-      - 'master'
+      - "master"
 
 jobs:
   tests:
@@ -29,14 +29,14 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: "1.13.12"
       - name: Add bins to PATH
         run: |
           echo "::add-path::/home/runner/go/bin"
           echo "::add-path::/usr/local/bin"
-      - name: Install and start K3S v1.0.1
+      - name: Install and start K3S v1.18.8+k3s1
         if: ${{ matrix.test != 'test' }}
-        run: curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.0.1 INSTALL_K3S_EXEC=--docker K3S_KUBECONFIG_MODE=644 sh - &
+        run: curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.18.8+k3s1 INSTALL_K3S_CHANNEL=stable INSTALL_K3S_EXEC=--docker K3S_KUBECONFIG_MODE=644 sh - &
       - name: Pre-pull images
         if: ${{ matrix.test != 'test' }}
         env:
@@ -97,7 +97,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: "1.13.12"
       - name: Add bins to PATH
         run: |
           echo "::add-path::/home/runner/go/bin"
@@ -140,7 +140,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: "14"
       - name: Restore node dependency cache
         uses: actions/cache@v1
         with:

--- a/USERS.md
+++ b/USERS.md
@@ -1,10 +1,13 @@
 ## Argo Workflows User Community Surveys & Feedback
+
 Please find [here](community/ArgoWorkflows2020SurveySummary.pdf) Argo Workflows user community 2020 survey results.
 
 ## Who uses Argo Workflows?
+
 As the Argo Community grows, we'd like to keep track of our users. Please send a PR with your organization name.
 
 Currently, the following organizations are **officially** using Argo Workflows:
+
 1. [23mofang](https://www.23mofang.com/)
 1. [Adevinta](https://www.adevinta.com/)
 1. [Admiralty](https://admiralty.io/)
@@ -90,3 +93,4 @@ Currently, the following organizations are **officially** using Argo Workflows:
 1. [Wavefront](https://www.wavefront.com/)
 1. [Wellcome Trust](https://wellcome.ac.uk/)
 1. [Helio](https://helio.exchange)
+1. [HSBC](https://hsbc.com)


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
* [ ] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 

PR related to: https://github.com/argoproj/argo/issues/4206

Removed the `if` clause completely coz `k3d start` doesn't mean anything there and `make start` seems to be alright, brings up both `argo-server` and `workflow-controller`. As for `github/workflow/ci-build.yaml` I don't think it's needed, coz I don't see any `k3d` commands in there, only `make start` ones which should be fine?

Also, changed context check as k3d prefixes `k3d-` to any cluster which user created and updates kubeconfig automatically.
