### PR TITLE
fix: Add WorkflowEventBinding to aggregated roles

### DIFF
--- a/manifests/cluster-install/workflow-controller-rbac/workflow-aggregate-roles.yaml
+++ b/manifests/cluster-install/workflow-controller-rbac/workflow-aggregate-roles.yaml
@@ -10,6 +10,8 @@ rules:
   resources:
   - workflows
   - workflows/finalizers
+  - workfloweventbinding
+  - workfloweventbinding/finalizers
   - workflowtemplates
   - workflowtemplates/finalizers
   - cronworkflows
@@ -34,6 +36,8 @@ rules:
   resources:
   - workflows
   - workflows/finalizers
+  - workfloweventbinding
+  - workfloweventbinding/finalizers
   - workflowtemplates
   - workflowtemplates/finalizers
   - cronworkflows
@@ -63,6 +67,8 @@ rules:
   resources:
   - workflows
   - workflows/finalizers
+  - workfloweventbinding
+  - workfloweventbinding/finalizers
   - workflowtemplates
   - workflowtemplates/finalizers
   - cronworkflows

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -146,6 +146,8 @@ rules:
   resources:
   - workflows
   - workflows/finalizers
+  - workfloweventbinding
+  - workfloweventbinding/finalizers
   - workflowtemplates
   - workflowtemplates/finalizers
   - cronworkflows
@@ -174,6 +176,8 @@ rules:
   resources:
   - workflows
   - workflows/finalizers
+  - workfloweventbinding
+  - workfloweventbinding/finalizers
   - workflowtemplates
   - workflowtemplates/finalizers
   - cronworkflows
@@ -202,6 +206,8 @@ rules:
   resources:
   - workflows
   - workflows/finalizers
+  - workfloweventbinding
+  - workfloweventbinding/finalizers
   - workflowtemplates
   - workflowtemplates/finalizers
   - cronworkflows


### PR DESCRIPTION
The aggregate roles in `cluster-install/workflow-controller-rbac` were missing `WorkflowEventBinding` CRD. - This PR should fix that.

Note: I don't know if `workfloweventbinding/finalizers` are even a thing, but I'm including them anyways. 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
* [x] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
