### PR TITLE
docs: Update quick-start and running-locally docs to help with running locally Argo

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -33,13 +33,13 @@ If you're using running Argo Workflows on a remote cluster (e.g. on EKS or GKE) 
 An alternative to quick test Argo locally is to use project [K3ai](https://docs.k3ai.in/). The automated installation provide you with a lightweight environment
 based on the popular Rancher K3s project.
 
-To use Argo with CPU only run:
+To use Argo with CPU only use:
 
 ```sh
 curl -sfL https://get.k3ai.in | bash -s -- --cpu --plugin_argo_workflow
 ```
 
-To use Argo with GPU support run:
+To use Argo with GPU support use:
 
 ```sh
 curl -sfL https://get.k3ai.in | bash -s -- --gpu --plugin_argo_workflow

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -30,6 +30,24 @@ This will serve the user interface on http://localhost:2746
 
 If you're using running Argo Workflows on a remote cluster (e.g. on EKS or GKE) then [follow these instructions](argo-server.md#access-the-argo-workflows-ui). 
 
+An alternative to quick test Argo locally is to use project [K3ai](https://docs.k3ai.in/). The automated installation provide you with a lightweight environment
+based on the popular Rancher K3s project.
+
+To explore Argo with CPU only run:
+
+```sh
+curl -sfL https://get.k3ai.in | bash -s -- --cpu --plugin_argo_workflow
+```
+
+To explore Argo with GPU support run:
+
+```sh
+curl -sfL https://get.k3ai.in | bash -s -- --gpu --plugin_argo_workflow
+```
+
+The automated installation will provide you the Argo UI address at the end of the process based. More option to run Argo on different enviroments (i.e.: WSL) are available
+on the K3ai site : [https://docs.k3ai.in/](https://docs.k3ai.in/)
+
 Next, Download the latest Argo CLI from our [releases page](https://github.com/argoproj/argo/releases).
 
 Finally, submit an example workflow:  

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -33,13 +33,13 @@ If you're using running Argo Workflows on a remote cluster (e.g. on EKS or GKE) 
 An alternative to quick test Argo locally is to use project [K3ai](https://docs.k3ai.in/). The automated installation provide you with a lightweight environment
 based on the popular Rancher K3s project.
 
-To explore Argo with CPU only run:
+To use Argo with CPU only run:
 
 ```sh
 curl -sfL https://get.k3ai.in | bash -s -- --cpu --plugin_argo_workflow
 ```
 
-To explore Argo with GPU support run:
+To use Argo with GPU support run:
 
 ```sh
 curl -sfL https://get.k3ai.in | bash -s -- --gpu --plugin_argo_workflow

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -1,5 +1,32 @@
 # Running Locally
 
+There are various alternatives to run Argo locally:
+
+- Running a pre-configured environment like K3ai
+- Building Argo from source
+
+# Using K3ai
+
+An alternative to quick test Argo locally is to use project [K3ai](https://docs.k3ai.in/). The automated installation provide you with a lightweight environment
+based on the popular Rancher K3s project.
+
+To explore Argo with CPU only run:
+
+```sh
+curl -sfL https://get.k3ai.in | bash -s -- --cpu --plugin_argo_workflow
+```
+
+To explore Argo with GPU support run:
+
+```sh
+curl -sfL https://get.k3ai.in | bash -s -- --gpu --plugin_argo_workflow
+```
+
+The automated installation will provide you the Argo UI address at the end of the process based. More option to run Argo on different enviroments (i.e.: WSL) are available
+on the K3ai site : [https://docs.k3ai.in/](https://docs.k3ai.in/)
+
+# Build Argo from source
+
 ## Pre-requisites
 
 * [Go](https://golang.org/dl/) (The project currently uses version 1.13)


### PR DESCRIPTION
Adding a way for users to experiment with Argo through a fully automated setup leveraging project k3ai. The goal of the project hence the reason to use it within Argo documentation is to provide community folks an easy way to setup a local environment closest as possible to what they may have in their DataCentre/Cloud envs.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
* [x] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
