### PR TITLE
feat(cli): Add the field selector option for delete command

### DIFF
--- a/cmd/argo/commands/delete.go
+++ b/cmd/argo/commands/delete.go
@@ -35,7 +35,7 @@ func NewDeleteCommand() *cobra.Command {
   argo delete @latest
 `,
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) == 0 && !(all || allNamespaces || flags.completed || flags.resubmitted || flags.prefix != "" || flags.labels != "" || flags.finishedAfter != "") {
+			if len(args) == 0 && !(all || allNamespaces || flags.completed || flags.resubmitted || flags.prefix != "" || flags.labels != "" || flags.fields != "" || flags.finishedAfter != "") {
 				cmd.HelpFunc()(cmd, args)
 				os.Exit(1)
 			}
@@ -51,7 +51,7 @@ func NewDeleteCommand() *cobra.Command {
 					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: flags.namespace},
 				})
 			}
-			if all || flags.completed || flags.resubmitted || flags.prefix != "" || flags.labels != "" || flags.finishedAfter != "" {
+			if all || flags.completed || flags.resubmitted || flags.prefix != "" || flags.labels != "" || flags.fields != "" || flags.finishedAfter != "" {
 				listed, err := listWorkflows(ctx, serviceClient, flags)
 				errors.CheckError(err)
 				workflows = append(workflows, listed...)
@@ -85,6 +85,7 @@ func NewDeleteCommand() *cobra.Command {
 	command.Flags().StringVar(&flags.prefix, "prefix", "", "Delete workflows by prefix")
 	command.Flags().StringVar(&flags.finishedAfter, "older", "", "Delete completed workflows finished before the specified duration (e.g. 10m, 3h, 1d)")
 	command.Flags().StringVarP(&flags.labels, "selector", "l", "", "Selector (label query) to filter on, not including uninitialized ones")
+	command.Flags().StringVar(&flags.fields, "field-selector", "", "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selectorkey1=value1,key2=value2). The server only supports a limited number of field queries per type.")
 	command.Flags().BoolVar(&dryRun, "dry-run", false, "Do not delete the workflow, only print what would happen")
 	return command
 }

--- a/docs/cli/argo_delete.md
+++ b/docs/cli/argo_delete.md
@@ -26,15 +26,16 @@ argo delete [--dry-run] [WORKFLOW...|[--all] [--older] [--completed] [--resubmit
 ### Options
 
 ```
-      --all               Delete all workflows
-      --all-namespaces    Delete workflows from all namespaces
-      --completed         Delete completed workflows
-      --dry-run           Do not delete the workflow, only print what would happen
-  -h, --help              help for delete
-      --older string      Delete completed workflows finished before the specified duration (e.g. 10m, 3h, 1d)
-      --prefix string     Delete workflows by prefix
-      --resubmitted       Delete resubmitted workflows
-  -l, --selector string   Selector (label query) to filter on, not including uninitialized ones
+      --all                     Delete all workflows
+      --all-namespaces          Delete workflows from all namespaces
+      --completed               Delete completed workflows
+      --dry-run                 Do not delete the workflow, only print what would happen
+      --field-selector string   Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selectorkey1=value1,key2=value2). The server only supports a limited number of field queries per type.
+  -h, --help                    help for delete
+      --older string            Delete completed workflows finished before the specified duration (e.g. 10m, 3h, 1d)
+      --prefix string           Delete workflows by prefix
+      --resubmitted             Delete resubmitted workflows
+  -l, --selector string         Selector (label query) to filter on, not including uninitialized ones
 ```
 
 ### Options inherited from parent commands

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -392,6 +393,23 @@ func (s *CLISuite) TestWorkflowDeleteByName() {
 			name = metadata.Name
 		}).
 		RunCli([]string{"delete", name}, func(t *testing.T, output string, err error) {
+			if assert.NoError(t, err) {
+				assert.Regexp(t, "Workflow 'basic-.*' deleted", output)
+			}
+		})
+}
+
+func (s *CLISuite) TestWorkflowDeleteByFieldSelector() {
+	var name string
+	s.Given().
+		Workflow("@smoke/basic.yaml").
+		When().
+		SubmitWorkflow().
+		Then().
+		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			name = metadata.Name
+		}).
+		RunCli([]string{"delete", "--field-selector", fmt.Sprintf("metadata.name=%s", name)}, func(t *testing.T, output string, err error) {
 			if assert.NoError(t, err) {
 				assert.Regexp(t, "Workflow 'basic-.*' deleted", output)
 			}


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 

Add to support `--field-selector` option for `delete` command.

This PR is separated from argoproj/argo#3962.


