### PR TITLE
fix(controller): Patch rather than update cron workflows.

### DIFF
--- a/workflow/cron/operator.go
+++ b/workflow/cron/operator.go
@@ -6,13 +6,14 @@ import (
 	"sort"
 	"time"
 
-	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/robfig/cron/v3"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo/pkg/client/clientset/versioned"
@@ -28,21 +29,18 @@ type cronWfOperationCtx struct {
 	// CronWorkflow is the CronWorkflow to be run
 	name        string
 	cronWf      *v1alpha1.CronWorkflow
-	origCronWf  *v1alpha1.CronWorkflow
 	wfClientset versioned.Interface
 	wfClient    typed.WorkflowInterface
 	wfLister    util.WorkflowLister
 	cronWfIf    typed.CronWorkflowInterface
 	log         *log.Entry
 	metrics     *metrics.Metrics
-	updated     bool
 }
 
 func newCronWfOperationCtx(cronWorkflow *v1alpha1.CronWorkflow, wfClientset versioned.Interface, wfLister util.WorkflowLister, metrics *metrics.Metrics) *cronWfOperationCtx {
 	return &cronWfOperationCtx{
 		name:        cronWorkflow.ObjectMeta.Name,
 		cronWf:      cronWorkflow,
-		origCronWf:  cronWorkflow.DeepCopy(),
 		wfClientset: wfClientset,
 		wfClient:    wfClientset.ArgoprojV1alpha1().Workflows(cronWorkflow.Namespace),
 		wfLister:    wfLister,
@@ -52,7 +50,6 @@ func newCronWfOperationCtx(cronWorkflow *v1alpha1.CronWorkflow, wfClientset vers
 			"namespace": cronWorkflow.ObjectMeta.Namespace,
 		}),
 		metrics: metrics,
-		updated: false,
 	}
 }
 
@@ -91,7 +88,6 @@ func (woc *cronWfOperationCtx) Run() {
 	woc.cronWf.Status.Active = append(woc.cronWf.Status.Active, getWorkflowObjectReference(wf, runWf))
 	woc.cronWf.Status.LastScheduledTime = &v1.Time{Time: time.Now()}
 	woc.cronWf.Status.Conditions.RemoveCondition(v1alpha1.ConditionTypeSubmissionError)
-	woc.updated = true
 }
 
 func (woc *cronWfOperationCtx) validateCronWorkflow() error {
@@ -102,7 +98,6 @@ func (woc *cronWfOperationCtx) validateCronWorkflow() error {
 		woc.reportCronWorkflowError(v1alpha1.ConditionTypeSpecError, fmt.Sprint(err))
 	} else {
 		woc.cronWf.Status.Conditions.RemoveCondition(v1alpha1.ConditionTypeSpecError)
-		woc.updated = true
 	}
 	return err
 }
@@ -121,75 +116,22 @@ func getWorkflowObjectReference(wf *v1alpha1.Workflow, runWf *v1alpha1.Workflow)
 }
 
 func (woc *cronWfOperationCtx) persistUpdate() {
-	if !woc.updated {
-		return
-	} else if woc.origCronWf.ResourceVersion != woc.cronWf.ResourceVersion {
-		woc.log.Error("cannot update cron workflow with mismatched resource versions")
+	data, err := json.Marshal(map[string]interface{}{"status": woc.cronWf.Status})
+	if err != nil {
+		woc.log.WithError(err).Error("failed to marshall cron workflow status data")
 		return
 	}
-
-	cronWf, err := woc.cronWfIf.Update(woc.cronWf)
-	if err != nil {
-		if !errors.IsConflict(err) {
-			woc.log.WithError(err).Error("failed to update CronWorkflow")
-			return
+	err = wait.ExponentialBackoff(retry.DefaultBackoff, func() (bool, error) {
+		cronWf, err := woc.cronWfIf.Patch(woc.cronWf.Name, types.MergePatchType, data)
+		if err != nil {
+			return false, err
 		}
-		var reapplyErr error
-		cronWf, reapplyErr = woc.reapplyUpdate()
-		if reapplyErr != nil {
-			woc.log.WithError(reapplyErr).WithField("original error", err).Error("failed to update CronWorkflow after reapply attempt")
-			return
-		} else {
-			woc.cronWf = cronWf
-		}
-	} else {
 		woc.cronWf = cronWf
-	}
-}
-
-func (woc *cronWfOperationCtx) reapplyUpdate() (*v1alpha1.CronWorkflow, error) {
-	if woc.origCronWf.ResourceVersion != woc.cronWf.ResourceVersion {
-		return nil, fmt.Errorf("cannot re-apply cron workflow update with mismatched resource versions")
-	}
-	orig, err := json.Marshal(woc.origCronWf)
+		return true, nil
+	})
 	if err != nil {
-		return nil, err
-	}
-	curr, err := json.Marshal(woc.cronWf)
-	if err != nil {
-		return nil, err
-	}
-	patch, err := jsonpatch.CreateMergePatch(orig, curr)
-	if err != nil {
-		return nil, err
-	}
-	attempts := 0
-	for {
-		currCronWf, err := woc.cronWfIf.Get(woc.name, v1.GetOptions{})
-		if err != nil {
-			return nil, err
-		}
-		currCronWfBytes, err := json.Marshal(currCronWf)
-		if err != nil {
-			return nil, err
-		}
-		newCronWfBytes, err := jsonpatch.MergePatch(currCronWfBytes, patch)
-		if err != nil {
-			return nil, err
-		}
-		var newCronWf v1alpha1.CronWorkflow
-		err = json.Unmarshal(newCronWfBytes, &newCronWf)
-		if err != nil {
-			return nil, err
-		}
-		cronWf, err := woc.cronWfIf.Update(&newCronWf)
-		if err == nil {
-			return cronWf, nil
-		}
-		attempts++
-		if attempts == 5 {
-			return nil, fmt.Errorf("ran out of retries when trying to reapply update: %s", err)
-		}
+		woc.log.WithError(err).Error("failed to data cron workflow")
+		return
 	}
 }
 
@@ -316,7 +258,6 @@ func (woc *cronWfOperationCtx) removeActiveWf(wf *v1alpha1.Workflow) {
 		return
 	}
 	woc.removeFromActiveList(wf.ObjectMeta.UID)
-	woc.updated = true
 }
 
 func (woc *cronWfOperationCtx) removeFromActiveList(uid types.UID) {
@@ -327,7 +268,6 @@ func (woc *cronWfOperationCtx) removeFromActiveList(uid types.UID) {
 		}
 	}
 	woc.cronWf.Status.Active = newActive
-	woc.updated = true
 }
 
 func (woc *cronWfOperationCtx) enforceHistoryLimit() {
@@ -409,5 +349,4 @@ func (woc *cronWfOperationCtx) reportCronWorkflowError(conditionType v1alpha1.Co
 		Status:  v1.ConditionTrue,
 	})
 	woc.metrics.CronWorkflowSubmissionError()
-	woc.updated = true
 }

--- a/workflow/cron/operator_test.go
+++ b/workflow/cron/operator_test.go
@@ -174,7 +174,6 @@ func TestCronWorkflowConditionSubmissionError(t *testing.T) {
 		wfClient:    cs.ArgoprojV1alpha1().Workflows(""),
 		cronWfIf:    cs.ArgoprojV1alpha1().CronWorkflows(""),
 		wfLister:    &fakeLister{},
-		origCronWf:  cronWf.DeepCopy(),
 		cronWf:      &cronWf,
 		log:         logrus.WithFields(logrus.Fields{}),
 		metrics:     testMetrics,
@@ -231,7 +230,6 @@ func TestSpecError(t *testing.T) {
 		wfClient:    cs.ArgoprojV1alpha1().Workflows(""),
 		cronWfIf:    cs.ArgoprojV1alpha1().CronWorkflows(""),
 		wfLister:    &fakeLister{},
-		origCronWf:  cronWf.DeepCopy(),
 		cronWf:      &cronWf,
 		log:         logrus.WithFields(logrus.Fields{}),
 		metrics:     testMetrics,
@@ -244,34 +242,4 @@ func TestSpecError(t *testing.T) {
 	assert.Equal(t, v1.ConditionTrue, submissionErrorCond.Status)
 	assert.Equal(t, v1alpha1.ConditionTypeSpecError, submissionErrorCond.Type)
 	assert.Contains(t, submissionErrorCond.Message, "cron schedule is malformed: end of range (12737123) above maximum (12): 12737123")
-}
-
-func TestReapplyUpdate(t *testing.T) {
-	cronWf := v1alpha1.CronWorkflow{
-		ObjectMeta: v1.ObjectMeta{Name: "my-wf"},
-		Spec:       v1alpha1.CronWorkflowSpec{Schedule: "* * * * *"},
-	}
-
-	cs := fake.NewSimpleClientset(&cronWf)
-	testMetrics := metrics.New(metrics.ServerConfig{}, metrics.ServerConfig{})
-	woc := &cronWfOperationCtx{
-		wfClientset: cs,
-		wfClient:    cs.ArgoprojV1alpha1().Workflows(""),
-		cronWfIf:    cs.ArgoprojV1alpha1().CronWorkflows(""),
-		wfLister:    &fakeLister{},
-		cronWf:      &cronWf,
-		origCronWf:  cronWf.DeepCopy(),
-		name:        cronWf.Name,
-		log:         logrus.WithFields(logrus.Fields{}),
-		metrics:     testMetrics,
-	}
-
-	cronWf.Spec.Schedule = "1 * * * *"
-	_, err := woc.reapplyUpdate()
-	if assert.NoError(t, err) {
-		updatedCronWf, err := woc.cronWfIf.Get("my-wf", v1.GetOptions{})
-		if assert.NoError(t, err) {
-			assert.Equal(t, "1 * * * *", updatedCronWf.Spec.Schedule)
-		}
-	}
 }


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
* [x] I've signed the CLA.
* [ ] ~~I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.~~
* [ ] My builds are green. Try syncing with master if they are not. 

The `ResourceVersion` checks made the assumption that the corn operation context is used only once. It is wrong, it is used many times - each time `Run` is invoked. This change instead uses `Patch` to update the cron workflow status. I believe that, unlike for a workflow, this is safe because all the status fields can be patched safely.
