### PR TITLE
fix(cli): Fix panic on argo template lint without argument

### DIFF
--- a/cmd/argo/commands/template/lint.go
+++ b/cmd/argo/commands/template/lint.go
@@ -24,6 +24,10 @@ func NewLintCommand() *cobra.Command {
 		Use:   "lint (DIRECTORY | FILE1 FILE2 FILE3...)",
 		Short: "validate a file or directory of workflow template manifests",
 		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 0 {
+				cmd.HelpFunc()(cmd, args)
+				os.Exit(1)
+			}
 			err := ServerSideLint(args, strict)
 			if err != nil {
 				log.Fatal(err)

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -725,6 +725,14 @@ func (s *CLIWithServerSuite) TestWorkflowWatch() {
 }
 
 func (s *CLISuite) TestTemplate() {
+	s.Run("LintWithoutArgs", func() {
+		s.Given().RunCli([]string{"template", "lint"}, func(t *testing.T, output string, err error) {
+			if assert.Error(t, err) {
+				assert.Contains(t, output, "Usage:")
+			}
+		})
+	})
+
 	s.Run("Lint", func() {
 		s.Given().RunCli([]string{"template", "lint", "smoke/workflow-template-whalesay-template.yaml"}, func(t *testing.T, output string, err error) {
 			if assert.NoError(t, err) {


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
* [ ] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
Fixes #4285 