### PR TITLE
fix(build): Some minor Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ crds: $(GOPATH)/bin/controller-gen
 $(GOPATH)/bin/controller-gen:
 	trap 'rm -Rf vendor' EXIT
 	go mod vendor
-	go install ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
+	go install -mod=vendor ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
 
 $(GOPATH)/bin/go-to-protobuf:
 	trap 'rm -Rf vendor' EXIT

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,11 @@ define docker_pull
 	if [ $(K3D) = true ]; then k3d image import $(1); fi
 endef
 
+ifndef $(GOPATH)
+	GOPATH=$(shell go env GOPATH)
+	export GOPATH
+endif
+
 .PHONY: build
 build: status clis images manifests
 

--- a/Makefile
+++ b/Makefile
@@ -483,7 +483,7 @@ dist/mixed.swagger.json: $(GOPATH)/bin/swagger $(SWAGGER_FILES) dist/swagger-con
 dist/swaggifed.swagger.json: dist/mixed.swagger.json hack/swaggify.sh
 	cat dist/mixed.swagger.json | sed 's/VERSION/$(VERSION)/' | ./hack/swaggify.sh > dist/swaggifed.swagger.json
 
-dist/kubeified.swagger.json: dist/swaggifed.swagger.json dist/kubernetes.swagger.json 
+dist/kubeified.swagger.json: dist/swaggifed.swagger.json dist/kubernetes.swagger.json
 	go run ./hack/swagger kubeifyswagger dist/swaggifed.swagger.json dist/kubeified.swagger.json
 
 api/openapi-spec/swagger.json: dist/kubeified.swagger.json


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
* [x] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 

# GOPATH
I use the default `GOPATH`, i.e. `${HOME}/go`. The original Makefile required `GOPATH` to be set. However if it is not set you get this error:
```bash
# Pack UI into a Go file.
/bin/staticfiles -o server/static/files.go ui/dist/app
make: /bin/staticfiles: No such file or directory
make: *** [server/static/files.go] Error 1
```
If it is not set we can use `go env GOPATH`.

# -mod=vendor
I also got this error trying to build with `make` using Go `1.15.2`:
```bash
go install ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
without -mod=vendor, directory /Users/ids/projects/argo/vendor/sigs.k8s.io/controller-tools/cmd/controller-gen has no package path
make: *** [/Users/ids/go/bin/controller-gen] Error 1
```
I fix this by adding `-mod=vendor` to the `go install` command.

# whitespace
Some whitespace fixes (trailing whitespace, missing last newline)