### PR TITLE
docs: Fix incorrect link to static code analysis document

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,4 +14,4 @@ Security vulnerabilities will be disclosed via [release notes](docs/releasing.md
 
 ## Vulnerability Scanning
 
-See [static code analysis](static-code-analysis.md).
+See [static code analysis](docs/static-code-analysis.md).


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
