### PR TITLE
fix(ui): correct typing errors in cron-workflow-details

### DIFF
--- a/ui/src/app/cron-workflows/components/cron-workflow-details/cron-workflow-details.tsx
+++ b/ui/src/app/cron-workflows/components/cron-workflow-details/cron-workflow-details.tsx
@@ -1,7 +1,7 @@
 import {NotificationType, Page} from 'argo-ui';
 import * as React from 'react';
 import {RouteComponentProps} from 'react-router';
-import {CronWorkflow, Workflow} from '../../../../models';
+import {CronWorkflow} from '../../../../models';
 import {uiUrl} from '../../../shared/base';
 import {BasePage} from '../../../shared/components/base-page';
 import {ErrorNotice} from '../../../shared/components/error-notice';
@@ -97,24 +97,24 @@ export class CronWorkflowDetails extends BasePage<RouteComponentProps<any>, Stat
         return <CronWorkflowSummaryPanel cronWorkflow={this.state.cronWorkflow} onChange={cronWorkflow => this.setState({cronWorkflow})} />;
     }
 
-    private submitCronWorkflow() {
-        services.workflows
-            .submit('cronwf', this.name, this.namespace)
-            .catch(e => {
-                this.appContext.apis.notifications.show({
-                    content: 'Failed to submit cron workflow ' + e,
-                    type: NotificationType.Error
-                });
-            })
-            .then((submitted: Workflow) => {
+    private async submitCronWorkflow() {
+        try {
+            const submitted = await services.workflows.submit('cronwf', this.name, this.namespace);
+
+            try {
                 document.location.href = uiUrl(`workflows/${submitted.metadata.namespace}/${submitted.metadata.name}`);
-            })
-            .catch(e => {
+            } catch (e) {
                 this.appContext.apis.notifications.show({
                     content: 'Failed redirect to newly submitted cron workflow ' + e,
                     type: NotificationType.Error
                 });
+            }
+        } catch (e) {
+            this.appContext.apis.notifications.show({
+                content: 'Failed to submit cron workflow ' + e,
+                type: NotificationType.Error
             });
+        }
     }
 
     private deleteCronWorkflow() {
@@ -142,13 +142,13 @@ export class CronWorkflowDetails extends BasePage<RouteComponentProps<any>, Stat
             .get(this.name, this.namespace)
             .then(latest => jsonMergePatch.apply(latest, patch))
             .then(patched => services.cronWorkflows.update(patched, this.name, this.namespace))
+            .then((updated: CronWorkflow) => this.setState({cronWorkflow: updated}))
             .catch(e => {
                 this.appContext.apis.notifications.show({
                     content: 'Failed to suspend cron workflow ' + e,
                     type: NotificationType.Error
                 });
-            })
-            .then((updated: CronWorkflow) => this.setState({cronWorkflow: updated}));
+            });
     }
 
     private resumeCronWorkflow() {
@@ -159,12 +159,12 @@ export class CronWorkflowDetails extends BasePage<RouteComponentProps<any>, Stat
             .get(this.name, this.namespace)
             .then(latest => jsonMergePatch.apply(latest, patch))
             .then(patched => services.cronWorkflows.update(patched, this.name, this.namespace))
+            .then((updated: CronWorkflow) => this.setState({cronWorkflow: updated}))
             .catch(e => {
                 this.appContext.apis.notifications.show({
                     content: 'Failed to resume cron workflow ' + e,
                     type: NotificationType.Error
                 });
-            })
-            .then((updated: CronWorkflow) => this.setState({cronWorkflow: updated}));
+            });
     }
 }


### PR DESCRIPTION
#4164

This corrects the only violations of `strictFunctionTypes` found in this project, although we still need to fix those errors in upstream libs like `argo-ui` before we can potentially enable that option here.