### PR TITLE
docs: Update pvc example with correct resource indentation. Fixes #4330

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1097,36 +1097,36 @@ spec:
         arguments:
           parameters:
             - name: pvc-name
-              value: '{{ steps.generate-volume.outputs.parameters.pvc-name }}'
+              value: '{{steps.generate-volume.outputs.parameters.pvc-name}}'
     - - name: print
         template: print-message
         arguments:
           parameters:
             - name: pvc-name
-              value: '{{ steps.generate-volume.outputs.parameters.pvc-name }}'
+              value: '{{steps.generate-volume.outputs.parameters.pvc-name}}'
 
   - name: generate-volume
     inputs:
       parameters:
         - name: pvc-size
-      resource:
-        action: create
-        setOwnerReference: true
-        manifest: |
-          apiVersion: v1
-          kind: PersistentVolumeClaim
-          metadata:
-            generateName: pvc-example-
-          spec:
-            accessModes: ['ReadWriteOnce', 'ReadOnlyMany']
-            resources:
-              requests:
-                storage: '{{inputs.parameters.pvc-size}}'
-      outputs:
-        parameters:
-          - name: pvc-name
-            valueFrom:
-              jsonPath: '{.metadata.name}'
+    resource:
+      action: create
+      setOwnerReference: true
+      manifest: |
+        apiVersion: v1
+        kind: PersistentVolumeClaim
+        metadata:
+          generateName: pvc-example-
+        spec:
+          accessModes: ['ReadWriteOnce', 'ReadOnlyMany']
+          resources:
+            requests:
+              storage: '{{inputs.parameters.pvc-size}}'
+    outputs:
+      parameters:
+        - name: pvc-name
+          valueFrom:
+            jsonPath: '{.metadata.name}'
 
   - name: whalesay
     inputs:


### PR DESCRIPTION
The "resource" keyword should be a child of the template.  Not the "inputs" value.

This incorrect indentation will cause an error during an `argo submit` execution, like the one below.

Failed to parse workflow: error unmarshaling JSON: while decoding JSON: json: unknown field "resource"

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
* [ ] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
