### PR TITLE
chore: match code comments to the generated documentation

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -2352,7 +2352,7 @@
           "type": "string"
         },
         "failedJobsHistoryLimit": {
-          "description": "FailedJobsHistoryLimit is the number of successful jobs to be kept at a time",
+          "description": "FailedJobsHistoryLimit is the number of failed jobs to be kept at a time",
           "type": "integer",
           "format": "int32"
         },

--- a/pkg/apis/workflow/v1alpha1/cron_workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/cron_workflow_types.go
@@ -63,7 +63,7 @@ type CronWorkflowSpec struct {
 	StartingDeadlineSeconds *int64 `json:"startingDeadlineSeconds,omitempty" protobuf:"varint,5,opt,name=startingDeadlineSeconds"`
 	// SuccessfulJobsHistoryLimit is the number of successful jobs to be kept at a time
 	SuccessfulJobsHistoryLimit *int32 `json:"successfulJobsHistoryLimit,omitempty" protobuf:"varint,6,opt,name=successfulJobsHistoryLimit"`
-	// FailedJobsHistoryLimit is the number of successful jobs to be kept at a time
+	// FailedJobsHistoryLimit is the number of failed jobs to be kept at a time
 	FailedJobsHistoryLimit *int32 `json:"failedJobsHistoryLimit,omitempty" protobuf:"varint,7,opt,name=failedJobsHistoryLimit"`
 	// Timezone is the timezone against which the cron schedule will be calculated, e.g. "Asia/Tokyo". Default is machine's local time.
 	Timezone string `json:"timezone,omitempty" protobuf:"bytes,8,opt,name=timezone"`

--- a/pkg/apis/workflow/v1alpha1/generated.proto
+++ b/pkg/apis/workflow/v1alpha1/generated.proto
@@ -241,7 +241,7 @@ message CronWorkflowSpec {
   // SuccessfulJobsHistoryLimit is the number of successful jobs to be kept at a time
   optional int32 successfulJobsHistoryLimit = 6;
 
-  // FailedJobsHistoryLimit is the number of successful jobs to be kept at a time
+  // FailedJobsHistoryLimit is the number of failed jobs to be kept at a time
   optional int32 failedJobsHistoryLimit = 7;
 
   // Timezone is the timezone against which the cron schedule will be calculated, e.g. "Asia/Tokyo". Default is machine's local time.

--- a/pkg/apis/workflow/v1alpha1/openapi_generated.go
+++ b/pkg/apis/workflow/v1alpha1/openapi_generated.go
@@ -856,7 +856,7 @@ func schema_pkg_apis_workflow_v1alpha1_CronWorkflowSpec(ref common.ReferenceCall
 					},
 					"failedJobsHistoryLimit": {
 						SchemaProps: spec.SchemaProps{
-							Description: "FailedJobsHistoryLimit is the number of successful jobs to be kept at a time",
+							Description: "FailedJobsHistoryLimit is the number of failed jobs to be kept at a time",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},


### PR DESCRIPTION
PR #4357 introduced a change to some generated documentation, but did not update the associated
comment in code, so CI would continually fail on the codegen step.  This updates the comment to match
what the desired docs are.
