### PR TITLE
fix: Ensure resourceDuration variables in metrics are always in seconds

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -91,7 +91,7 @@ step.
 | `inputs.parameters.<NAME>` | Input parameter of the metric-emitting template |
 | `outputs.parameters.<NAME>` | Output parameter of the metric-emitting template |
 | `outputs.result` | Output result of the metric-emitting template |
-| `resourcesDuration` | Resources duration as a string. Can also be indexed for a selected resource, if available (may be one of `resourcesDuration.cpu` or `resourcesDuration.memory`. For more info, see the [Resource Duration](resource-duration.md) doc.|
+| `resourcesDuration.{cpu,memory}` | Resources duration **in seconds**. Must be one of `resourcesDuration.cpu` or `resourcesDuration.memory`, if available. For more info, see the [Resource Duration](resource-duration.md) doc.|
 
 ### Realtime Metrics
 

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -521,9 +521,8 @@ func (woc *wfOperationCtx) prepareMetricScope(node *wfv1.NodeStatus) (map[string
 	}
 
 	if node.ResourcesDuration != nil {
-		localScope[common.LocalVarResourcesDuration] = node.ResourcesDuration.String()
 		for name, duration := range node.ResourcesDuration {
-			localScope[fmt.Sprintf("%s.%s", common.LocalVarResourcesDuration, name)] = duration.String()
+			localScope[fmt.Sprintf("%s.%s", common.LocalVarResourcesDuration, name)] = fmt.Sprint(duration.Duration().Seconds())
 		}
 	}
 

--- a/workflow/controller/steps_test.go
+++ b/workflow/controller/steps_test.go
@@ -161,9 +161,7 @@ func TestResourceDurationMetric(t *testing.T) {
 	err := yaml.Unmarshal([]byte(nodeStatus), &node)
 	if assert.NoError(t, err) {
 		localScope, _ := woc.prepareMetricScope(&node)
-		assert.Contains(t, localScope["resourcesDuration"], "24s*(100Mi memory)")
-		assert.Contains(t, localScope["resourcesDuration"], "33s*(1 cpu)")
-		assert.Equal(t, "33s", localScope["resourcesDuration.cpu"])
-		assert.Equal(t, "24s", localScope["resourcesDuration.memory"])
+		assert.Equal(t, "33", localScope["resourcesDuration.cpu"])
+		assert.Equal(t, "24", localScope["resourcesDuration.memory"])
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/argoproj/argo/issues/4402

~**Still needs tests**~

Signed-off-by: Simon Behar <simbeh7@gmail.com>

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
* [ ] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
