### PR TITLE
fix(docs): update link to container spec

### DIFF
--- a/docs/workflow-concepts.md
+++ b/docs/workflow-concepts.md
@@ -45,7 +45,7 @@ These templates _define_ work to be done, usually in a Container.
 
 ##### [Container](fields.md#container)
 
-Perhaps the most common template type, it will schedule a Container. The spec of the template is the same as the [K8s container spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#container-v1-core), so you can define a container here the same way you do anywhere else in K8s.
+Perhaps the most common template type, it will schedule a Container. The spec of the template is the same as the [K8s container spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#container-v1-core), so you can define a container here the same way you do anywhere else in K8s.
     
 Example:
 ```yaml


### PR DESCRIPTION
The old link points to a missing page. This uses a newer spec version but the page does exist.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
