### PR TITLE
fix(ui): Check node children before counting them.

### DIFF
--- a/ui/src/app/workflows/components/workflow-dag/workflow-dag.tsx
+++ b/ui/src/app/workflows/components/workflow-dag/workflow-dag.tsx
@@ -607,7 +607,7 @@ export class WorkflowDag extends React.Component<WorkflowDagProps, WorkflowDagRe
         // Filter the node if it is a virtual node or a Retry node with one child
         return (
             !(this.state.nodesToDisplay.includes('type:' + node.type) && this.state.nodesToDisplay.includes('phase:' + node.phase)) ||
-            (node.type === 'Retry' && node.children.length === 1)
+            (node.type === 'Retry' && node.children && node.children.length === 1)
         );
     }
 


### PR DESCRIPTION
We recently had Argo UI (v2.11.7) crash with the following error when trying to show hidden nodes:
```
Cannot read property 'length' of undefined
 Reload this page to try again.

Stack Trace
TypeError: Cannot read property 'length' of undefined
    at t.hiddenNode (https://argo.intacct.training.sail.sagedatacloud.com/main.44d1c937d2b2bb2c533b.js:478:443061)
    at t.generateEdge (https://argo.intacct.training.sail.sagedatacloud.com/main.44d1c937d2b2bb2c533b.js:478:441687)
    at https://argo.intacct.training.sail.sagedatacloud.com/main.44d1c937d2b2bb2c533b.js:478:440362
    at Array.forEach (<anonymous>)
    at t.layoutGraphPretty (https://argo.intacct.training.sail.sagedatacloud.com/main.44d1c937d2b2bb2c533b.js:478:440321)
    at t.layoutGraph (https://argo.intacct.training.sail.sagedatacloud.com/main.44d1c937d2b2bb2c533b.js:478:443275)
    at t.render (https://argo.intacct.training.sail.sagedatacloud.com/main.44d1c937d2b2bb2c533b.js:478:435385)
    at Ei (https://argo.intacct.training.sail.sagedatacloud.com/main.44d1c937d2b2bb2c533b.js:396:62906)
    at Oi (https://argo.intacct.training.sail.sagedatacloud.com/main.44d1c937d2b2bb2c533b.js:396:62701)
    at Pi (https://argo.intacct.training.sail.sagedatacloud.com/main.44d1c937d2b2bb2c533b.js:396:66535)
Component Stack

    in t
    in t
    in div
    in div
    in div
    in div
    in div
    in Unknown
    in t
    in t
    in t
    in Unknown
    in t
    in t
    in t
    in div
    in Unknown
    in t
    in n
```

The browser console contained the following message:
```
TypeError: Cannot read property 'length' of undefined
    at t.hiddenNode (workflow-dag.tsx:592)
    at t.generateEdge (workflow-dag.tsx:530)
    at workflow-dag.tsx:463
    at Array.forEach (<anonymous>)
    at t.layoutGraphPretty (workflow-dag.tsx:462)
    at t.layoutGraph (workflow-dag.tsx:606)
    at t.render (workflow-dag.tsx:196)
    at Ei (react-dom.production.min.js:173)
    at Oi (react-dom.production.min.js:172)
    at Pi (react-dom.production.min.js:180)
ha @ react-dom.production.min.js:198
Ma.i.componentDidCatch.n.callback @ react-dom.production.min.js:211
oa @ react-dom.production.min.js:193
ra @ react-dom.production.min.js:193
Ha @ react-dom.production.min.js:216
Va @ react-dom.production.min.js:220
(anonymous) @ react-dom.production.min.js:250
t.unstable_runWithPriority @ scheduler.production.min.js:18
Ts @ react-dom.production.min.js:250
Es @ react-dom.production.min.js:249
Ds @ react-dom.production.min.js:248
js @ react-dom.production.min.js:251
Cn @ react-dom.production.min.js:85
```

The stack trace is apparently pointing to the [location](https://github.com/argoproj/argo/blob/v2.11.7/ui/src/app/workflows/components/workflow-dag/workflow-dag.tsx#L592) checking the node children's length, so this change adds a check to for the children attribute before trying to access the length. The workflow this happens on seems to have been left by the workflow controller in a bad state (node statuses not matching the workflow status or pod status), but being able to see such workflow in the UI is still very useful.

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
