### PR TITLE
fix(server): Add `list sa` and `create secret` to `argo-server` roles. Closes #4526

### DIFF
--- a/manifests/cluster-install/argo-server-rbac/argo-server-clusterole.yaml
+++ b/manifests/cluster-install/argo-server-rbac/argo-server-clusterole.yaml
@@ -17,6 +17,7 @@ rules:
       - secrets
     verbs:
       - get
+      - create
   - apiGroups:
       - ""
     resources:
@@ -39,10 +40,10 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - secrets
       - serviceaccounts
     verbs:
       - get
+      - list
   - apiGroups:
       - argoproj.io
     resources:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -159,7 +159,7 @@ rules:
   - delete
   - deletecollection
   - get
-:  - list
+  - list
   - patch
   - update
   - watch

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -159,7 +159,7 @@ rules:
   - delete
   - deletecollection
   - get
-  - list
+:  - list
   - patch
   - update
   - watch
@@ -358,7 +358,6 @@ rules:
   verbs:
   - get
   - list
-
 - apiGroups:
   - argoproj.io
   resources:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -331,6 +331,7 @@ rules:
   - secrets
   verbs:
   - get
+  - create
 - apiGroups:
   - ""
   resources:
@@ -353,10 +354,11 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
   - serviceaccounts
   verbs:
   - get
+  - list
+
 - apiGroups:
   - argoproj.io
   resources:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -261,10 +261,10 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
   - serviceaccounts
   verbs:
   - get
+  - list
 - apiGroups:
   - argoproj.io
   resources:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -238,6 +238,7 @@ rules:
   - secrets
   verbs:
   - get
+  - create
 - apiGroups:
   - ""
   resources:

--- a/manifests/namespace-install/argo-server-rbac/argo-server-role.yaml
+++ b/manifests/namespace-install/argo-server-rbac/argo-server-role.yaml
@@ -40,10 +40,10 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - secrets
       - serviceaccounts
     verbs:
       - get
+      - list
   - apiGroups:
       - argoproj.io
     resources:

--- a/manifests/namespace-install/argo-server-rbac/argo-server-role.yaml
+++ b/manifests/namespace-install/argo-server-rbac/argo-server-role.yaml
@@ -17,6 +17,7 @@ rules:
       - secrets
     verbs:
       - get
+      - create
   - apiGroups:
       - ""
     resources:

--- a/manifests/quick-start-minimal.yaml
+++ b/manifests/quick-start-minimal.yaml
@@ -243,6 +243,7 @@ rules:
   - secrets
   verbs:
   - get
+  - create
 - apiGroups:
   - ""
   resources:
@@ -265,10 +266,10 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
   - serviceaccounts
   verbs:
   - get
+  - list
 - apiGroups:
   - argoproj.io
   resources:

--- a/manifests/quick-start-minimal.yaml
+++ b/manifests/quick-start-minimal.yaml
@@ -612,7 +612,8 @@ spec:
         runAsNonRoot: true
       serviceAccountName: argo-server
       volumes:
-      - name: tmp
+      - emptyDir: {}
+        name: tmp
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/quick-start-minimal.yaml
+++ b/manifests/quick-start-minimal.yaml
@@ -612,8 +612,7 @@ spec:
         runAsNonRoot: true
       serviceAccountName: argo-server
       volumes:
-      - emptyDir: {}
-        name: tmp
+      - name: tmp
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/quick-start-mysql.yaml
+++ b/manifests/quick-start-mysql.yaml
@@ -243,6 +243,7 @@ rules:
   - secrets
   verbs:
   - get
+  - create
 - apiGroups:
   - ""
   resources:
@@ -265,10 +266,10 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
   - serviceaccounts
   verbs:
   - get
+  - list
 - apiGroups:
   - argoproj.io
   resources:

--- a/manifests/quick-start-mysql.yaml
+++ b/manifests/quick-start-mysql.yaml
@@ -656,8 +656,7 @@ spec:
         runAsNonRoot: true
       serviceAccountName: argo-server
       volumes:
-      - emptyDir: {}
-        name: tmp
+      - name: tmp
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/quick-start-mysql.yaml
+++ b/manifests/quick-start-mysql.yaml
@@ -656,7 +656,8 @@ spec:
         runAsNonRoot: true
       serviceAccountName: argo-server
       volumes:
-      - name: tmp
+      - emptyDir: {}
+        name: tmp
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/quick-start-postgres.yaml
+++ b/manifests/quick-start-postgres.yaml
@@ -243,6 +243,7 @@ rules:
   - secrets
   verbs:
   - get
+  - create
 - apiGroups:
   - ""
   resources:
@@ -265,10 +266,10 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
   - serviceaccounts
   verbs:
   - get
+  - list
 - apiGroups:
   - argoproj.io
   resources:

--- a/manifests/quick-start-postgres.yaml
+++ b/manifests/quick-start-postgres.yaml
@@ -656,8 +656,7 @@ spec:
         runAsNonRoot: true
       serviceAccountName: argo-server
       volumes:
-      - emptyDir: {}
-        name: tmp
+      - name: tmp
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/quick-start-postgres.yaml
+++ b/manifests/quick-start-postgres.yaml
@@ -656,7 +656,8 @@ spec:
         runAsNonRoot: true
       serviceAccountName: argo-server
       volumes:
-      - name: tmp
+      - emptyDir: {}
+        name: tmp
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
In 2.12.0-rc1 when using SSO RBAC - argo fails to create the secret, due to missing permissions in the argo-server-role
https://github.com/argoproj/argo/blob/0931baf5fbe48487278b9a6c2fa206ab02406e5b/server/auth/sso/sso.go#L135-L138