### PR TITLE
feat: adds millisecond-level timestamps to argo and workflow-controller

### DIFF
--- a/cmd/argo/commands/common.go
+++ b/cmd/argo/commands/common.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	log "github.com/sirupsen/logrus"
+
 	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 )
 
@@ -41,6 +43,10 @@ const (
 )
 
 func initializeSession() {
+	log.SetFormatter(&log.TextFormatter{
+		TimestampFormat: "2006-01-02T15:04:05.000Z",
+		FullTimestamp:   true,
+	})
 	if noUtf8 {
 		jobStatusIconMap = map[wfv1.NodePhase]string{
 			wfv1.NodePending:   ansiFormat("Pending", FgYellow),

--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -108,6 +108,17 @@ func NewRootCommand() *cobra.Command {
 	return &command
 }
 
+func init() {
+	cobra.OnInitialize(initConfig)
+}
+
+func initConfig() {
+	log.SetFormatter(&log.TextFormatter{
+		TimestampFormat: "2006-01-02T15:04:05.000Z",
+		FullTimestamp:   true,
+	})
+}
+
 func main() {
 	if err := NewRootCommand().Execute(); err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
Adding millisecond-level timestamps in follow-up to #2795 so that we have them everywhere and not just in argoexec. Thanks to @astein-te for implementing the original feature request.

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
