### PR TITLE
fix: executor/pns containerid prefix fix

### DIFF
--- a/workflow/executor/pns/pns.go
+++ b/workflow/executor/pns/pns.go
@@ -418,9 +418,8 @@ func parseContainerIDFromCgroupLine(line string) string {
 		if containerID := parts[len(parts)-1]; containerID != "" {
 			// need to check for empty string because the line may look like: 5:rdma:/
 
-			// for crio we need to get rid of "crio-" prefix and ".scope" suffix
-			// e.g. crio-7a92a067289f6197148912be1c15f20f0330c7f3c541473d3b9c4043ca137b42.scope
-			containerID := strings.TrimSuffix(strings.TrimPrefix(containerID, "crio-"), ".scope")
+			// remove possible ".scope" suffix
+			containerID := strings.TrimSuffix(containerID, ".scope")
 
 			// for compatibility with cri-containerd record format when using systemd cgroup path
 			// example record in /proc/{pid}/cgroup:
@@ -428,8 +427,13 @@ func parseContainerIDFromCgroupLine(line string) string {
 			if strings.Contains(containerID, "cri-containerd") {
 				strList := strings.Split(containerID, ":")
 				containerID = strList[len(strList)-1]
-				containerID = strings.TrimPrefix(containerID, "cri-containerd-")
 			}
+
+			// get rid of possible "*-" prefix
+			// e.g. crio-7a92a067289f6197148912be1c15f20f0330c7f3c541473d3b9c4043ca137b42.scope
+			parts := strings.Split(containerID, "-")
+			containerID = parts[len(parts)-1]
+
 			return containerID
 		}
 	}

--- a/workflow/executor/pns/pns_test.go
+++ b/workflow/executor/pns/pns_test.go
@@ -39,6 +39,6 @@ func TestPNSExecutor_parseContainerIDFromCgroupLine(t *testing.T) {
 
 	for _, testCase := range testCases {
 		containerID := parseContainerIDFromCgroupLine(testCase.line)
-		assert.Equal(t, containerID, testCase.expected)
+		assert.Equal(t, testCase.expected, containerID)
 	}
 }

--- a/workflow/executor/pns/pns_test.go
+++ b/workflow/executor/pns/pns_test.go
@@ -31,6 +31,10 @@ func TestPNSExecutor_parseContainerIDFromCgroupLine(t *testing.T) {
 			line:     "8:cpu,cpuacct:/kubepods/besteffort/pod2fad8aad-dcd0-4fef-b45a-151630b9a4b5/crio-7a92a067289f6197148912be1c15f20f0330c7f3c541473d3b9c4043ca137b42.scope",
 			expected: "7a92a067289f6197148912be1c15f20f0330c7f3c541473d3b9c4043ca137b42",
 		},
+		{
+			line:     "2:cpuacct,cpu:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1cd87fe8_8ea0_11ea_8d51_566f300c000a.slice/docker-6b40fc7f75fe3210621a287412ac056e43554b1026a01625b48ba7d136d8a125.scope",
+			expected: "6b40fc7f75fe3210621a287412ac056e43554b1026a01625b48ba7d136d8a125",
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

In several environments, where docker is used **and** the kubelet and docker are managed by systemd, the cgroup line has a `docker-` prefix. [Here](https://github.com/cri-o/cri-o/issues/842#issuecomment-327428272) is a table of the possible combinations and the resulting cgroup lines.

This PR fixes the behaviour and removes all possible "\*-" prefixes, like "docker-*" in systemd controlled docker/kubelet environments.

Failing example before the fix:

```
time="2020-11-18T12:10:04.158Z" level=info msg="containerID docker-4bb908294439e857f63daec791892a3dddace0cd02bec10fe3f1c5d91589d31f mapped to pid 39"
time="2020-11-18T12:10:04.158Z" level=warning msg="Failed to get main PID: Failed to determine pid for containerID 4bb908294439e857f63daec791892a3dddace0cd02bec10fe3f1c5d91589d31f: container may have exited too quickly"
```



<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->

