### PR TITLE
fix(server): use the correct name when downloading artifacts

### DIFF
--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -924,6 +924,22 @@ func (a *ArtifactLocation) GetType() ArtifactLocationType {
 
 }
 
+func (a *ArtifactLocation) GetKey() string {
+	if a.S3 != nil {
+		return a.S3.Key
+	}
+
+	if a.OSS != nil {
+		return a.OSS.Key
+	}
+
+	if a.GCS != nil {
+		return a.GCS.Key
+	}
+
+	return ""
+}
+
 type ArtifactRepositoryRef struct {
 	ConfigMap string `json:"configMap,omitempty" protobuf:"bytes,1,opt,name=configMap"`
 	Key       string `json:"key,omitempty" protobuf:"bytes,2,opt,name=key"`

--- a/server/artifacts/artifact_server_test.go
+++ b/server/artifacts/artifact_server_test.go
@@ -2,9 +2,14 @@ package artifacts
 
 import (
 	"context"
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"testing"
+
+	artifact "github.com/argoproj/argo/workflow/artifacts"
+	"github.com/argoproj/argo/workflow/artifacts/resource"
 
 	"github.com/stretchr/testify/assert"
 	testhttp "github.com/stretchr/testify/http"
@@ -30,6 +35,19 @@ func mustParse(text string) *url.URL {
 	return u
 }
 
+type fakeArtifactDriver struct {
+	artifact.ArtifactDriver
+	data []byte
+}
+
+func (a *fakeArtifactDriver) Load(_ *wfv1.Artifact, path string) error {
+	return ioutil.WriteFile(path, a.data, 0666)
+}
+
+func (a *fakeArtifactDriver) Save(_ string, _ *wfv1.Artifact) error {
+	return fmt.Errorf("not implemented")
+}
+
 func newServer() *ArtifactServer {
 	gatekeeper := &authmocks.Gatekeeper{}
 	kube := kubefake.NewSimpleClientset()
@@ -44,10 +62,26 @@ func newServer() *ArtifactServer {
 					Outputs: &wfv1.Outputs{
 						Artifacts: wfv1.Artifacts{
 							{
-								Name: "my-artifact",
+								Name: "my-s3-artifact",
 								ArtifactLocation: wfv1.ArtifactLocation{
-									Raw: &wfv1.RawArtifact{
-										Data: "my-data",
+									S3: &wfv1.S3Artifact{
+										Key: "my-wf/my-node/my-s3-artifact.tgz",
+									},
+								},
+							},
+							{
+								Name: "my-gcs-artifact",
+								ArtifactLocation: wfv1.ArtifactLocation{
+									GCS: &wfv1.GCSArtifact{
+										Key: "my-wf/my-node/my-gcs-artifact",
+									},
+								},
+							},
+							{
+								Name: "my-oss-artifact",
+								ArtifactLocation: wfv1.ArtifactLocation{
+									GCS: &wfv1.GCSArtifact{
+										Key: "my-wf/my-node/my-oss-artifact.zip",
 									},
 								},
 							},
@@ -62,18 +96,46 @@ func newServer() *ArtifactServer {
 	gatekeeper.On("Context", mock.Anything).Return(ctx, nil)
 	a := &mocks.WorkflowArchive{}
 	a.On("GetWorkflow", "my-uuid").Return(wf, nil)
-	return NewArtifactServer(gatekeeper, hydratorfake.Noop, a, instanceid.NewService(instanceId))
+
+	fakeArtifactDriverFactory := func(_ *wfv1.Artifact, _ resource.Interface) (artifact.ArtifactDriver, error) {
+		return &fakeArtifactDriver{data: []byte("my-data")}, nil
+	}
+
+	return newArtifactServer(gatekeeper, hydratorfake.Noop, a, instanceid.NewService(instanceId), fakeArtifactDriverFactory)
 }
 
 func TestArtifactServer_GetArtifact(t *testing.T) {
 	s := newServer()
-	r := &http.Request{}
-	r.URL = mustParse("/artifacts/my-ns/my-wf/my-node/my-artifact")
-	w := &testhttp.TestResponseWriter{}
-	s.GetArtifact(w, r)
-	assert.Equal(t, 200, w.StatusCode)
-	assert.Equal(t, "filename=\"my-artifact.tgz\"", w.Header().Get("Content-Disposition"))
-	assert.Equal(t, "my-data", w.Output)
+
+	tests := []struct {
+		fileName     string
+		artifactName string
+	}{
+		{
+			fileName:     "my-s3-artifact.tgz",
+			artifactName: "my-s3-artifact",
+		},
+		{
+			fileName:     "my-gcs-artifact",
+			artifactName: "my-gcs-artifact",
+		},
+		{
+			fileName:     "my-oss-artifact.zip",
+			artifactName: "my-oss-artifact",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.artifactName, func(t *testing.T) {
+			r := &http.Request{}
+			r.URL = mustParse(fmt.Sprintf("/artifacts/my-ns/my-wf/my-node/%s", tt.artifactName))
+			w := &testhttp.TestResponseWriter{}
+			s.GetArtifact(w, r)
+			assert.Equal(t, 200, w.StatusCode)
+			assert.Equal(t, fmt.Sprintf(`filename="%s"`, tt.fileName), w.Header().Get("Content-Disposition"))
+			assert.Equal(t, "my-data", w.Output)
+		})
+	}
 }
 
 func TestArtifactServer_GetArtifactWithoutInstanceID(t *testing.T) {

--- a/workflow/artifacts/artifacts.go
+++ b/workflow/artifacts/artifacts.go
@@ -27,6 +27,8 @@ type ArtifactDriver interface {
 
 var ErrUnsupportedDriver = fmt.Errorf("unsupported artifact driver")
 
+type NewDriverFunc func(art *wfv1.Artifact, ri resource.Interface) (ArtifactDriver, error)
+
 // NewDriver initializes an instance of an artifact driver
 func NewDriver(art *wfv1.Artifact, ri resource.Interface) (ArtifactDriver, error) {
 	if art.S3 != nil {


### PR DESCRIPTION
When artifacts are uploaded to whatever repository is in use, they're stored
under a key that includes both the intended file name as well as the extension
to use based on whether or not compression was used when it was created.

Use that key as the file name when returning artifacts for download rather than
just "filename.tgz", that way we don't incorrectly identify non-compressed artifacts
as compressed tarballs.

Fixes #4252
