### PR TITLE
fix(controller): Prevent tasks with names starting with digit to use either 'depends' or 'dependencies'

### DIFF
--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -1204,7 +1204,7 @@ func (ctx *templateValidationCtx) validateDAG(scope map[string]interface{}, tmpl
 	// Verify dependencies for all tasks can be resolved as well as template names
 	for _, task := range tmpl.DAG.Tasks {
 
-		if (usingDepends || len(task.Dependencies) > 0) && '0' <= task.Name[0] && task.Name[0] <= '9' {
+		if '0' <= task.Name[0] && task.Name[0] <= '9' {
 			return errors.Errorf(errors.CodeBadRequest, "templates.%s.tasks.%s name cannot begin with a digit when using either 'depends' or 'dependencies'", tmpl.Name, task.Name)
 		}
 

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -1204,8 +1204,8 @@ func (ctx *templateValidationCtx) validateDAG(scope map[string]interface{}, tmpl
 	// Verify dependencies for all tasks can be resolved as well as template names
 	for _, task := range tmpl.DAG.Tasks {
 
-		if usingDepends && '0' <= task.Name[0] && task.Name[0] <= '9' {
-			return errors.Errorf(errors.CodeBadRequest, "templates.%s.tasks.%s name cannot begin with a digit when using 'depends'", tmpl.Name, task.Name)
+		if (usingDepends || len(task.Dependencies) > 0) && '0' <= task.Name[0] && task.Name[0] <= '9' {
+			return errors.Errorf(errors.CodeBadRequest, "templates.%s.tasks.%s name cannot begin with a digit when using either 'depends' or 'dependencies'", tmpl.Name, task.Name)
 		}
 
 		if usingDepends && len(task.Dependencies) > 0 {

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -1204,7 +1204,7 @@ func (ctx *templateValidationCtx) validateDAG(scope map[string]interface{}, tmpl
 	// Verify dependencies for all tasks can be resolved as well as template names
 	for _, task := range tmpl.DAG.Tasks {
 
-		if '0' <= task.Name[0] && task.Name[0] <= '9' {
+		if (usingDepends || len(task.Dependencies) > 0) && '0' <= task.Name[0] && task.Name[0] <= '9' {
 			return errors.Errorf(errors.CodeBadRequest, "templates.%s.tasks.%s name cannot begin with a digit when using either 'depends' or 'dependencies'", tmpl.Name, task.Name)
 		}
 

--- a/workflow/validate/validate_dag_test.go
+++ b/workflow/validate/validate_dag_test.go
@@ -743,3 +743,45 @@ func TestDAGDependsDigit(t *testing.T) {
 		assert.Contains(t, err.Error(), "templates.diamond.tasks.5A name cannot begin with a digit when using either 'depends' or 'dependencies'")
 	}
 }
+
+var dagDependenciesDigit = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: dag-diamond-
+spec:
+  entrypoint: diamond
+  templates:
+    - name: diamond
+      dag:
+        tasks:
+          - name: 5A
+            template: pass
+          - name: B
+            dependencies: [5A]
+            template: pass
+          - name: C
+            dependencies: [5A]
+            template: fail
+    - name: pass
+      container:
+        image: alpine:3.7
+        command:
+          - sh
+          - -c
+          - exit 0
+    - name: fail
+      container:
+        image: alpine:3.7
+        command:
+          - sh
+          - -c
+          - exit 1
+`
+
+func TestDAGDependenciesDigit(t *testing.T) {
+	_, err := validate(dagDependenciesDigit)
+	if assert.NotNil(t, err) {
+		assert.Contains(t, err.Error(), "templates.diamond.tasks.5A name cannot begin with a digit when using either 'depends' or 'dependencies'")
+	}
+}

--- a/workflow/validate/validate_dag_test.go
+++ b/workflow/validate/validate_dag_test.go
@@ -740,6 +740,6 @@ spec:
 func TestDAGDependsDigit(t *testing.T) {
 	_, err := validate(dagDependsDigit)
 	if assert.NotNil(t, err) {
-		assert.Contains(t, err.Error(), "templates.diamond.tasks.5A name cannot begin with a digit when using 'depends'")
+		assert.Contains(t, err.Error(), "templates.diamond.tasks.5A name cannot begin with a digit when using either 'depends' or 'dependencies'")
 	}
 }

--- a/workflow/validate/validate_dag_test.go
+++ b/workflow/validate/validate_dag_test.go
@@ -763,6 +763,18 @@ spec:
           - name: C
             dependencies: [5A]
             template: fail
+          - name: should-execute-1
+            depends: "'5A' && (C.Succeeded || C.Failed)"   # For more information about this depends field, see: docs/enhanced-depends-logic.md
+            template: pass
+          - name: should-execute-2
+            depends: B || C
+            template: pass
+          - name: should-not-execute
+            depends: B && C
+            template: pass
+          - name: should-execute-3
+            depends: should-execute-2.Succeeded || should-not-execute
+            template: pass
     - name: pass
       container:
         image: alpine:3.7


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo/issues/4570. Related https://github.com/argoproj/argo/issues/4199. It looks like `dependencies` is first converted into `depends` to support backwards compatibility ([related code](https://github.com/argoproj/argo/blob/4531d7936c25174b3251e926288866c69fc2dba3/workflow/common/ancestry.go#L100-L127)) so either 'depends' or 'dependencies' should fail the validation. 

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
