### PR TITLE
fix(cli): correct display of cron NextScheduledTime regardless of controller timezone

### DIFF
--- a/cmd/argo/commands/cron/get.go
+++ b/cmd/argo/commands/cron/get.go
@@ -91,7 +91,7 @@ func getCronWorkflowGet(cwf *wfv1.CronWorkflow) string {
 
 	next, err := GetNextRuntime(cwf)
 	if err == nil {
-		out += fmt.Sprintf(fmtStr, "NextScheduledTime:", humanize.Timestamp(next)+" (assumes workflow-controller is in UTC)")
+		out += fmt.Sprintf(fmtStr, "NextScheduledTime:", humanize.Timestamp(next))
 	}
 
 	if len(cwf.Status.Active) > 0 {

--- a/cmd/argo/commands/cron/root.go
+++ b/cmd/argo/commands/cron/root.go
@@ -7,7 +7,7 @@ import (
 func NewCronWorkflowCommand() *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "cron",
-		Short: "manage cron workflows\n\nNextScheduledRun assumes that the workflow-controller uses UTC as its timezone",
+		Short: "manage cron workflows",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)
 		},

--- a/cmd/argo/commands/cron/util.go
+++ b/cmd/argo/commands/cron/util.go
@@ -8,8 +8,7 @@ import (
 	"github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 )
 
-// GetNextRuntime returns the next time the workflow should run in local time. It assumes the workflow-controller is in
-// UTC, but nevertheless returns the time in the local timezone.
+// GetNextRuntime returns the next time the workflow should run in local timezone.
 func GetNextRuntime(cwf *v1alpha1.CronWorkflow) (time.Time, error) {
 	cronScheduleString := cwf.Spec.Schedule
 	if cwf.Spec.Timezone != "" {

--- a/docs/cli/argo.md
+++ b/docs/cli/argo.md
@@ -104,8 +104,6 @@ argo [flags]
 * [argo cluster-template](argo_cluster-template.md)	 - manipulate cluster workflow templates
 * [argo completion](argo_completion.md)	 - output shell completion code for the specified shell (bash or zsh)
 * [argo cron](argo_cron.md)	 - manage cron workflows
-
-NextScheduledRun assumes that the workflow-controller uses UTC as its timezone
 * [argo delete](argo_delete.md)	 - delete workflows
 * [argo get](argo_get.md)	 - display details about a workflow
 * [argo lint](argo_lint.md)	 - validate files or directories of workflow manifests

--- a/docs/cli/argo_cron.md
+++ b/docs/cli/argo_cron.md
@@ -2,13 +2,9 @@
 
 manage cron workflows
 
-NextScheduledRun assumes that the workflow-controller uses UTC as its timezone
-
 ### Synopsis
 
 manage cron workflows
-
-NextScheduledRun assumes that the workflow-controller uses UTC as its timezone
 
 ```
 argo cron [flags]

--- a/docs/cli/argo_cron_create.md
+++ b/docs/cli/argo_cron_create.md
@@ -60,5 +60,3 @@ argo cron create FILE1 FILE2... [flags]
 
 * [argo cron](argo_cron.md)	 - manage cron workflows
 
-NextScheduledRun assumes that the workflow-controller uses UTC as its timezone
-

--- a/docs/cli/argo_cron_delete.md
+++ b/docs/cli/argo_cron_delete.md
@@ -51,5 +51,3 @@ argo cron delete [CRON_WORKFLOW... | --all] [flags]
 
 * [argo cron](argo_cron.md)	 - manage cron workflows
 
-NextScheduledRun assumes that the workflow-controller uses UTC as its timezone
-

--- a/docs/cli/argo_cron_get.md
+++ b/docs/cli/argo_cron_get.md
@@ -51,5 +51,3 @@ argo cron get CRON_WORKFLOW... [flags]
 
 * [argo cron](argo_cron.md)	 - manage cron workflows
 
-NextScheduledRun assumes that the workflow-controller uses UTC as its timezone
-

--- a/docs/cli/argo_cron_lint.md
+++ b/docs/cli/argo_cron_lint.md
@@ -51,5 +51,3 @@ argo cron lint FILE... [flags]
 
 * [argo cron](argo_cron.md)	 - manage cron workflows
 
-NextScheduledRun assumes that the workflow-controller uses UTC as its timezone
-

--- a/docs/cli/argo_cron_list.md
+++ b/docs/cli/argo_cron_list.md
@@ -52,5 +52,3 @@ argo cron list [flags]
 
 * [argo cron](argo_cron.md)	 - manage cron workflows
 
-NextScheduledRun assumes that the workflow-controller uses UTC as its timezone
-

--- a/docs/cli/argo_cron_resume.md
+++ b/docs/cli/argo_cron_resume.md
@@ -50,5 +50,3 @@ argo cron resume [CRON_WORKFLOW...] [flags]
 
 * [argo cron](argo_cron.md)	 - manage cron workflows
 
-NextScheduledRun assumes that the workflow-controller uses UTC as its timezone
-

--- a/docs/cli/argo_cron_suspend.md
+++ b/docs/cli/argo_cron_suspend.md
@@ -50,5 +50,3 @@ argo cron suspend CRON_WORKFLOW... [flags]
 
 * [argo cron](argo_cron.md)	 - manage cron workflows
 
-NextScheduledRun assumes that the workflow-controller uses UTC as its timezone
-

--- a/docs/cron-workflows.md
+++ b/docs/cron-workflows.md
@@ -100,8 +100,6 @@ NextScheduledTime:             Thu Oct 29 13:03:00 +0000 (32 seconds from now)
 Active Workflows:              test-cron-wf-rt4nf
 ```
 
-**Note**: `NextScheduledRun` assumes that the workflow-controller uses UTC as its timezone
-
 ### `kubectl`
 
 Using `kubectl apply -f` and `kubectl get cwf`

--- a/ui/src/app/cron-workflows/components/cron-workflow-summary-panel.tsx
+++ b/ui/src/app/cron-workflows/components/cron-workflow-summary-panel.tsx
@@ -37,7 +37,7 @@ export const CronWorkflowSummaryPanel = (props: Props) => {
         {title: 'Last Scheduled Time', value: props.cronWorkflow.status.lastScheduledTime},
         {
             title: 'Next Scheduled Time',
-            value: getNextScheduledTime(props.cronWorkflow.spec.schedule, props.cronWorkflow.spec.timezone) + ' (assumes workflow-controller is in UTC)'
+            value: getNextScheduledTime(props.cronWorkflow.spec.schedule, props.cronWorkflow.spec.timezone)
         },
         {title: 'Conditions', value: <ConditionsPanel conditions={props.cronWorkflow.status.conditions} />}
     ];


### PR DESCRIPTION
This PR fixes the issue that 
when workflow-controller is set on a different timezone, 
`cli cron get` will produce inconsistent NextScheduledRun estimation

Signed-off-by: Tianchu Zhao <evantczhao@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
