### PR TITLE
feat(executor): More informative log when executors do not support output param from base image layer

### DIFF
--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -494,6 +494,12 @@ func (we *WorkflowExecutor) SaveParameters() error {
 
 		var output *wfv1.AnyString
 		if we.isBaseImagePath(param.ValueFrom.Path) {
+			executorType := os.Getenv(common.EnvVarContainerRuntimeExecutor)
+			if executorType == common.ContainerRuntimeExecutorK8sAPI || executorType == common.ContainerRuntimeExecutorKubelet {
+				log.Infof("Copying output parameter %s from base image layer %s is not supported for k8sapi and kubelet executors. " +
+					"Consider using an emptyDir volume: https://argoproj.github.io/argo/empty-dir/.", param.Name, param.ValueFrom.Path)
+				continue
+			}
 			log.Infof("Copying %s from base image layer", param.ValueFrom.Path)
 			fileContents, err := we.RuntimeExecutor.GetFileContents(mainCtrID, param.ValueFrom.Path)
 			if err != nil {

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -496,7 +496,7 @@ func (we *WorkflowExecutor) SaveParameters() error {
 		if we.isBaseImagePath(param.ValueFrom.Path) {
 			executorType := os.Getenv(common.EnvVarContainerRuntimeExecutor)
 			if executorType == common.ContainerRuntimeExecutorK8sAPI || executorType == common.ContainerRuntimeExecutorKubelet {
-				log.Infof("Copying output parameter %s from base image layer %s is not supported for k8sapi and kubelet executors. " +
+				log.Infof("Copying output parameter %s from base image layer %s is not supported for k8sapi and kubelet executors. "+
 					"Consider using an emptyDir volume: https://argoproj.github.io/argo/empty-dir/.", param.Name, param.ValueFrom.Path)
 				continue
 			}


### PR DESCRIPTION
Currently if we use k8sapi or kubelet executor with output parameters from base image layer, e.g. `/tmp`, we will see the following warning: 

```
Warning  WorkflowNodeError      9s    workflow-controller  Error node couler-test-2[1].heads-114: failed to save outputs: open /mainctrfs/tmp/dummy.txt: no such file or directory
```

This is a bit misleading and not informative to users.
 

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
