### PR TITLE
fix: Fix inconsistent persitence of cron workflow objects

### DIFF
--- a/workflow/cron/operator.go
+++ b/workflow/cron/operator.go
@@ -6,14 +6,13 @@ import (
 	"sort"
 	"time"
 
+	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/robfig/cron/v3"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/retry"
 
 	"github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo/pkg/client/clientset/versioned"
@@ -29,17 +28,20 @@ type cronWfOperationCtx struct {
 	// CronWorkflow is the CronWorkflow to be run
 	name        string
 	cronWf      *v1alpha1.CronWorkflow
+	origCronWf  *v1alpha1.CronWorkflow
 	wfClientset versioned.Interface
 	wfClient    typed.WorkflowInterface
 	cronWfIf    typed.CronWorkflowInterface
 	log         *log.Entry
 	metrics     *metrics.Metrics
+	updated     bool
 }
 
 func newCronWfOperationCtx(cronWorkflow *v1alpha1.CronWorkflow, wfClientset versioned.Interface, metrics *metrics.Metrics) *cronWfOperationCtx {
 	return &cronWfOperationCtx{
 		name:        cronWorkflow.ObjectMeta.Name,
 		cronWf:      cronWorkflow,
+		origCronWf:  cronWorkflow.DeepCopy(),
 		wfClientset: wfClientset,
 		wfClient:    wfClientset.ArgoprojV1alpha1().Workflows(cronWorkflow.Namespace),
 		cronWfIf:    wfClientset.ArgoprojV1alpha1().CronWorkflows(cronWorkflow.Namespace),
@@ -48,6 +50,7 @@ func newCronWfOperationCtx(cronWorkflow *v1alpha1.CronWorkflow, wfClientset vers
 			"namespace": cronWorkflow.ObjectMeta.Namespace,
 		}),
 		metrics: metrics,
+		updated: false,
 	}
 }
 
@@ -80,6 +83,7 @@ func (woc *cronWfOperationCtx) Run() {
 	woc.cronWf.Status.Active = append(woc.cronWf.Status.Active, getWorkflowObjectReference(wf, runWf))
 	woc.cronWf.Status.LastScheduledTime = &v1.Time{Time: time.Now()}
 	woc.cronWf.Status.Conditions.RemoveCondition(v1alpha1.ConditionTypeSubmissionError)
+	woc.updated = true
 }
 
 func (woc *cronWfOperationCtx) validateCronWorkflow() error {
@@ -90,6 +94,7 @@ func (woc *cronWfOperationCtx) validateCronWorkflow() error {
 		woc.reportCronWorkflowError(v1alpha1.ConditionTypeSpecError, fmt.Sprint(err))
 	} else {
 		woc.cronWf.Status.Conditions.RemoveCondition(v1alpha1.ConditionTypeSpecError)
+		woc.updated = true
 	}
 	return err
 }
@@ -108,22 +113,75 @@ func getWorkflowObjectReference(wf *v1alpha1.Workflow, runWf *v1alpha1.Workflow)
 }
 
 func (woc *cronWfOperationCtx) persistUpdate() {
-	data, err := json.Marshal(map[string]interface{}{"status": woc.cronWf.Status})
-	if err != nil {
-		woc.log.WithError(err).Error("failed to marshall cron workflow status data")
+	if !woc.updated {
+		return
+	} else if woc.origCronWf.ResourceVersion != woc.cronWf.ResourceVersion {
+		woc.log.Error("cannot update cron workflow with mismatched resource versions")
 		return
 	}
-	err = wait.ExponentialBackoff(retry.DefaultBackoff, func() (bool, error) {
-		cronWf, err := woc.cronWfIf.Patch(woc.cronWf.Name, types.MergePatchType, data)
-		if err != nil {
-			return false, err
-		}
-		woc.cronWf = cronWf
-		return true, nil
-	})
+
+	cronWf, err := woc.cronWfIf.Update(woc.cronWf)
 	if err != nil {
-		woc.log.WithError(err).Error("failed to data cron workflow")
-		return
+		if !errors.IsConflict(err) {
+			woc.log.WithError(err).Error("failed to update CronWorkflow")
+			return
+		}
+		var reapplyErr error
+		cronWf, reapplyErr = woc.reapplyUpdate()
+		if reapplyErr != nil {
+			woc.log.WithError(reapplyErr).WithField("original error", err).Error("failed to update CronWorkflow after reapply attempt")
+			return
+		} else {
+			woc.cronWf = cronWf
+		}
+	} else {
+		woc.cronWf = cronWf
+	}
+}
+
+func (woc *cronWfOperationCtx) reapplyUpdate() (*v1alpha1.CronWorkflow, error) {
+	if woc.origCronWf.ResourceVersion != woc.cronWf.ResourceVersion {
+		return nil, fmt.Errorf("cannot re-apply cron workflow update with mismatched resource versions")
+	}
+	orig, err := json.Marshal(woc.origCronWf)
+	if err != nil {
+		return nil, err
+	}
+	curr, err := json.Marshal(woc.cronWf)
+	if err != nil {
+		return nil, err
+	}
+	patch, err := jsonpatch.CreateMergePatch(orig, curr)
+	if err != nil {
+		return nil, err
+	}
+	attempts := 0
+	for {
+		currCronWf, err := woc.cronWfIf.Get(woc.name, v1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		currCronWfBytes, err := json.Marshal(currCronWf)
+		if err != nil {
+			return nil, err
+		}
+		newCronWfBytes, err := jsonpatch.MergePatch(currCronWfBytes, patch)
+		if err != nil {
+			return nil, err
+		}
+		var newCronWf v1alpha1.CronWorkflow
+		err = json.Unmarshal(newCronWfBytes, &newCronWf)
+		if err != nil {
+			return nil, err
+		}
+		cronWf, err := woc.cronWfIf.Update(&newCronWf)
+		if err == nil {
+			return cronWf, nil
+		}
+		attempts++
+		if attempts == 5 {
+			return nil, fmt.Errorf("ran out of retries when trying to reapply update: %s", err)
+		}
 	}
 }
 
@@ -249,6 +307,7 @@ func (woc *cronWfOperationCtx) removeFromActiveList(uid types.UID) {
 		}
 	}
 	woc.cronWf.Status.Active = newActive
+	woc.updated = true
 }
 
 func (woc *cronWfOperationCtx) enforceHistoryLimit(workflows []v1alpha1.Workflow) error {
@@ -320,4 +379,5 @@ func (woc *cronWfOperationCtx) reportCronWorkflowError(conditionType v1alpha1.Co
 		Status:  v1.ConditionTrue,
 	})
 	woc.metrics.CronWorkflowSubmissionError()
+	woc.updated = true
 }

--- a/workflow/cron/operator.go
+++ b/workflow/cron/operator.go
@@ -131,12 +131,9 @@ func (woc *cronWfOperationCtx) persistUpdate() {
 		if reapplyErr != nil {
 			woc.log.WithError(reapplyErr).WithField("original error", err).Error("failed to update CronWorkflow after reapply attempt")
 			return
-		} else {
-			woc.cronWf = cronWf
 		}
-	} else {
-		woc.cronWf = cronWf
 	}
+	woc.cronWf = cronWf
 }
 
 func (woc *cronWfOperationCtx) reapplyUpdate() (*v1alpha1.CronWorkflow, error) {

--- a/workflow/cron/operator.go
+++ b/workflow/cron/operator.go
@@ -115,9 +115,6 @@ func getWorkflowObjectReference(wf *v1alpha1.Workflow, runWf *v1alpha1.Workflow)
 func (woc *cronWfOperationCtx) persistUpdate() {
 	if !woc.updated {
 		return
-	} else if woc.origCronWf.ResourceVersion != woc.cronWf.ResourceVersion {
-		woc.log.Error("cannot update cron workflow with mismatched resource versions")
-		return
 	}
 
 	cronWf, err := woc.cronWfIf.Update(woc.cronWf)

--- a/workflow/cron/operator_test.go
+++ b/workflow/cron/operator_test.go
@@ -241,3 +241,32 @@ func TestSpecError(t *testing.T) {
 	assert.Equal(t, v1alpha1.ConditionTypeSpecError, submissionErrorCond.Type)
 	assert.Contains(t, submissionErrorCond.Message, "cron schedule is malformed: end of range (12737123) above maximum (12): 12737123")
 }
+
+func TestReapplyUpdate(t *testing.T) {
+	cronWf := v1alpha1.CronWorkflow{
+		ObjectMeta: v1.ObjectMeta{Name: "my-wf"},
+		Spec:       v1alpha1.CronWorkflowSpec{Schedule: "* * * * *"},
+	}
+
+	cs := fake.NewSimpleClientset(&cronWf)
+	testMetrics := metrics.New(metrics.ServerConfig{}, metrics.ServerConfig{})
+	woc := &cronWfOperationCtx{
+		wfClientset: cs,
+		wfClient:    cs.ArgoprojV1alpha1().Workflows(""),
+		cronWfIf:    cs.ArgoprojV1alpha1().CronWorkflows(""),
+		cronWf:      &cronWf,
+		origCronWf:  cronWf.DeepCopy(),
+		name:        cronWf.Name,
+		log:         logrus.WithFields(logrus.Fields{}),
+		metrics:     testMetrics,
+	}
+
+	cronWf.Spec.Schedule = "1 * * * *"
+	_, err := woc.reapplyUpdate()
+	if assert.NoError(t, err) {
+		updatedCronWf, err := woc.cronWfIf.Get("my-wf", v1.GetOptions{})
+		if assert.NoError(t, err) {
+			assert.Equal(t, "1 * * * *", updatedCronWf.Spec.Schedule)
+		}
+	}
+}


### PR DESCRIPTION
Maybe fixes: https://github.com/argoproj/argo/issues/4558

**What I think the issue is**

There are two places in the code where we read a cron workflow from the informer:

1. When building a context when processing a cron workflow CRD. The cron workflow is then stored and used by `Run` at the next scheduled runtime:
    https://github.com/argoproj/argo/blob/1212df4d19dd18045fd0aded7fd1dc5726f7d5c5/workflow/cron/controller.go#L124
2. When running `syncAll`:
    https://github.com/argoproj/argo/blob/1212df4d19dd18045fd0aded7fd1dc5726f7d5c5/workflow/cron/controller.go#L216

I believe that there is a chacne a cron workflow will be scheduled at the same time `syncAll` is called. When this happens `syncAll` will pick up a cron workflow from the informer that is identical to the one about to be use to schedule a workflow in `Run`. `Run` processes the cron workflow, schedules a new workflow, updates `LastScheduledTime` to the current time, and _patches_ the cron workflow in the cluster. At the same time, `syncAll` runs and since it never modifies `LastScheduledTime`, it _patches_ the cron workflow in the cluster to the _previous_ (and now incorrect) `LastScheduledTime`. As soon as this happens, the cron workflow controller picks up the most recent cron workflow (patched by `SyncAll`) and process it. Since it sees that the (incorrect) `LastScheduledTime` implies an execution was missed, it schedules a new workflow.

The main issue here is that we use `patch` to update the cron workflow (as changed in https://github.com/argoproj/argo/pull/4294). Since we use `patch`, there is no code that checks if we are trying to update an object with stale and outdated information.

**Why I think this solution may work**

Using `update` instead of `patch` guarantees that we won't update the cron workflow in the cluster with information that is now stale. Moreover, this approach allows us to run `reapplyUpdate` to attempt to reconcile the differences if the scenario above does indeed happen.

Moreover, I believe the reservation from #4294 does not apply:

> The ResourceVersion checks made the assumption that the corn operation context is used only once. It is wrong, it is used many times - each time Run is invoked.

I believe this is not true. It is true that `Run` would use the same `origCronWf` every time `Run` is called (i.e. every time the cron workflow is scheduled). However, since we create an entirely new context every time the cron workflow object in the cluster is modified (which includes new executions), we can guarantee that `origCronWf` will always be the most recent version that is present in the cluster.

The only exception to this is when the cron workflow in the cluster was modified _while_ `Run` was being executed. In which case there is even a stronger argument to using `update` instead of `patch`, in order to recognize this has happened.

**Why I believe #4294 introduced this bug**

From #4294:

>  This change instead uses Patch to update the cron workflow status. I believe that, unlike for a workflow, this is safe because all the status fields can be patched safely.

For the reasons above, I don't believe this is true.

**Would using deterministic workflow names fix this issue?**

Maybe in most cases. However, there is an edge case: After the `patch` is made with stale information and the controller tries to scheduled the "missed" workflow, it will fail because a workflow with that (deterministic) name will already exist. However, it is possible that the original workflow was completed and delete from the cluster in that time, in which case the "missed" workflow will still be scheduled.

Although I believe that using deterministic names is a hacky solution to this problem, I now do believe that we should use them as a whole regardless. To that end I have opened: https://github.com/argoproj/argo/pull/4638

**What is holding me back from fully endorsing this solution**

I would like to know why #4294 was done originally. I seem to recall a problem with cron workflows and mismatched `resourceVersions`. If that is the case, I think we should explore fixing that issue with a different approach. I would like @alexec to comment on this