### PR TITLE
feat(cli): Add shorthanded option -A for --all-namespaces

### DIFF
--- a/cmd/argo/commands/cron/list.go
+++ b/cmd/argo/commands/cron/list.go
@@ -58,7 +58,7 @@ func NewListCommand() *cobra.Command {
 			}
 		},
 	}
-	command.Flags().BoolVar(&listArgs.allNamespaces, "all-namespaces", false, "Show workflows from all namespaces")
+	command.Flags().BoolVarP(&listArgs.allNamespaces, "all-namespaces", "A", false, "Show workflows from all namespaces")
 	command.Flags().StringVarP(&listArgs.output, "output", "o", "", "Output format. One of: wide|name")
 	return command
 }

--- a/cmd/argo/commands/delete.go
+++ b/cmd/argo/commands/delete.go
@@ -78,7 +78,7 @@ func NewDeleteCommand() *cobra.Command {
 		},
 	}
 
-	command.Flags().BoolVar(&allNamespaces, "all-namespaces", false, "Delete workflows from all namespaces")
+	command.Flags().BoolVarP(&allNamespaces, "all-namespaces", "A", false, "Delete workflows from all namespaces")
 	command.Flags().BoolVar(&all, "all", false, "Delete all workflows")
 	command.Flags().BoolVar(&flags.completed, "completed", false, "Delete completed workflows")
 	command.Flags().BoolVar(&flags.resubmitted, "resubmitted", false, "Delete resubmitted workflows")

--- a/cmd/argo/commands/list.go
+++ b/cmd/argo/commands/list.go
@@ -61,7 +61,7 @@ func NewListCommand() *cobra.Command {
 			errors.CheckError(err)
 		},
 	}
-	command.Flags().BoolVar(&allNamespaces, "all-namespaces", false, "Show workflows from all namespaces")
+	command.Flags().BoolVarP(&allNamespaces, "all-namespaces", "A", false, "Show workflows from all namespaces")
 	command.Flags().StringVar(&listArgs.prefix, "prefix", "", "Filter workflows by prefix")
 	command.Flags().StringVar(&listArgs.finishedAfter, "older", "", "List completed workflows finished before the specified duration (e.g. 10m, 3h, 1d)")
 	command.Flags().StringSliceVar(&listArgs.status, "status", []string{}, "Filter by status (comma separated)")

--- a/cmd/argo/commands/template/list.go
+++ b/cmd/argo/commands/template/list.go
@@ -52,7 +52,7 @@ func NewListCommand() *cobra.Command {
 
 		},
 	}
-	command.Flags().BoolVar(&listArgs.allNamespaces, "all-namespaces", false, "Show workflows from all namespaces")
+	command.Flags().BoolVarP(&listArgs.allNamespaces, "all-namespaces", "A", false, "Show workflows from all namespaces")
 	command.Flags().StringVarP(&listArgs.output, "output", "o", "", "Output format. One of: wide|name")
 	return command
 }

--- a/docs/cli/argo_cron_list.md
+++ b/docs/cli/argo_cron_list.md
@@ -13,7 +13,7 @@ argo cron list [flags]
 ### Options
 
 ```
-      --all-namespaces   Show workflows from all namespaces
+  -A, --all-namespaces   Show workflows from all namespaces
   -h, --help             help for list
   -o, --output string    Output format. One of: wide|name
 ```

--- a/docs/cli/argo_delete.md
+++ b/docs/cli/argo_delete.md
@@ -27,7 +27,7 @@ argo delete [--dry-run] [WORKFLOW...|[--all] [--older] [--completed] [--resubmit
 
 ```
       --all                     Delete all workflows
-      --all-namespaces          Delete workflows from all namespaces
+  -A, --all-namespaces          Delete workflows from all namespaces
       --completed               Delete completed workflows
       --dry-run                 Do not delete the workflow, only print what would happen
       --field-selector string   Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selectorkey1=value1,key2=value2). The server only supports a limited number of field queries per type.

--- a/docs/cli/argo_list.md
+++ b/docs/cli/argo_list.md
@@ -13,7 +13,7 @@ argo list [flags]
 ### Options
 
 ```
-      --all-namespaces          Show workflows from all namespaces
+  -A, --all-namespaces          Show workflows from all namespaces
       --chunk-size int          Return large lists in chunks rather than all at once. Pass 0 to disable.
       --completed               Show completed workflows. Mutually exclusive with --running.
       --field-selector string   Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selectorkey1=value1,key2=value2). The server only supports a limited number of field queries per type.

--- a/docs/cli/argo_template_list.md
+++ b/docs/cli/argo_template_list.md
@@ -13,7 +13,7 @@ argo template list [flags]
 ### Options
 
 ```
-      --all-namespaces   Show workflows from all namespaces
+  -A, --all-namespaces   Show workflows from all namespaces
   -h, --help             help for list
   -o, --output string    Output format. One of: wide|name
 ```


### PR DESCRIPTION
Feature: Add shorthanded option -A for --all-namespaces

Signed-off-by: makocchi-git <makocchi@gmail.com>

kubectl's --all-namespaces has an shortened alias -A.
It would be nice if argo has the same alias.