### PR TITLE
feat(executor): Allow to configure the interval of resource state checking

### DIFF
--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	envutil "github.com/argoproj/argo/util/env"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -21,6 +20,7 @@ import (
 
 	"github.com/argoproj/argo/errors"
 	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
+	envutil "github.com/argoproj/argo/util/env"
 	"github.com/argoproj/argo/workflow/common"
 	os_specific "github.com/argoproj/argo/workflow/executor/os-specific"
 )


### PR DESCRIPTION
See some context in https://github.com/argoproj/argo/issues/4467. This is a workaround that could reduce the burden of the cluster.

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
