### PR TITLE
fix(executor): Deal with the pod watch API call timing out

### DIFF
--- a/workflow/executor/common/wait/wait.go
+++ b/workflow/executor/common/wait/wait.go
@@ -26,22 +26,32 @@ func UntilTerminated(kubernetesInterface kubernetes.Interface, namespace, podNam
 }
 
 func untilTerminatedAux(podInterface v1.PodInterface, containerID string, listOptions metav1.ListOptions) (bool, error) {
+	for {
+		complete, done, err := doWatch(podInterface, containerID, listOptions)
+		if complete {
+			return done, err
+		}
+		log.Infof("Pod watch timed out, restarting watch on %s", containerID)
+	}
+}
+
+func doWatch(podInterface v1.PodInterface, containerID string, listOptions metav1.ListOptions) (bool, bool, error) {
 	w, err := podInterface.Watch(listOptions)
 	if err != nil {
-		return true, fmt.Errorf("could not watch pod: %w", err)
+		return true, true, fmt.Errorf("could not watch pod: %w", err)
 	}
 	defer w.Stop()
 	for event := range w.ResultChan() {
 		pod, ok := event.Object.(*corev1.Pod)
 		if !ok {
-			return false, apierrors.FromObject(event.Object)
+			return true, false, apierrors.FromObject(event.Object)
 		}
 		for _, s := range pod.Status.ContainerStatuses {
 			if common.GetContainerID(&s) == containerID && s.State.Terminated != nil {
-				return true, nil
+				return true, true, nil
 			}
 		}
 		listOptions.ResourceVersion = pod.ResourceVersion
 	}
-	return true, nil
+	return false, false, nil
 }


### PR DESCRIPTION
Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->


Tested manually by adding a couple of lines to reduce the api timeout to ~20 seconds and then running a tweaked hello-world workflow with a sleep 60. Ideally this would be an e2e test, but in your youtube contributor video you mentioned needing all the e2e tests to run in under 10 minutes. I'm not sure how much you could compress the times and still have a reliable test for this, so I haven't added an end to end test. Opinions welcome.