### PR TITLE
fix(executor): Copy main/executor container resources from controller by value instead of reference

### DIFF
--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -153,11 +153,11 @@ func (woc *wfOperationCtx) createWorkflowPod(nodeName string, mainCtr apiv1.Cont
 	mainCtr.Name = common.MainContainerName
 	// Allow customization of main container resources.
 	if isResourcesSpecified(woc.controller.Config.MainContainer) {
-		mainCtr.Resources = woc.controller.Config.MainContainer.Resources
+		mainCtr.Resources = *woc.controller.Config.MainContainer.Resources.DeepCopy()
 	}
 	// Container resources in workflow spec takes precedence over the main container's configuration in controller.
 	if isResourcesSpecified(tmpl.Container) && tmpl.Container.Name == common.MainContainerName {
-		mainCtr.Resources = tmpl.Container.Resources
+		mainCtr.Resources = *tmpl.Container.Resources.DeepCopy()
 	}
 
 	var activeDeadlineSeconds *int64
@@ -571,9 +571,9 @@ func (woc *wfOperationCtx) newExecContainer(name string, tmpl *wfv1.Template) *a
 		}
 	}
 	if isResourcesSpecified(woc.controller.Config.Executor) {
-		exec.Resources = woc.controller.Config.Executor.Resources
+		exec.Resources = *woc.controller.Config.Executor.Resources.DeepCopy()
 	} else if woc.controller.Config.ExecutorResources != nil {
-		exec.Resources = *woc.controller.Config.ExecutorResources
+		exec.Resources = *woc.controller.Config.ExecutorResources.DeepCopy()
 	}
 	if woc.controller.Config.KubeConfig != nil {
 		path := woc.controller.Config.KubeConfig.MountPath


### PR DESCRIPTION
This is cherry-picked from my colleague's stale PR https://github.com/argoproj/argo/pull/4432 as well as applying a similar change to main container's resource copying logic. cc @simster7 @alexec 

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>
Co-authored-by: merlintang <tangrock@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
