### PR TITLE
chore(example): Add watch timeout and print out workflow status message

### DIFF
--- a/examples/example-golang/main.go
+++ b/examples/example-golang/main.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/utils/pointer"
 
 	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	wfclientset "github.com/argoproj/argo/pkg/client/clientset/versioned"
@@ -60,7 +61,7 @@ func main() {
 
 	// wait for the workflow to complete
 	fieldSelector := fields.ParseSelectorOrDie(fmt.Sprintf("metadata.name=%s", createdWf.Name))
-	watchIf, err := wfClient.Watch(metav1.ListOptions{FieldSelector: fieldSelector.String()})
+	watchIf, err := wfClient.Watch(metav1.ListOptions{FieldSelector: fieldSelector.String(), TimeoutSeconds: pointer.Int64Ptr(180)})
 	errors.CheckError(err)
 	defer watchIf.Stop()
 	for next := range watchIf.ResultChan() {
@@ -70,6 +71,9 @@ func main() {
 		}
 		if !wf.Status.FinishedAt.IsZero() {
 			fmt.Printf("Workflow %s %s at %v\n", wf.Name, wf.Status.Phase, wf.Status.FinishedAt)
+			if wf.Status.Phase == wfv1.NodeFailed || wf.Status.Phase == wfv1.NodeError {
+				fmt.Printf("Workflow %s failed due to: %s", wf.Name, wf.Status.Message)
+			}
 			break
 		}
 	}

--- a/examples/example-golang/main.go
+++ b/examples/example-golang/main.go
@@ -70,10 +70,7 @@ func main() {
 			continue
 		}
 		if !wf.Status.FinishedAt.IsZero() {
-			fmt.Printf("Workflow %s %s at %v\n", wf.Name, wf.Status.Phase, wf.Status.FinishedAt)
-			if wf.Status.Phase == wfv1.NodeFailed || wf.Status.Phase == wfv1.NodeError {
-				fmt.Printf("Workflow %s failed due to: %s", wf.Name, wf.Status.Message)
-			}
+			fmt.Printf("Workflow %s %s at %v. Message: %s.\n", wf.Name, wf.Status.Phase, wf.Status.FinishedAt, wf.Status.Message)
 			break
 		}
 	}


### PR DESCRIPTION
The workflow in the current example would only exit the loop when it reaches completion. It's better to exit loop immediately when the workflow has failed. 

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
