### PR TITLE
fix(server): Update argo-server crt/key owner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,7 +142,7 @@ ARG IMAGE_OS=linux
 COPY --from=argoexec-base /etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts
 COPY --from=argoexec-base /etc/nsswitch.conf /etc/nsswitch.conf
 COPY --from=argoexec-base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=argo-build /go/src/github.com/argoproj/argo/argo-server.crt argo-server.crt
-COPY --from=argo-build /go/src/github.com/argoproj/argo/argo-server.key argo-server.key
+COPY --from=argo-build --chown=8737 /go/src/github.com/argoproj/argo/argo-server.crt argo-server.crt
+COPY --from=argo-build --chown=8737 /go/src/github.com/argoproj/argo/argo-server.key argo-server.key
 COPY --from=argo-build /go/src/github.com/argoproj/argo/dist/argo-${IMAGE_OS}-* /bin/argo
 ENTRYPOINT [ "argo" ]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -93,7 +93,7 @@ FROM scratch as argocli
 USER 8737
 COPY --from=argoexec-base /etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts
 COPY --from=argoexec-base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY argo-server.crt argo-server.crt
-COPY argo-server.key argo-server.key
+COPY --chown=8737 argo-server.crt argo-server.crt
+COPY --chown=8737 argo-server.key argo-server.key
 COPY argo /bin/
 ENTRYPOINT [ "argo" ]


### PR DESCRIPTION
Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

The self-signed key bundled in the argocli image cannot be used.

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: argo-server
spec:
  selector:
    matchLabels:
      app: argo-server
  template:
    metadata:
      labels:
        app: argo-server
    spec:
      serviceAccountName: argo-server
      containers:
      - name: argo-server
        image: argoproj/argocli:v2.11.8
        securityContext:
          capabilities:
            drop:
              - ALL
        args:
        - server
        - --configmap
        - argo-server-cm
        - --auth-mode
        - sso
        - --secure
        ports:
        - name: web
          containerPort: 2746
        readinessProbe:
          httpGet:
            port: 2746
            scheme: HTTP
            path: /
          initialDelaySeconds: 10
          periodSeconds: 20
        volumeMounts:
        - mountPath: /tmp
          name: tmp
      volumes:
      - name: tmp
        emptyDir: { }
      securityContext:
        runAsUser: 8737 # argo UID
        runAsGroup: 8737 # argo UID
      nodeSelector:
        kubernetes.io/os: linux
```

Here's the log.

```
$ k logs argo-server-6dd9dc9cbd-8pqm8
time="2020-12-16T00:38:54Z" level=info authModes="[sso]" baseHRef=/ managedNamespace= namespace=argo secure=true
time="2020-12-16T00:38:54Z" level=fatal msg="open argo-server.key: permission denied"
```