### PR TITLE
Update argo server auth-mode documentation

### DIFF
--- a/docs/argo-server-auth-mode.md
+++ b/docs/argo-server-auth-mode.md
@@ -10,5 +10,5 @@ By default, the server will start with auth mode of "server".
 
 To change the server auth mode specify the list as multiple auth-mode flags:
 ```
-argo server --auth-mode sso --auth-mode ...
+argo server --auth-mode=sso --auth-mode=...
 ```


### PR DESCRIPTION
The `--auth-mode` flag requires an `=` symbol. Without it, startup will fail with `unknown flag: --auth-mode client`

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
