### PR TITLE
feat(cli): add phase option to `node set` command

### DIFF
--- a/cmd/argo/commands/node.go
+++ b/cmd/argo/commands/node.go
@@ -91,6 +91,7 @@ func NewNodeCommand() *cobra.Command {
 		},
 	}
 	command.Flags().StringVar(&setArgs.nodeFieldSelector, "node-field-selector", "", "Selector of node to set, eg: --node-field-selector inputs.paramaters.myparam.value=abc")
+	command.Flags().StringVar(&setArgs.phase, "phase", "", "Phase to set the node to, eg: --phase Succeeded")
 	command.Flags().StringArrayVarP(&setArgs.outputParameters, "output-parameter", "p", []string{}, "Set a \"supplied\" output parameter of node, eg: --output-parameter parameter-name=\"Hello, world!\"")
 	command.Flags().StringVarP(&setArgs.message, "message", "m", "", "Set the message of a node, eg: --message \"Hello, world!\"")
 	return command

--- a/docs/cli/argo_node.md
+++ b/docs/cli/argo_node.md
@@ -30,6 +30,7 @@ argo node ACTION WORKFLOW FLAGS [flags]
   -m, --message string                 Set the message of a node, eg: --message "Hello, world!"
       --node-field-selector string     Selector of node to set, eg: --node-field-selector inputs.paramaters.myparam.value=abc
   -p, --output-parameter stringArray   Set a "supplied" output parameter of node, eg: --output-parameter parameter-name="Hello, world!"
+      --phase string                   Phase to set the node to, eg: --phase Succeeded
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Checklist:

* [X] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

This adds the missing 'phase' command to the node cli command, eg:

```argo node set my-wf --node-field-selector displayName=approve --phase Succeeded```

would set the phase for the suspend node with displayName=approve to Succeeded
