### PR TITLE
feat: Expose exitCode to step level metrics

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -88,6 +88,7 @@ step.
 |----------|------------|
 | `status` | Phase status of the metric-emitting template |
 | `duration` | Duration of the metric-emitting template in seconds (only applicable in `Template`-level metrics, for `Workflow`-level use `workflow.duration`) |
+| `exitCode` | Exit code of the metric-emitting template |
 | `inputs.parameters.<NAME>` | Input parameter of the metric-emitting template |
 | `outputs.parameters.<NAME>` | Output parameter of the metric-emitting template |
 | `outputs.result` | Output result of the metric-emitting template |

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -160,6 +160,8 @@ const (
 	LocalVarStatus = "status"
 	// LocalVarResourcesDuration is a step level variable (currently only available in metric emission) that tracks the resources duration of the step
 	LocalVarResourcesDuration = "resourcesDuration"
+	// LocalVarExitCode is a step level variable (currently only available in metric emission) that tracks the step's exit code
+	LocalVarExitCode = "exitCode"
 
 	KubeConfigDefaultMountPath    = "/kube/config"
 	KubeConfigDefaultVolumeName   = "kubeconfig"

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -522,6 +522,9 @@ func (woc *wfOperationCtx) prepareMetricScope(node *wfv1.NodeStatus) (map[string
 		if node.Outputs.Result != nil {
 			localScope["outputs.result"] = *node.Outputs.Result
 		}
+		if node.Outputs.ExitCode != nil {
+			localScope[common.LocalVarExitCode] = *node.Outputs.ExitCode
+		}
 		for _, param := range node.Outputs.Parameters {
 			key := fmt.Sprintf("outputs.parameters.%s", param.Name)
 			localScope[key] = param.Value.String()

--- a/workflow/controller/steps_test.go
+++ b/workflow/controller/steps_test.go
@@ -168,6 +168,7 @@ func TestResourceDurationMetric(t *testing.T) {
 		localScope, _ := woc.prepareMetricScope(&node)
 		assert.Equal(t, "33", localScope["resourcesDuration.cpu"])
 		assert.Equal(t, "24", localScope["resourcesDuration.memory"])
+		assert.Equal(t, "0", localScope["exitCode"])
 	}
 }
 


### PR DESCRIPTION
An `exitCode` from each step can be referenced as an output value since https://github.com/argoproj/argo/pull/2111. It would be nice if we can use the same value in the step/task-level metrics.

This PR maps the `node.Outputs.ExitCode` to a `exitCode` variable within the local scope of the metrics. This follow the variable scheme used for steps and task where the exit code is put on the same level as phase status (`steps.<STEPNAME>.exitCode`) and not within the `outputs.*` scope (like `outputs.result` for example).

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
