### PR TITLE
fix(controller): Revert prepending ExecutorScriptSourcePath which brought a breaking change in args handling

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2345,16 +2345,6 @@ func getStepOrDAGTaskName(nodeName string) string {
 	return nodeName
 }
 
-func extractMainCtrFromScriptTemplate(tmpl *wfv1.Template) apiv1.Container {
-	mainCtr := tmpl.Script.Container
-	// If script source is provided then pass all container args to the
-	// script instead of passing them to the container command directly
-	if tmpl.Script.Source != "" {
-		mainCtr.Args = append([]string{common.ExecutorScriptSourcePath}, mainCtr.Args...)
-	}
-	return mainCtr
-}
-
 func (woc *wfOperationCtx) executeScript(ctx context.Context, nodeName string, templateScope string, tmpl *wfv1.Template, orgTmpl wfv1.TemplateReferenceHolder, opts *executeTemplateOpts) (*wfv1.NodeStatus, error) {
 	node := woc.wf.GetNodeByName(nodeName)
 	if node == nil {
@@ -2370,7 +2360,8 @@ func (woc *wfOperationCtx) executeScript(ctx context.Context, nodeName string, t
 		return node, err
 	}
 
-	mainCtr := extractMainCtrFromScriptTemplate(tmpl)
+	mainCtr := tmpl.Script.Container
+	mainCtr.Args = append(mainCtr.Args, common.ExecutorScriptSourcePath)
 	_, err = woc.createWorkflowPod(ctx, nodeName, mainCtr, tmpl, &createWorkflowPodOpts{
 		includeScriptOutput: includeScriptOutput,
 		onExitPod:           opts.onExitTemplate,

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -69,42 +69,6 @@ func TestScriptTemplateWithVolume(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-var scriptTemplateWithArgsAndWithSource = `
-name: script-with-args-and-with-source
-script:
-  image: alpine:latest
-  command: [sh]
-  args: ["hello world"]
-  source: |
-    echo $@
-`
-
-// TestScriptTemplateMainCtrArgsWhenArgsAndWhenSource ensure order of merged args
-// and script path is correct when both args and script source are specified
-func TestScriptTemplateMainCtrArgsWhenArgsAndWhenSource(t *testing.T) {
-	tmpl := unmarshalTemplate(scriptTemplateWithArgsAndWithSource)
-	mainCtr := extractMainCtrFromScriptTemplate(tmpl)
-	assert.Equal(t, []string{"sh"}, mainCtr.Command)
-	assert.Equal(t, []string{common.ExecutorScriptSourcePath, "hello world"}, mainCtr.Args)
-}
-
-var scriptTemplateWithArgsAndWithoutSource = `
-name: script-with-args-and-without-source
-script:
-  image: alpine:latest
-  command: [echo]
-  args: ["hello world"]
-`
-
-// TestScriptTemplateMainCtrArgsWhenArgsAndWhenNoSource ensure only args are passed
-// to the resulting container when script source is empty
-func TestScriptTemplateMainCtrArgsWhenArgsAndWhenNoSource(t *testing.T) {
-	tmpl := unmarshalTemplate(scriptTemplateWithArgsAndWithoutSource)
-	mainCtr := extractMainCtrFromScriptTemplate(tmpl)
-	assert.Equal(t, []string{"echo"}, mainCtr.Command)
-	assert.Equal(t, []string{"hello world"}, mainCtr.Args)
-}
-
 var scriptTemplateWithOptionalInputArtifactProvided = `
 name: script-with-input-artifact
 inputs:


### PR DESCRIPTION
This reverts commit 64ae33034d30a943dca71b0c5e4ebd97018448bf.

This PR reverts #4492 which changes the way args are passed to a script template. Due to this change we are not able to override `args` with a docker image and an entrypoint with an `exec "$@"` in argo workflow 2.12.x.

This is convenient to execute the docker entrypoint of the base image and then execute the script in the workflow. We use it to do some privileged action and then drop those privileges before executing the script passed in the workflow. You can find more information in #4782 with an example to test the behavior that brokes in 2.12.x.

This revert will obviously break the behavior that the author of this commit has intended to introduce so I don't know if reverting is the best things to do...

Resolves #4782
