### PR TITLE
fix(ui): removing unneeded ':' in protocol for workflow-event-bindings

### DIFF
--- a/ui/src/app/workflow-event-bindings/components/workflow-event-bindings/workflow-event-bindings.tsx
+++ b/ui/src/app/workflow-event-bindings/components/workflow-event-bindings/workflow-event-bindings.tsx
@@ -96,7 +96,7 @@ export const WorkflowEventBindings = ({match, location, history}: RouteComponent
                     </p>
                     <p>
                         <code>
-                            curl '{document.location.protocol}://{document.location.host}/api/v1/events/{namespace}/-' -H 'Content-Type: application/json' -H 'Authorization:
+                            curl '{document.location.protocol}//{document.location.host}/api/v1/events/{namespace}/-' -H 'Content-Type: application/json' -H 'Authorization:
                             $ARGO_TOKEN' -d '&#123;&#125;'
                         </code>
                     </p>


### PR DESCRIPTION
Super minor typo fix.  The URL will still be valid in a browser with `::`, but still good to correct.
![Screen Shot 2021-01-15 at 2 33 47 PM](https://user-images.githubusercontent.com/5673097/104785353-26c60580-573f-11eb-824a-c73c0e7a3c1d.png)
