### PR TITLE
fix(ui): objecteditor only runs onChange when values are modified

### DIFF
--- a/ui/src/app/shared/components/object-editor/object-editor.tsx
+++ b/ui/src/app/shared/components/object-editor/object-editor.tsx
@@ -26,15 +26,18 @@ export const ObjectEditor = <T extends any>({type, value, buttons, onChange}: Pr
     useEffect(() => storage.setItem('lang', lang, defaultLang), [lang]);
     useEffect(() => setText(stringify(value, lang)), [value]);
     useEffect(() => setText(stringify(parse(text), lang)), [lang]);
-    if (onChange) {
-        useEffect(() => {
-            try {
-                onChange(parse(text));
-            } catch (e) {
-                setError(e);
+    const updateText = (newValue: string) => {
+        if (onChange) {
+            {
+                setText(newValue);
+                try {
+                    onChange(parse(newValue));
+                } catch (e) {
+                    setError(e);
+                }
             }
-        }, [text]);
-    }
+        }
+    };
 
     useEffect(() => {
         if (type && lang === 'json') {
@@ -88,6 +91,7 @@ export const ObjectEditor = <T extends any>({type, value, buttons, onChange}: Pr
                         renderIndentGuides: false,
                         scrollBeyondLastLine: true
                     }}
+                    onChange={newValue => updateText(newValue)}
                 />
             </div>
             <div style={{paddingTop: '1em'}}>


### PR DESCRIPTION
Fix UI

Issue:
- when switching tabs (other -> manifest) in template/cron wf detail views, the submit button becomes disabled despite no change in manifest
- when toggling yaml<->json in template/cron wf detail view manifest, the submit button becomes disabled despite no change in manifest

Change:
- only updates text when values are modified in monaco-editor


Signed-off-by: Tianchu Zhao <evantczhao@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
