### PR TITLE
fix(ui): fix object-editor text render issue

### DIFF
--- a/ui/src/app/shared/components/object-editor/object-editor.tsx
+++ b/ui/src/app/shared/components/object-editor/object-editor.tsx
@@ -22,22 +22,22 @@ export const ObjectEditor = <T extends any>({type, value, buttons, onChange}: Pr
     const [error, setError] = useState<Error>();
     const [lang, setLang] = useState<string>(storage.getItem('lang', defaultLang));
     const [text, setText] = useState<string>(stringify(value, lang));
+    const [isModified, setIsModified] = useState<boolean>(false);
 
     useEffect(() => storage.setItem('lang', lang, defaultLang), [lang]);
     useEffect(() => setText(stringify(value, lang)), [value]);
     useEffect(() => setText(stringify(parse(text), lang)), [lang]);
-    const updateText = (newValue: string) => {
-        if (onChange) {
-            {
-                setText(newValue);
+    if (onChange) {
+        useEffect(() => {
+            if (isModified) {
                 try {
-                    onChange(parse(newValue));
+                    onChange(parse(text));
                 } catch (e) {
                     setError(e);
                 }
             }
-        }
-    };
+        }, [text, isModified]);
+    }
 
     useEffect(() => {
         if (type && lang === 'json') {
@@ -91,7 +91,7 @@ export const ObjectEditor = <T extends any>({type, value, buttons, onChange}: Pr
                         renderIndentGuides: false,
                         scrollBeyondLastLine: true
                     }}
-                    onChange={newValue => updateText(newValue)}
+                    onChange={() => setIsModified(true)}
                 />
             </div>
             <div style={{paddingTop: '1em'}}>


### PR DESCRIPTION
Fixed issue introduced by PR #4911

Sorry, the previous implementation is very buggy,

Issues:
object-editor
- unable to create newline, due to rendering text with stringify removes all empty lines
- duplicate render, text was first rendered by monaco, then the rendered text got rendered again by useEffect hook

Changed:
base on the pre #4911 code, add an additional isModified hook to trigger initial onChange


Signed-off-by: Tianchu Zhao <evantczhao@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->