### PR TITLE
feat: Allow to specify resource version for executor

### DIFF
--- a/workflow/executor/common/wait/wait.go
+++ b/workflow/executor/common/wait/wait.go
@@ -3,6 +3,7 @@ package wait
 import (
 	"context"
 	"fmt"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -17,7 +18,8 @@ import (
 func UntilTerminated(ctx context.Context, kubernetesInterface kubernetes.Interface, namespace, podName, containerID string) error {
 	log.Infof("Waiting for container %s to be terminated", containerID)
 	podInterface := kubernetesInterface.CoreV1().Pods(namespace)
-	listOptions := metav1.ListOptions{FieldSelector: "metadata.name=" + podName}
+	resourceVersion, _ := os.LookupEnv("EXECUTOR_OPTION_RESOURCE_VERSION")
+	listOptions := metav1.ListOptions{FieldSelector: "metadata.name=" + podName, ResourceVersion: resourceVersion}
 	for {
 		done, err := untilTerminatedAux(ctx, podInterface, containerID, listOptions)
 		if done {

--- a/workflow/executor/k8sapi/client.go
+++ b/workflow/executor/k8sapi/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"syscall"
 
 	corev1 "k8s.io/api/core/v1"
@@ -62,7 +63,8 @@ func (c *k8sAPIClient) getLogsAsStream(ctx context.Context, containerID string) 
 }
 
 func (c *k8sAPIClient) getPod(ctx context.Context) (*corev1.Pod, error) {
-	return c.clientset.CoreV1().Pods(c.namespace).Get(ctx, c.podName, metav1.GetOptions{})
+	resourceVersion, _ := os.LookupEnv("EXECUTOR_OPTION_RESOURCE_VERSION")
+	return c.clientset.CoreV1().Pods(c.namespace).Get(ctx, c.podName, metav1.GetOptions{ResourceVersion: resourceVersion})
 }
 
 func (c *k8sAPIClient) GetContainerStatus(ctx context.Context, containerID string) (*corev1.Pod, *corev1.ContainerStatus, error) {


### PR DESCRIPTION
One use case for this is that we'd like to retrieve pods from cache instead of always relying on remote storage which would introduce a lot of burden on our apiserver when the scale is large.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
