### PR TITLE
doc: Add a note for docker executors regarding outputs.result

### DIFF
--- a/docs/workflow-executors.md
+++ b/docs/workflow-executors.md
@@ -23,6 +23,8 @@ The executor to be used in your workflows can be changed in [the configmap](./wo
 * Configuration:
     * No additional configuration needed.
 
+**Note**: when using docker as workflow executors, messages printed in both `stdout` and `stderr` are captured in the [Argo variable](./variables.md#scripttemplate) `.outputs.result`.
+
 ## Kubelet (kubelet)
 
 * Reliability:


### PR DESCRIPTION
When using docker as executors, both messages in `stdout` and `stderr` are stored into `outputs.result` since we use `docker logs` to capture the output of a container. I think this is something that is worth being noted since it leads to errors, even for our workflow examples. For instance, [parameter-aggregation](https://github.com/argoproj/argo/blob/master/examples/parameter-aggregation.yaml) fails in step `divide-by-2` when the controller tries to unmarshal the input parameter, `+ echo 2\n2`, which contains the message in `stderr` of the step's ancestor.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
