### PR TITLE
fix(ui): Display all node inputs/output in one tab. Resolves #5027

### DIFF
--- a/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
+++ b/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
@@ -3,6 +3,7 @@ import * as moment from 'moment';
 import * as React from 'react';
 
 import * as models from '../../../../models';
+import {Artifact, NodeStatus, Workflow} from '../../../../models';
 import {Button} from '../../../shared/components/button';
 import {DropDownButton} from '../../../shared/components/drop-down-button';
 import {DurationPanel} from '../../../shared/components/duration-panel';
@@ -166,30 +167,38 @@ const WorkflowNodeSummary = (props: Props) => {
     );
 };
 
-const WorkflowNodeInputs = (props: {inputs: models.Inputs}) => {
-    const parameters = (props.inputs.parameters || []).map(artifact => ({
-        title: artifact.name,
-        value: artifact.value
-    }));
-    const artifacts = (props.inputs.artifacts || []).map(artifact => ({
-        title: artifact.name,
-        value: artifact.path
-    }));
+const WorkflowNodeInputs = (props: Props) => (
+    <>
+        <h5>Inputs</h5>
+        <WorkflowNodeParameters parameters={props.node.inputs && props.node.inputs.parameters} />
+        <WorkflowNodeArtifacts {...props} artifacts={props.node.inputs && props.node.inputs.artifacts} />
+    </>
+);
+
+const WorkflowNodeOutputs = (props: Props) => (
+    <>
+        <h5>Outputs</h5>
+        <WorkflowNodeParameters parameters={props.node.outputs && props.node.outputs.parameters} />
+        <WorkflowNodeArtifacts {...props} artifacts={props.node.outputs && props.node.outputs.artifacts} />
+    </>
+);
+
+const WorkflowNodeParameters = ({parameters}: {parameters: models.Parameter[]}) => {
     return (
         <div className='white-box'>
             <div className='white-box__details'>
-                {parameters.length > 0 && [
-                    <div className='row white-box__details-row' key='title'>
-                        <p>Parameters</p>
-                    </div>,
-                    <AttributeRows key='attrs' attributes={parameters} />
-                ]}
-                {artifacts.length > 0 && [
-                    <div className='row white-box__details-row' key='title'>
-                        <p>Input Artifacts</p>
-                    </div>,
-                    <AttributeRows key='attrs' attributes={artifacts} />
-                ]}
+                {parameters && parameters.length > 0 ? (
+                    <>
+                        <div className='row white-box__details-row' key='title'>
+                            <p>Parameters</p>
+                        </div>
+                        <AttributeRows key='attrs' attributes={parameters.map(x => ({title: x.name, value: x.value}))} />
+                    </>
+                ) : (
+                    <div className='row'>
+                        <div className='columns small-12 text-center'>No parameters</div>
+                    </div>
+                )}
             </div>
         </div>
     );
@@ -309,11 +318,10 @@ class WorkflowNodeContainers extends React.Component<Props, {selectedSidecar: st
     }
 }
 
-const WorkflowNodeArtifacts = (props: Props) => {
+const WorkflowNodeArtifacts = (props: {workflow: Workflow; node: NodeStatus; archived: boolean; artifacts: Artifact[]}) => {
     const artifacts =
-        (props.node.outputs &&
-            props.node.outputs.artifacts &&
-            props.node.outputs.artifacts.map(artifact =>
+        (props.artifacts &&
+            props.artifacts.map(artifact =>
                 Object.assign({}, artifact, {
                     downloadUrl: services.workflows.getArtifactDownloadUrl(props.workflow, props.node.id, artifact.name, props.archived),
                     stepName: props.node.name,
@@ -326,7 +334,7 @@ const WorkflowNodeArtifacts = (props: Props) => {
         <div className='white-box'>
             {artifacts.length === 0 && (
                 <div className='row'>
-                    <div className='columns small-12 text-center'>No data to display</div>
+                    <div className='columns small-12 text-center'>No artifacts</div>
                 </div>
             )}
             {artifacts.length > 0 && props.archived && (
@@ -351,7 +359,7 @@ const WorkflowNodeArtifacts = (props: Props) => {
                             <span title={artifact.path} className='muted'>
                                 {artifact.path}
                             </span>
-                            <span title={artifact.dateCreated.toString()} className='muted'>
+                            <span title={artifact.dateCreated} className='muted'>
                                 <Timestamp date={artifact.dateCreated} />
                             </span>
                         </div>
@@ -374,7 +382,6 @@ export const WorkflowNodeInfo = (props: Props) => (
                     content: (
                         <div>
                             <WorkflowNodeSummary {...props} />
-                            {props.node.inputs && <WorkflowNodeInputs inputs={props.node.inputs} />}
                         </div>
                     )
                 },
@@ -384,9 +391,14 @@ export const WorkflowNodeInfo = (props: Props) => (
                     content: <WorkflowNodeContainers {...props} />
                 },
                 {
-                    title: 'OUTPUT ARTIFACTS',
-                    key: 'artifacts',
-                    content: <WorkflowNodeArtifacts {...props} />
+                    title: 'INPUTS/OUTPUTS',
+                    key: 'inputs-outputs',
+                    content: (
+                        <>
+                            <WorkflowNodeInputs {...props} />
+                            <WorkflowNodeOutputs {...props} />
+                        </>
+                    )
                 }
             ]}
         />


### PR DESCRIPTION
Resolves #5027

Rather than hiding the inputs below the summary, I put them into an inputs tab. Then I realized I wanted to see inputs and outputs at the same time, so I could understand the outputs in the context of the inputs.


![image](https://user-images.githubusercontent.com/1142830/106959181-322da080-66ef-11eb-8e97-0845ed7792b3.png)
