### PR TITLE
fix(examples): Fix golang build for CI examples

### DIFF
--- a/examples/ci-output-artifact.yaml
+++ b/examples/ci-output-artifact.yaml
@@ -45,6 +45,7 @@ spec:
         path: /go/src/github.com/golang/example
         git:
           repo: https://github.com/golang/example.git
+          revision: cfe12d6
     container:
       image: golang:1.8
       command: [sh, -c]

--- a/examples/ci.yaml
+++ b/examples/ci.yaml
@@ -5,12 +5,12 @@ metadata:
 spec:
   # entrypoint is the name of the template used as the starting point of the workflow
   entrypoint: ci-example
-  # the 'ci-example' template accepts an parameter 'revision', with a default of 'master'.
+  # the 'ci-example' template accepts an parameter 'revision', with a default of 'cfe12d6'.
   # this can be overridden via argo CLI (e.g. `argo submit ci.yaml -p revision=0dea2d0`)
   arguments:
     parameters:
     - name: revision
-      value: master
+      value: cfe12d6
   # a temporary volume, named workdir, will be used as a working directory
   # for this workflow. This volume is passed around from step to step.
   volumeClaimTemplates:


### PR DESCRIPTION
Checklist:

* [x] `examples/ci.yaml` is working
* [x] `examples/ci-output-artifact.yaml` is working

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
