### PR TITLE
fix: Don't allow graph container to have its own scroll

### DIFF
--- a/ui/src/app/workflows/components/workflow-details/workflow-details.scss
+++ b/ui/src/app/workflows/components/workflow-details/workflow-details.scss
@@ -39,7 +39,6 @@
 
   &__graph-container {
     position: relative;
-    overflow: auto;
     height: calc(100vh - 2 * #{$top-bar-height});
     width: 100%;
     transition: width 0.2s;


### PR DESCRIPTION
Currently the DAG graph container overflows into scroll, creating a situation where the main page has a scroll and the DAG graph also has one. See how the node is cut where the DAG's scroll ends:

<img width="837" alt="image" src="https://user-images.githubusercontent.com/614838/107400712-f14ed680-6ab6-11eb-98f9-cc6dc425901a.png">

This fixes that